### PR TITLE
do not define the WIN32 macro unconditionally

### DIFF
--- a/devel/libecl/include/ert/ecl/ecl_endian_flip.h
+++ b/devel/libecl/include/ert/ecl/ecl_endian_flip.h
@@ -36,8 +36,6 @@ extern "C" {
 */
 
 #define ECLIPSE_BYTE_ORDER  __BIG_ENDIAN   // Alternatively: __LITTLE_ENDIAN
-#define WIN32 1
-
 
 #ifdef BYTE_ORDER
   #if  BYTE_ORDER == ECLIPSE_BYTE_ORDER


### PR DESCRIPTION
WTF? this seems like it was a debugging artifact...

thanks to @robertk-iris for finding this.
