### PR TITLE
ERT-112 Bug in ert_util_count_content for the case where the the file to...

### DIFF
--- a/devel/libert_util/src/util.c
+++ b/devel/libert_util/src/util.c
@@ -2102,11 +2102,16 @@ int util_count_content_file_lines(FILE * stream) {
       col = 0;
       c = fgetc(stream);
       if (! feof(stream) ) {
-        if (!EOL_CHAR(c))
+        if (!EOL_CHAR(c)){
           fseek(stream , -1 , SEEK_CUR);
+	}
+      }else if (c == EOF){
+	lines++;
       }
-    } else if (c == EOF)
+      
+    } else if (c == EOF){
       lines++;
+    }
     else {
       if (c != ' ')
         col++;


### PR DESCRIPTION
... be read has an empty newline charachter as the last element is now fixed.

This fixes the problem with RFT plotting
