### PR TITLE
ERT-491 - gERT asks for "creation of new file" when saving config file

### DIFF
--- a/devel/python/python/ert/enkf/enkf_main.py
+++ b/devel/python/python/ert/enkf/enkf_main.py
@@ -137,6 +137,11 @@ class EnKFMain(BaseCClass):
         site_conf_file = EnKFMain.cNamespace().get_site_config_file(self)
         return site_conf_file
 
+    def getUserConfigFile(self):
+        """ @rtype: str """
+        config_file = EnKFMain.cNamespace().get_user_config_file(self)
+        return config_file
+
 
     def getHistoryLength(self):
         return EnKFMain.cNamespace().get_history_length(self)
@@ -222,6 +227,8 @@ EnKFMain.cNamespace().get_workflow_list = cwrapper.prototype("ert_workflow_list_
 
 EnKFMain.cNamespace().fprintf_config = cwrapper.prototype("void enkf_main_fprintf_config(enkf_main)")
 EnKFMain.cNamespace().create_new_config = cwrapper.prototype("void enkf_main_create_new_config(char* , char*, char* , char* , int)")
+
+EnKFMain.cNamespace().get_user_config_file = cwrapper.prototype("char* enkf_main_get_user_config_file(enkf_main)")
 
 
 

--- a/devel/python/python/ert_gui/gert_main.py
+++ b/devel/python/python/ert_gui/gert_main.py
@@ -143,9 +143,12 @@ class Ert(object):
         self.__ert = enkf_main
 
     def reloadGERT(self):
-        python = sys.executable
+        python_executable = sys.executable
+        ert_gui_main = sys.argv[0]
+        config_file = self.__ert.getUserConfigFile()
+
         self.__ert.free()
-        os.execl(python, python, *sys.argv)
+        os.execl(python_executable, python_executable, ert_gui_main, config_file)
 
     def ert(self):
         return self.__ert


### PR DESCRIPTION
Opening a config file changes the working directory to location of the config file. A reload must take this into consideration.
