### PR TITLE
Fixed missing MSW branches

### DIFF
--- a/devel/libecl_well/src/well_segment.c
+++ b/devel/libecl_well/src/well_segment.c
@@ -164,7 +164,9 @@ well_segment_type * well_segment_get_outlet( const well_segment_type * segment )
 bool well_segment_link( well_segment_type * segment , well_segment_type * outlet_segment ) {
   if (segment->outlet_segment_id == outlet_segment->segment_id) {
     segment->outlet_segment = outlet_segment;
-    outlet_segment->link_count++;
+    if (outlet_segment->branch_id == segment->branch_id){
+      outlet_segment->link_count++;
+    }
     return true;
   } else 
     /* 


### PR DESCRIPTION
The link_count seems to be used only to detect the start segments of the
different branches. In that way the link_count must _not_ be incremented
if a segment on a different branch is reffering to the segment.
If we did, we would be missing all branches that has an endpoint
continuing in another branch.
