### PR TITLE
Ert 538 Improve binning of log-plotted histograms.

### DIFF
--- a/devel/share/gui/plots/scripts/histogram.js
+++ b/devel/share/gui/plots/scripts/histogram.js
@@ -136,8 +136,8 @@ function Histogram(element) {
         x_scale.domain([min, max]).nice();
 
 
-        var from_log = Math.floor(Math.log(min) / Math.log(10));
-        var to_log = Math.ceil(Math.log(max) / Math.log(10));
+        var from_log = Math.round(Math.log(min) / Math.log(10));
+        var to_log = Math.round(Math.log(max) / Math.log(10));
         var from = Math.pow(10, from_log);
         var to = Math.pow(10, to_log);
 
@@ -174,17 +174,18 @@ function Histogram(element) {
         function binner(range, values) {
             var thresholds = [];
 
-            var r = range[1] - range[0];
+            var range_diff = range[1] - range[0];
 
-            var from = Math.round(Math.log(range[0]) / Math.log(10));
-            var to = Math.round(Math.log(range[1]) / Math.log(10));
+            var from_log = Math.round(Math.log(range[0]) / Math.log(10));
+            var to_log = Math.round(Math.log(range[1]) / Math.log(10));
 
-            var log_bin_count = to - from;
-            var log_bin_count_next = log_bin_count * 2;
+            var from_to_diff = to_log - from_log;
+            var log_bin_count = from_to_diff;
+            var log_bin_count_next = from_to_diff * 2;
 
             while(log_bin_count_next < bin_count) {
                 log_bin_count = log_bin_count_next;
-                log_bin_count_next *= 2;
+                log_bin_count_next += from_to_diff;
             }
 
             if(log_bin_count_next - bin_count < bin_count - log_bin_count) {
@@ -193,14 +194,14 @@ function Histogram(element) {
                 bin_count = log_bin_count;
             }
 
-            var step = bin_count / (to - from);
+            var step = bin_count / (from_to_diff);
 
             var sum = 0;
             for(var i = 0; i <= bin_count; i++) {
                 sum += Math.pow(10, i * step);
             }
 
-            var bin_size = r / sum;
+            var bin_size = range_diff / sum;
 
             thresholds.push(range[0]);
 


### PR DESCRIPTION
While plotting histograms with logarithms the binning function now considers this logarithm. 

First finds the difference between the exponent of the minimum value and the maximum value. 
Then finds the number of bins that is closest to the sqrt(realization_count) and also a also a multiple of the first value.
