### PR TITLE
Mistake using util_scanf_int instead of util_sscanf_int

### DIFF
--- a/devel/libenkf/src/site_config.c
+++ b/devel/libenkf/src/site_config.c
@@ -421,7 +421,7 @@ static void site_config_select_TORQUE_job_queue(site_config_type * site_config) 
 static int site_config_get_queue_max_running_option(queue_driver_type * driver) {
   const char * max_running_string = queue_driver_get_option(driver, MAX_RUNNING);
   int max_running = 0;
-  if(!util_scanf_int(max_running_string, &max_running)) {
+  if(!util_sscanf_int(max_running_string, &max_running)) {
     fprintf(stderr, "** Warning: String:%s for max_running is not parsable as int, using 0\n", max_running_string);
   }
   return max_running;

--- a/devel/libjob_queue/src/job_queue.c
+++ b/devel/libjob_queue/src/job_queue.c
@@ -1144,7 +1144,7 @@ static void job_queue_handle_EXIT( job_queue_type * queue , job_queue_node_type 
 int job_queue_get_max_running_option(queue_driver_type * driver) {
   char * max_running_string = (char*)queue_driver_get_option(driver, MAX_RUNNING);
   int max_running;
-  if (!util_scanf_int(max_running_string, max_running)) {
+  if (!util_sscanf_int(max_running_string, &max_running)) {
     fprintf(stderr, "%s: Unable to parse option MAX_RUNNING with value %s to an int", __func__, max_running_string);
   }
   return max_running;


### PR DESCRIPTION
Fixed two occurences, and corrected one of them to pass int as reference.
