### PR TITLE
ERT-456: Option setting LICENSE_PATH can only be set from model config; ...

### DIFF
--- a/devel/libenkf/src/site_config.c
+++ b/devel/libenkf/src/site_config.c
@@ -1045,9 +1045,11 @@ void site_config_add_config_items(config_type * config, bool site_mode) {
   config_schema_item_set_argc_minmax(item, 2, 2);
   config_schema_item_set_envvar_expansion(item, false); /* Do not expand $VAR expressions (that is done in util_interp_setenv()). */
 
-  item = config_add_schema_item(config, LICENSE_PATH_KEY, site_mode);
-  config_schema_item_set_argc_minmax(item, 1, 1);
-  config_schema_item_iset_type(item, 0, CONFIG_PATH);
+  if (!site_mode) {
+    item = config_add_schema_item(config, LICENSE_PATH_KEY, false);
+    config_schema_item_set_argc_minmax(item, 1, 1);
+    config_schema_item_iset_type(item, 0, CONFIG_PATH);
+  }
 
 
   /*****************************************************************/

--- a/devel/libenkf/tests/enkf_site_config.c
+++ b/devel/libenkf/tests/enkf_site_config.c
@@ -55,8 +55,10 @@ void test_init(const char * config_file) {
   config_type * config = config_alloc();
 
   site_config_add_config_items( config , true );
-  if (!config_parse(config , config_file , "--" , INCLUDE_KEY , DEFINE_KEY , CONFIG_UNRECOGNIZED_WARN , true))
+  if (!config_parse(config , config_file , "--" , INCLUDE_KEY , DEFINE_KEY , CONFIG_UNRECOGNIZED_WARN , true)) {
+    config_fprintf_errors( config , true , stdout );
     test_error_exit("Parsing site config file:%s failed \n",config_file );
+  }
 
   if (!site_config_init( site_config , config ))
     test_error_exit("Loading site_config from config failed\n");
@@ -101,6 +103,7 @@ void test_job_script() {
 
 int main(int argc , char ** argv) {
   const char * site_config_file = argv[1];
+
   test_empty();
   test_init( site_config_file );
   test_job_script();


### PR DESCRIPTION
...not from site-config - since cwd is typically in a non-writable location when parsin site config.
