### PR TITLE
fix deadlock bug in util_abort for very long (C++) function named

### DIFF
--- a/devel/libert_util/src/util_abort_gnu.c
+++ b/devel/libert_util/src/util_abort_gnu.c
@@ -142,7 +142,7 @@ static void util_fprintf_backtrace(FILE * stream) {
   const char * unknown_format     = " #%02d ???? \n";
 
   const int max_bt = 50;
-  const int max_func_length = 45;
+  const int max_func_length = 60;
   void *bt_addr[max_bt];
   int    size,i;
 
@@ -164,7 +164,7 @@ static void util_fprintf_backtrace(FILE * stream) {
       else
         function = "???";
 
-      pad_length = 2 + max_func_length - strlen(function);
+      pad_length = util_int_max (2, 2 + max_func_length - strlen(function));
       padding = realloc_padding( padding , pad_length);
       fprintf(stream , with_linenr_format , i , function , padding , file_name , line_nr);
     } else {


### PR DESCRIPTION
the problem is that in function names can become quite long in C++ which lead to a negative number of bytes for the padding which in turn lead to the malloc operation to fail.

BTW: the backtrace would be more readable if the names would be demangled using "__cxa_abi_demangle" (if available, see http://panthema.net/2008/0901-stacktrace-demangled/cxa_demangle.html)
