### PR TITLE
Check for BUILD_TESTS in python subdirectory.

### DIFF
--- a/devel/python/CMakeLists.txt
+++ b/devel/python/CMakeLists.txt
@@ -1,3 +1,5 @@
 set(PYTHON_INSTALL_PREFIX "python")
-add_subdirectory( test )
+if (BUILD_TESTS)
+   add_subdirectory( test )
+endif()
 add_subdirectory( python )


### PR DESCRIPTION
Added check for BUILD_TESTS. Building of python/tests fails outside Statoil. This is also consistent with how it is done in other sub-directories.
