### PR TITLE
ERT-769: Moved load_segment flag further in.

### DIFF
--- a/devel/libecl_well/applications/segment_info.c
+++ b/devel/libecl_well/applications/segment_info.c
@@ -57,8 +57,10 @@ int main(int argc , char ** argv) {
       {
         well_conn_collection_type * connections = well_conn_collection_alloc();
         well_segment_collection_type * segments = well_segment_collection_alloc();
+        bool load_segment_information = true;
+        bool is_MSW_well = false;
                 
-        if (well_segment_collection_load_from_kw( segments , well_nr , iwel_kw , iseg_kw , rseg_loader , rst_head )) {
+        if (well_segment_collection_load_from_kw( segments , well_nr , iwel_kw , iseg_kw , rseg_loader , rst_head , load_segment_information , &is_MSW_well)) {
           well_branch_collection_type * branches = well_branch_collection_alloc();
 
           well_conn_collection_load_from_kw( connections , iwel_kw , icon_kw , scon_kw , well_nr , rst_head);

--- a/devel/libecl_well/include/ert/ecl_well/well_segment_collection.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_segment_collection.h
@@ -47,7 +47,9 @@ extern "C" {
                                                                        const ecl_kw_type * iwel_kw , 
                                                                        const ecl_kw_type * iseg_kw , 
                                                                        const well_rseg_loader_type * rseg_loader ,
-                                                                       const ecl_rsthead_type * rst_head);
+                                                                       const ecl_rsthead_type * rst_head,
+                                                                       bool load_segment_information , bool * is_MSW_well);
+  
   void                           well_segment_collection_link(const  well_segment_collection_type * segment_collection);
   void                           well_segment_collection_add_connections(well_segment_collection_type * segment_collection , 
                                                                          const char * grid_name , 

--- a/devel/libecl_well/include/ert/ecl_well/well_state.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_state.h
@@ -50,7 +50,9 @@ extern "C" {
 
   bool well_state_add_MSW( well_state_type * well_state , 
                            const ecl_file_type * rst_file , 
-                           int well_nr);
+                           int  well_nr,
+                           bool load_segment_information);
+                           
 
   bool well_state_is_MSW( const well_state_type * well_state);
 

--- a/devel/libecl_well/src/well_segment_collection.c
+++ b/devel/libecl_well/src/well_segment_collection.c
@@ -104,23 +104,28 @@ int well_segment_collection_load_from_kw( well_segment_collection_type * segment
                                           const ecl_kw_type * iwel_kw , 
                                           const ecl_kw_type * iseg_kw , 
                                           const well_rseg_loader_type * rseg_loader ,
-                                          const ecl_rsthead_type * rst_head) {
-
+                                          const ecl_rsthead_type * rst_head , 
+                                          bool load_segments , bool * is_MSW_well) {
+  
   int iwel_offset = rst_head->niwelz * well_nr;
   int segment_well_nr = ecl_kw_iget_int( iwel_kw , iwel_offset + IWEL_SEGMENTED_WELL_NR_ITEM) - 1; 
   int segments_added = 0;
       
   if (segment_well_nr != IWEL_SEGMENTED_WELL_NR_NORMAL_VALUE) {
     int segment_index;
-    for (segment_index = 0; segment_index < rst_head->nsegmx; segment_index++) {
-      int segment_id = segment_index + WELL_SEGMENT_OFFSET;
-      well_segment_type * segment = well_segment_alloc_from_kw( iseg_kw , rseg_loader , rst_head , segment_well_nr , segment_index , segment_id );
+    *is_MSW_well = true;
 
-      if (well_segment_active( segment )) {
-        well_segment_collection_add( segment_collection , segment );
-        segments_added++;
-      } else
-        well_segment_free( segment );
+    if (load_segments) {
+      for (segment_index = 0; segment_index < rst_head->nsegmx; segment_index++) {
+        int segment_id = segment_index + WELL_SEGMENT_OFFSET;
+        well_segment_type * segment = well_segment_alloc_from_kw( iseg_kw , rseg_loader , rst_head , segment_well_nr , segment_index , segment_id );
+        
+        if (well_segment_active( segment )) {
+          well_segment_collection_add( segment_collection , segment );
+          segments_added++;
+        } else
+          well_segment_free( segment );
+      }
     }
   }
   return segments_added;

--- a/devel/libecl_well/src/well_state.c
+++ b/devel/libecl_well/src/well_state.c
@@ -372,7 +372,8 @@ void well_state_add_connections( well_state_type * well_state ,
 
 bool well_state_add_MSW( well_state_type * well_state ,
                          const ecl_file_type * rst_file ,
-                         int well_nr) {
+                         int well_nr,
+                         bool load_segment_information) {
 
   if (ecl_file_has_kw( rst_file , ISEG_KW)) {
     ecl_rsthead_type  * rst_head  = ecl_rsthead_alloc( rst_file );
@@ -380,37 +381,42 @@ bool well_state_add_MSW( well_state_type * well_state ,
     const ecl_kw_type * iseg_kw = ecl_file_iget_named_kw( rst_file , ISEG_KW , 0);
     well_rseg_loader_type * rseg_loader = NULL;
     
-    int segments;
+    int segment_count;
 
-    if (ecl_file_has_kw( rst_file , RSEG_KW ))
+    if (ecl_file_has_kw( rst_file , RSEG_KW )) {
+      if (load_segment_information)
         rseg_loader = well_rseg_loader_alloc(rst_file);
+        
+      segment_count = well_segment_collection_load_from_kw( well_state->segments ,
+                                                            well_nr ,
+                                                            iwel_kw ,
+                                                            iseg_kw ,
+                                                            rseg_loader ,
+                                                            rst_head,
+                                                            load_segment_information , 
+                                                            &well_state->is_MSW_well);
+      
+      
+      if (segment_count > 0) {
+        hash_iter_type * grid_iter = hash_iter_alloc( well_state->connections );
+        while (!hash_iter_is_complete( grid_iter )) {
+          const char * grid_name = hash_iter_get_next_key( grid_iter );
+          const well_conn_collection_type * connections = hash_get( well_state->connections , grid_name );
+          well_segment_collection_add_connections( well_state->segments , grid_name , connections );
+        }
+        hash_iter_free( grid_iter );
 
-    segments = well_segment_collection_load_from_kw( well_state->segments ,
-                                                     well_nr ,
-                                                     iwel_kw ,
-                                                     iseg_kw ,
-                                                     rseg_loader ,
-                                                     rst_head);
-
-    if (segments) {
-      well_state->is_MSW_well = true;
-      hash_iter_type * grid_iter = hash_iter_alloc( well_state->connections );
-      while (!hash_iter_is_complete( grid_iter )) {
-        const char * grid_name = hash_iter_get_next_key( grid_iter );
-        const well_conn_collection_type * connections = hash_get( well_state->connections , grid_name );
-        well_segment_collection_add_connections( well_state->segments , grid_name , connections );
+        well_segment_collection_link( well_state->segments );
+        well_segment_collection_add_branches( well_state->segments , well_state->branches );
       }
-      hash_iter_free( grid_iter );
-      well_segment_collection_link( well_state->segments );
-      well_segment_collection_add_branches( well_state->segments , well_state->branches );
-    }
-    ecl_rsthead_free( rst_head );
-
-    if(rseg_loader != NULL) {
+      ecl_rsthead_free( rst_head );
+      
+      if (rseg_loader != NULL) {
         well_rseg_loader_free(rseg_loader);
+      }
+      
+      return true;
     }
-
-    return true;
   } else
     return false;
 }
@@ -462,12 +468,9 @@ well_state_type * well_state_alloc_from_file( ecl_file_type * ecl_file , const e
       free( name );
 
       well_state_add_connections( well_state , grid , ecl_file , global_well_nr);
-      if (ecl_file_has_kw( ecl_file , ISEG_KW)){
-          well_state->is_MSW_well = true;
-          if(load_segment_information){
-            well_state_add_MSW( well_state , ecl_file , global_well_nr );
-          }
-      }
+      if (ecl_file_has_kw( ecl_file , ISEG_KW))
+        well_state_add_MSW( well_state , ecl_file , global_well_nr , load_segment_information);
+      
 
     }
     ecl_rsthead_free( global_header );

--- a/devel/libecl_well/tests/well_segment_branch_conn_load.c
+++ b/devel/libecl_well/tests/well_segment_branch_conn_load.c
@@ -56,8 +56,10 @@ int main(int argc , char ** argv) {
       well_conn_collection_load_from_kw( connections , iwel_kw , icon_kw , scon_kw , well_nr , rst_head);
       {
         well_segment_collection_type * segments = well_segment_collection_alloc();
+        bool load_segment_information = true;
+        bool is_MSW_well = false;
                 
-        if (well_segment_collection_load_from_kw( segments , well_nr , iwel_kw , iseg_kw , rseg_loader , rst_head )) {
+        if (well_segment_collection_load_from_kw( segments , well_nr , iwel_kw , iseg_kw , rseg_loader , rst_head , load_segment_information , &is_MSW_well)) {
           well_branch_collection_type * branches = well_branch_collection_alloc();
           
           test_assert_true( well_segment_well_is_MSW( well_nr , iwel_kw , rst_head));

--- a/devel/libecl_well/tests/well_segment_load.c
+++ b/devel/libecl_well/tests/well_segment_load.c
@@ -74,8 +74,16 @@ int main(int argc , char ** argv) {
 
       {
         well_segment_collection_type * segments2 = well_segment_collection_alloc();
-        test_assert_int_equal( well_segment_collection_load_from_kw( segments2 , well_nr , iwel_kw , iseg_kw , rseg_loader , rst_head ) ,
+        bool load_segments = true;
+        bool is_MSW_well = false;
+        test_assert_int_equal( well_segment_collection_load_from_kw( segments2 , well_nr , iwel_kw , iseg_kw , rseg_loader , rst_head , load_segments , &is_MSW_well ) ,
                                well_segment_collection_get_size( segments));
+
+        if (well_segment_collection_get_size( segments ) > 0)
+          test_assert_true( is_MSW_well );
+        else
+          test_assert_false( is_MSW_well );
+        
 
         well_segment_collection_link( segments );
         well_segment_collection_link( segments2 );

--- a/devel/libecl_well/tests/well_state_load.c
+++ b/devel/libecl_well/tests/well_state_load.c
@@ -45,7 +45,8 @@ int main(int argc , char ** argv) {
     bool open = false;
     well_type_enum type = GAS_INJECTOR;
     int global_well_nr = 0;
-    
+    bool load_segment_information = true;
+
     for (global_well_nr = 0; global_well_nr < header->nwells; global_well_nr++) {
       well_state_type * well_state = well_state_alloc(well_name , global_well_nr , open , type , report_nr , valid_from);
       test_assert_true( well_state_is_instance( well_state) );
@@ -55,7 +56,7 @@ int main(int argc , char ** argv) {
       test_assert_false( well_state_has_grid_connections( well_state , "???" ));
       test_assert_true( well_state_has_global_connections( well_state ));
       
-      well_state_add_MSW( well_state , rst_file , global_well_nr );
+      well_state_add_MSW( well_state , rst_file , global_well_nr , load_segment_information );
       {
         const well_segment_collection_type * segments = well_state_get_segments( well_state );
         const well_branch_collection_type * branches = well_state_get_branches( well_state );

--- a/devel/libecl_well/tests/well_state_load_missing_RSEG.c
+++ b/devel/libecl_well/tests/well_state_load_missing_RSEG.c
@@ -45,12 +45,13 @@ int main(int argc , char ** argv) {
     bool open = false;
     well_type_enum type = GAS_INJECTOR;
     int global_well_nr = 0;
+    bool load_segment_information = false;
     
     for (global_well_nr = 0; global_well_nr < header->nwells; global_well_nr++) {
       well_state_type * well_state = well_state_alloc(well_name , global_well_nr , open , type , report_nr , valid_from);
       test_assert_true( well_state_is_instance( well_state) );
       well_state_add_connections( well_state , grid , rst_file , 0 );
-      well_state_add_MSW( well_state , rst_file , global_well_nr );
+      well_state_add_MSW( well_state , rst_file , global_well_nr , load_segment_information );
 
       {
         const well_segment_collection_type * segments = well_state_get_segments( well_state );

--- a/devel/python/test/ert_tests/well/test_ecl_well.py
+++ b/devel/python/test/ert_tests/well/test_ecl_well.py
@@ -211,8 +211,8 @@ class EclWellTest(ExtendedTestCase):
         self.assertEqual(open_states[True], 53)
         self.assertEqual(open_states[False], 169)
 
-        self.assertEqual(msw_states[True], 222)
-        self.assertEqual(msw_states[False], 0)
+        self.assertEqual(msw_states[True], 169)
+        self.assertEqual(msw_states[False], 53)
 
         self.assertEqual(well_types[WellTypeEnum.UNDOCUMENTED_ZERO], 0)
         self.assertEqual(well_types[WellTypeEnum.WATER_INJECTOR], 0)
@@ -342,7 +342,7 @@ class EclWellTest(ExtendedTestCase):
         well_time_line = well_info[well_name]
         well_state = well_time_line[0]
 
-        self.assertTrue(well_state.isMultiSegmentWell())
+        self.assertFalse(well_state.isMultiSegmentWell())
 
         self.assertTrue(well_state.hasGlobalConnections())
         global_connections = well_state.globalConnections()


### PR DESCRIPTION
This change was introduced to ensure that the is_MSW flag is correctly
set on a per-well basis, even when the load_segment flag is false. The
commit also incldues reverting some test asserts in the Python test.
