### PR TITLE
fixed: mark dev(el) packages as arch independent

### DIFF
--- a/devel/debian/changelog
+++ b/devel/debian/changelog
@@ -1,3 +1,9 @@
+libert.ecl (1.0-2) precise; urgency=low
+
+  * Mark -dev package as architecture independent
+
+ -- Arne Morten Kvarving <akva@SINTEFPC4169>  Tue, 19 Feb 2013 10:03:04 +0100
+
 libert.ecl (1.0-1) unstable; urgency=low
 
   * Initial release

--- a/devel/debian/control
+++ b/devel/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/Ensembles/ert
 
 Package: libert.ecl-dev
 Section: libdevel
-Architecture: any
+Architecture: all
 Depends: libert.ecl1 (= ${binary:Version})
 Description: The Ensemble based Reservoir Tool -- Development files
  ERT - Ensemble based Reservoir Tool is a tool for managing en ensemble

--- a/devel/redhat/ert.ecl.spec
+++ b/devel/redhat/ert.ecl.spec
@@ -4,7 +4,7 @@
 
 Name:           ert.ecl
 Version:        1.0
-Release:        0
+Release:        1
 Summary:        ERT - Ensemble based Reservoir Tool - ECL library
 License:        GPL-3+
 Group:          Development/Libraries/C and C++
@@ -38,6 +38,7 @@ Group:          Development/Libraries/C and C++
 Requires:       %{name} = %{version}
 Requires:       lapack-devel
 Requires:       libert.ecl1 = %{version}
+BuildArch:      noarch
 
 %description devel
 This package contains the development and header files for ert.ecl
@@ -72,3 +73,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{_libdir}/*.so
 %{_includedir}/*
+
+%changelog
+* Tue Feb 19 2013 Arne Morten Kvarving <arne.morten.kvarving@sintef.no> 1.0-1
+- Mark -devel package as architecture independent


### PR DESCRIPTION
Small packaging update which marks -dev(el) packages as arch independent.

No sense building one of these for each arch.
