### PR TITLE
Set the module flags for RML to include ANALYSIS_SCALE_DATA

### DIFF
--- a/devel/libanalysis/modules/rml_enkf.c
+++ b/devel/libanalysis/modules/rml_enkf.c
@@ -139,7 +139,7 @@ void * rml_enkf_data_alloc( rng_type * rng) {
   
   rml_enkf_set_truncation( data , DEFAULT_ENKF_TRUNCATION_ );
   rml_enkf_set_subspace_dimension( data , DEFAULT_SUBSPACE_DIMENSION );
-  data->option_flags = ANALYSIS_NEED_ED + ANALYSIS_UPDATE_A + ANALYSIS_ITERABLE;
+  data->option_flags = ANALYSIS_NEED_ED + ANALYSIS_UPDATE_A + ANALYSIS_ITERABLE + ANALYSIS_SCALE_DATA;
   data->iteration_nr = 0;
   data->Std          = 0; 
   data->state        = NULL;

--- a/devel/libanalysis/modules/rml_enkf_imodel.c
+++ b/devel/libanalysis/modules/rml_enkf_imodel.c
@@ -140,7 +140,7 @@ void * rml_enkf_imodel_data_alloc( rng_type * rng) {
   
   rml_enkf_imodel_set_truncation( data , DEFAULT_ENKF_TRUNCATION_ );
   rml_enkf_imodel_set_subspace_dimension( data , DEFAULT_SUBSPACE_DIMENSION );
-  data->option_flags = ANALYSIS_NEED_ED + ANALYSIS_UPDATE_A + ANALYSIS_ITERABLE;
+  data->option_flags = ANALYSIS_NEED_ED + ANALYSIS_UPDATE_A + ANALYSIS_ITERABLE + ANALYSIS_SCALE_DATA;
   data->iteration_nr = 0;
   data->Std          = 0; 
   return data;


### PR DESCRIPTION
This PR will set the ANALYSIS_SCALE_DATA flag for the two modules rml_enkf and rml_enkf_imodel
