### PR TITLE
Fix failure if there are spaces in the source path.

### DIFF
--- a/devel/libenkf/applications/ert_tui/git_commit.sh
+++ b/devel/libenkf/applications/ert_tui/git_commit.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-cd $1
+cd "$1"
 git rev-parse HEAD


### PR DESCRIPTION
Small fix. The old version fails if there are spaces within the ERT source path.
