### PR TITLE
Allow state change STATE_PARENT_FAILURE -> STATE_PARENT_FAILURE

### DIFF
--- a/devel/libenkf/include/ert/enkf/state_map.h
+++ b/devel/libenkf/include/ert/enkf/state_map.h
@@ -47,6 +47,7 @@ extern "C" {
   void                     state_map_set_from_inverted_mask(state_map_type * map, const bool_vector_type *mask , realisation_state_enum state);
   void                     state_map_set_from_mask(state_map_type * map, const bool_vector_type *mask , realisation_state_enum state);
   int                      state_map_count_matching( state_map_type * state_map , int mask);
+  bool                     state_map_legal_transition( realisation_state_enum state1 , realisation_state_enum state2);
 
   UTIL_IS_INSTANCE_HEADER( state_map );
 

--- a/devel/libenkf/tests/enkf_state_map.c
+++ b/devel/libenkf/tests/enkf_state_map.c
@@ -283,6 +283,43 @@ void test_count_matching() {
   state_map_free( map1 );
 }
 
+// Probably means that the target should be explicitly set to
+// undefined before workflows which automatically change case.
+void test_transitions() {
+
+  test_assert_false( state_map_legal_transition(STATE_UNDEFINED , STATE_UNDEFINED ));
+  test_assert_true( state_map_legal_transition(STATE_UNDEFINED  , STATE_INITIALIZED ));
+  test_assert_false( state_map_legal_transition(STATE_UNDEFINED , STATE_HAS_DATA ));
+  test_assert_false( state_map_legal_transition(STATE_UNDEFINED , STATE_LOAD_FAILURE ));
+  test_assert_true( state_map_legal_transition(STATE_UNDEFINED  , STATE_PARENT_FAILURE ));
+  
+  test_assert_false( state_map_legal_transition(STATE_INITIALIZED , STATE_UNDEFINED ));
+  test_assert_true( state_map_legal_transition(STATE_INITIALIZED  , STATE_INITIALIZED ));
+  test_assert_true( state_map_legal_transition(STATE_INITIALIZED  , STATE_HAS_DATA ));
+  test_assert_true( state_map_legal_transition(STATE_INITIALIZED  , STATE_LOAD_FAILURE ));
+  test_assert_true( state_map_legal_transition(STATE_INITIALIZED  , STATE_PARENT_FAILURE ));    // Should maybe false - if the commenta baove is taken into account.
+  
+  test_assert_false( state_map_legal_transition(STATE_HAS_DATA , STATE_UNDEFINED ));
+  test_assert_false( state_map_legal_transition(STATE_HAS_DATA  , STATE_INITIALIZED ));
+  test_assert_true( state_map_legal_transition(STATE_HAS_DATA  , STATE_HAS_DATA ));
+  test_assert_true( state_map_legal_transition(STATE_HAS_DATA  , STATE_LOAD_FAILURE ));
+  test_assert_true( state_map_legal_transition(STATE_HAS_DATA  , STATE_PARENT_FAILURE ));   // Rerun
+
+  test_assert_false( state_map_legal_transition(STATE_LOAD_FAILURE , STATE_UNDEFINED ));
+  test_assert_true( state_map_legal_transition(STATE_LOAD_FAILURE  , STATE_INITIALIZED ));
+  test_assert_true( state_map_legal_transition(STATE_LOAD_FAILURE  , STATE_HAS_DATA ));
+  test_assert_false( state_map_legal_transition(STATE_LOAD_FAILURE  , STATE_LOAD_FAILURE ));
+  test_assert_false( state_map_legal_transition(STATE_LOAD_FAILURE  , STATE_PARENT_FAILURE ));   
+
+  test_assert_false( state_map_legal_transition(STATE_PARENT_FAILURE , STATE_UNDEFINED ));
+  test_assert_true( state_map_legal_transition(STATE_PARENT_FAILURE  , STATE_INITIALIZED ));
+  test_assert_false( state_map_legal_transition(STATE_PARENT_FAILURE  , STATE_HAS_DATA ));
+  test_assert_false( state_map_legal_transition(STATE_PARENT_FAILURE  , STATE_LOAD_FAILURE ));
+  test_assert_true( state_map_legal_transition(STATE_PARENT_FAILURE  , STATE_PARENT_FAILURE ));   
+}
+
+
+
 int main(int argc , char ** argv) {
   create_test();
   get_test();
@@ -294,6 +331,7 @@ int main(int argc , char ** argv) {
   test_update_undefined( );
   test_select_matching();
   test_count_matching();
+  test_transitions();
   exit(0);
 }
 


### PR DESCRIPTION
In cases where repeated intgerated smoother updates have the same realisation(s) failing the target case will get the state transition STATE_PARENT_FAILURE -> STATE_PARENT_FAILURE.

This PR will allow that transition - and also the allowed transition have been factored out in an exported function for better testing.
