### PR TITLE
Include header for object size standard type

### DIFF
--- a/devel/libert_util/src/ssize_t.h
+++ b/devel/libert_util/src/ssize_t.h
@@ -20,8 +20,15 @@
 #define __SSIZE_T_H__
 
 #ifdef _MSC_VER
-// This should of course check 32/64/...
+/* maximum number of bytes addressable */
+#ifdef _WIN64
+typedef __int64 ssize_t;
+#else
 typedef long ssize_t;
+#endif
+#else
+/* POSIX 2008 states that it should be defined here */
+#include <sys/types.h>
 #endif
 
 #endif


### PR DESCRIPTION
The header previously only defined ssize_t for the platform(s) which
lacked a standard definition in sys/types.h (namely Windows), but then
relied on this being available by some other inclusion on POSIX
compliant platforms (namely Linux). This caused a compilation error if
only ecl_util.h is included.

Include the header in which it is defined so it will always be available
regardless of what else is included. The guard in the header files means
that no existing code should notice any difference.

Also, define a variants for Windows which reflects the word size of the
platform that is used.
