### PR TITLE
[ERT-448] Fix crash when starting gert with new config file.

### DIFF
--- a/devel/python/python/ert/enkf/enkf_main.py
+++ b/devel/python/python/ert/enkf/enkf_main.py
@@ -27,6 +27,9 @@ class EnKFMain(BaseCClass):
         self.__simulation_runner = EnkfSimulationRunner(self)
         self.__fs_manager = EnkfFsManager(self)
 
+    @staticmethod
+    def createNewConfig(config_file, storage_path, case_name, dbase_type, num_realizations):
+        EnKFMain.cNamespace().create_new_config(config_file, storage_path, case_name, dbase_type, num_realizations)
 
     def set_eclbase(self, eclbase):
         EnKFMain.cNamespace().set_eclbase(self, eclbase)
@@ -154,11 +157,6 @@ class EnKFMain(BaseCClass):
 
     def get_observation_count(self, user_key):
         return EnKFMain.cNamespace().get_observation_count(self, user_key)
-
-
-    def createNewConfig(self, storage_path, case_name, dbase_type, num_realizations):
-        EnKFMain.cNamespace().create_new_config(self, storage_path, case_name, dbase_type, num_realizations)
-
 
     def getEnkfSimulationRunner(self):
         """ @rtype: EnkfSimulationRunner """

--- a/devel/python/test/ert_tests/enkf/test_enkf.py
+++ b/devel/python/test/ert_tests/enkf/test_enkf.py
@@ -120,3 +120,14 @@ class EnKFTest(ExtendedTestCase):
             self.assertIsInstance(main.getMemberRunningState(0), EnKFState)
 
             main.free()
+            
+    def test_enkf_create_config_file(self):
+        config_file      = "test_new_config"
+        firste_case_name = "default_1"
+        dbase_type       = "PLAIN"
+        num_realizations = 42
+        
+        with TestAreaContext("python/ens_condif/create_config") as ta:
+            EnKFMain.createNewConfig(config_file, ta.get_cwd(), firste_case_name, dbase_type, num_realizations)
+            main = EnKFMain(config_file, self.site_config_file)
+            self.assertEqual(main.getEnsembleSize(), num_realizations)


### PR DESCRIPTION
Make createNewConfig static so that it can be called.
Added testsuite-case for createNewConfig.
