### PR TITLE
Temporary files from tests (ERT-116)

### DIFF
--- a/devel/libecl/tests/ecl_file.c
+++ b/devel/libecl/tests/ecl_file.c
@@ -118,6 +118,7 @@ void test_writable(const char * src_file ) {
     swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 0 );
     test_assert_true( util_double_approx_equal( ecl_kw_iget_float( swat , 0 ) , 1000 ));
   }
+  util_unlink_existing( "/tmp/ECL.UNRST" );
 }
 
 
@@ -132,6 +133,7 @@ int main( int argc , char ** argv) {
   test_close_stream1( src_file , target_file );
   test_close_stream2( src_file , target_file );
   test_writable( src_file );
+  util_unlink_existing( target_file );
                  
   exit(0);
 }

--- a/devel/libenkf/tests/enkf_rng.c
+++ b/devel/libenkf/tests/enkf_rng.c
@@ -26,6 +26,7 @@
 #include <ert/enkf/enkf_state.h>
 #include <ert/enkf/rng_config.h>
 
+
 int main(int argc , char ** argv) {
   unsigned int rand1,rand2;
   {
@@ -87,6 +88,7 @@ int main(int argc , char ** argv) {
       enkf_main_free( enkf_main );
     }
     test_assert_uint_equal( rand1 , rand2 );
+    util_unlink_existing( seed_file );
   }
   /*****************************************************************/
   {


### PR DESCRIPTION
Have done some cleanup in the test ecl_file and enkf_rng; please confirm that these tests now run without glitch? 
- Still a glitch, the enkf_rng fails with
  util_entry_exists: error checking for entry:/private/joaho/ERT/Statoil/etc/ERT/Scripts/job_dispatch.py  13/Permission denied 
