### PR TITLE
ERT 736: No need to alloc rng twice. 

### DIFF
--- a/devel/libenkf/src/enkf_main.c
+++ b/devel/libenkf/src/enkf_main.c
@@ -2831,8 +2831,6 @@ enkf_main_type * enkf_main_bootstrap(const char * _site_config, const char * _mo
     /*
       Initializing the various 'large' sub config objects. 
     */
-    rng_config_init( enkf_main->rng_config , config );
-    enkf_main_rng_init( enkf_main );  /* Must be called before the ensmeble is created. */
     enkf_main_init_subst_list( enkf_main );
     ert_workflow_list_init( enkf_main->workflow_list , config );
     


### PR DESCRIPTION
The error was that the rng pointer in the analysis_config struct was not updated after the second allocation of enkf_main->rng. This led to the analysis_config struct pointing to a freed rng. As there is no need to alloc the rng twice; removed the unecessary second allocation
