### PR TITLE
Changes to locate site-config

### DIFF
--- a/devel/python/python/ert_gui/CMakeLists.txt
+++ b/devel/python/python/ert_gui/CMakeLists.txt
@@ -17,3 +17,14 @@ add_subdirectory(simulation)
 add_subdirectory(tools)
 add_subdirectory(viewer)
 add_subdirectory(widgets)
+
+#-----------------------------------------------------------------
+
+set(site_config_target "${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/ert_gui/site_config.py")
+set(destination "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX}/ert_gui")
+set(install_target "${destination}/site_config.py") 
+
+configure_file(site_config.py.in ${site_config_target})
+install(FILES ${site_config_target} DESTINATION ${destination} )
+install(CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/cmake/cmake_pyc_file ${install_target})")
+

--- a/devel/python/python/ert_gui/gert_main.py
+++ b/devel/python/python/ert_gui/gert_main.py
@@ -135,6 +135,12 @@ from ert_gui.widgets import util
 
 import ert_gui.widgets.util
 
+try:
+    import site_config
+    site_config_file = site_config.config_file
+except ImportError:
+    site_config_file = None
+
 if os.getenv("ERT_SHARE_PATH"):
     ert_share_path = os.getenv("ERT_SHARE_PATH")
 else:
@@ -198,7 +204,8 @@ def main(argv):
     help_center.setHelpMessageLink("welcome_to_ert")
 
     strict = True
-    site_config = os.getenv("ERT_SITE_CONFIG")
+    if os.getenv("ERT_SITE_CONFIG"):
+        site_config_file = os.getenv("ERT_SITE_CONFIG")
 
     if not os.path.exists(config_file):
         print("Trying to start new config")
@@ -233,7 +240,7 @@ def main(argv):
     now = time.time()
 
 
-    ert = Ert(EnKFMain(config_file, site_config=site_config, strict=strict))
+    ert = Ert(EnKFMain(config_file, site_config = site_config_file, strict=strict))
     ErtConnector.setErt(ert.ert())
 
     window = GertMainWindow()

--- a/devel/python/python/ert_gui/site_config.py.in
+++ b/devel/python/python/ert_gui/site_config.py.in
@@ -1,0 +1,1 @@
+config_file = "${SITE_CONFIG_FILE}"


### PR DESCRIPTION
With this commit the system for locating the site config file is as
follows:
1. During the configure process cmake will create a file site_config.py
   in the build/python/ert_gui directory, the content of this file will
   be:
   
   ```
   config_file = "${SITE_CONFIG_FILE}"
   ```
   
    where ${SITE_CONFIG_FILE} is the variable set during the configure
    step. The generated file will be installed alongside the gert_main
    module.
2. The gert_main module tries to import the site_config module and uses
   the config_file setting from there.
3. If the ERT_SITE_CONFIG environment variable has been set that will
   take presedence.

With these changes it is not necessary for the frontend script to set
the ERT_SITE_CONFIG variable.
