### PR TITLE
Removed duplicate declaration and definition for method workflow_joblist_has_job(..).

### DIFF
--- a/devel/libjob_queue/include/ert/job_queue/workflow_joblist.h
+++ b/devel/libjob_queue/include/ert/job_queue/workflow_joblist.h
@@ -32,14 +32,13 @@ typedef struct workflow_joblist_struct workflow_joblist_type;
 
   workflow_joblist_type   * workflow_joblist_alloc();
   void                      workflow_joblist_free( workflow_joblist_type * joblist);
-  bool                      workflow_joblist_has_job( const workflow_joblist_type * joblist , const char * job_name);
   const workflow_job_type * workflow_joblist_get_job( const workflow_joblist_type * joblist , const char * job_name);
   void                      workflow_joblist_add_job( workflow_joblist_type * joblist , const workflow_job_type * job);
   bool                      workflow_joblist_add_job_from_file( workflow_joblist_type * joblist , const char * job_name , const char * config_file );
   config_type             * workflow_joblist_get_compiler( const workflow_joblist_type * joblist );
   config_type             * workflow_joblist_get_job_config( const workflow_joblist_type * joblist );
   bool                      workflow_joblist_has_job( const workflow_joblist_type * joblist , const char * job_name);
-  
+    
 #ifdef __cplusplus
 }
 #endif

--- a/devel/libjob_queue/src/workflow_joblist.c
+++ b/devel/libjob_queue/src/workflow_joblist.c
@@ -59,11 +59,6 @@ void workflow_joblist_free( workflow_joblist_type * joblist) {
 }
 
 
-bool workflow_joblist_has_job( const workflow_joblist_type * joblist , const char * job_name) {
- workflow_job_type * job = hash_safe_get(joblist->joblist, job_name);
- return (NULL != job);
-}
-
 const workflow_job_type * workflow_joblist_get_job( const workflow_joblist_type * joblist , const char * job_name) {
   return hash_get( joblist->joblist , job_name );
 }
@@ -76,7 +71,8 @@ void workflow_joblist_add_job( workflow_joblist_type * joblist , const workflow_
 
 
 bool workflow_joblist_has_job( const workflow_joblist_type * joblist , const char * job_name) {
-  return hash_has_key( joblist->joblist , job_name);
+ workflow_job_type * job = hash_safe_get(joblist->joblist, job_name);
+ return (NULL != job);
 }
 
 bool workflow_joblist_add_job_from_file( workflow_joblist_type * joblist , const char * job_name , const char * config_file ) {


### PR DESCRIPTION
Removed duplicate declaration and definition for method workflow_joblist_has_job(..). Introduced with PR 329. Kept the definition that uses hash_safe_get instead of hash_get. 
The method then returns false instead of chrashing when the job is not in the list. 
