### PR TITLE
Set output directories relative to build tree

### DIFF
--- a/devel/CMakeLists.txt
+++ b/devel/CMakeLists.txt
@@ -30,8 +30,8 @@ else()
    set( LIBRARY_TYPE STATIC )
 endif()     
 
-set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/build/lib)
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/build/bin)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 #-----------------------------------------------------------------
 find_library( ZLIB_LIBRARY NAMES z )


### PR DESCRIPTION
Doing so enables true out-of-tree builds where it isn't necessary to
separate the output from the source before version control operations
or backup, for instance.
