### PR TITLE
Add __clang__ version to util_abort() declarations.

### DIFF
--- a/devel/libert_util/include/ert/util/util.h
+++ b/devel/libert_util/include/ert/util/util.h
@@ -476,6 +476,10 @@ void      util_abort_test_set_intercept_function(const char * function);
 #define util_abort(fmt , ...) util_abort__(__FILE__ , __func__ , __LINE__ , fmt , ##__VA_ARGS__)
 #endif
 
+#ifdef __clang__
+#define util_abort(fmt , ...) util_abort__(__FILE__ , __func__ , __LINE__ , fmt , ##__VA_ARGS__)
+#endif
+
 #ifdef COMPILER_MSVC
 #define util_abort(fmt , ...) util_abort__(__FILE__ , __func__ , __LINE__ , fmt , __VA_ARGS__)
 #endif


### PR DESCRIPTION
Without this, only gcc and msvc compilers are supported.

The declaration itself is the same as that for gcc, but without the auxillary functions defined in that section.
