### PR TITLE
The latex compiler wrapper depends on fork.

### DIFF
--- a/devel/libert_util/src/CMakeLists.txt
+++ b/devel/libert_util/src/CMakeLists.txt
@@ -11,15 +11,15 @@ endif()
 
 
 if (WITH_LATEX)
-if (HAVE_FORK)
-   add_definitions( -DWITH_LATEX )
-   add_definitions( -DLATEX_CMD=\"${LATEX_PATH}\")
+   if (HAVE_FORK)
+      add_definitions( -DWITH_LATEX )
+      add_definitions( -DLATEX_CMD=\"${LATEX_PATH}\")
 
-   list( APPEND source_files latex.c )
-   list( APPEND header_files latex.h )
-else()
-message( STATUS "Disabling latex support due to missing fork() call")
-endif()
+      list( APPEND source_files latex.c )
+      list( APPEND header_files latex.h )
+   else()
+      message( STATUS "Disabling latex support due to missing fork() call")
+   endif()
 endif()
 
 if (WITH_LAPACK)


### PR DESCRIPTION
Small fix. This prevents the building of Latex if fork is not available. However the user can still set WITH_LATEX on, without anything happening.

What is correct behavior? Is it possible to only be able to set WITH_LATEX if fork is available?
