### PR TITLE
fixed: open() calls with O_CREATE requires creation mode parameter

### DIFF
--- a/devel/libert_util/src/util_lockf.c
+++ b/devel/libert_util/src/util_lockf.c
@@ -70,7 +70,7 @@ FILE * util_fopen_lockf(const char * filename, const char * mode) {
   if (strcmp(mode , "w") == 0)
     flags += O_CREAT;
   
-  fd = open(filename , flags);
+  fd = open(filename , flags, S_IRUSR|S_IWUSR);
   if (fd == -1) 
     util_abort("%s: failed to open:%s with flags:%d \n",__func__ , filename , flags);
   


### PR DESCRIPTION
calls to open() (always) require[s|d] the creation mode parameter. newer toolchains has started to detect this and fails to build.
