### PR TITLE
ERT-825: Changes in doc building:

### DIFF
--- a/devel/docs/CMakeLists.txt
+++ b/devel/docs/CMakeLists.txt
@@ -1,6 +1,20 @@
-set( ERT_DOC_INSTALL_PATH "" CACHE PATH "Absolute path to install documentation *in addition* to $PREFIX/documentation")
+set( ERT_DOC_INSTALL_PATH  "" CACHE PATH "Absolute path to install documentation *in addition* to $PREFIX/documentation")
+set( ERT_DOC_EXTERNAL_ROOT "" CACHE PATH "Path to site local ERT documentation")
 
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Static DESTINATION ${PROJECT_BINARY_DIR}/tmp_doc/)
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/tmp_doc")
+EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/user" "${PROJECT_BINARY_DIR}/tmp_doc/user")
+EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/code" "${PROJECT_BINARY_DIR}/tmp_doc/code")
+
+if (ERT_DOC_EXTERNAL_ROOT)
+    EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${ERT_DOC_EXTERNAL_ROOT}" "${PROJECT_BINARY_DIR}/tmp_doc/external-doc")
+    message(STATUS "Adding documentation link ${PROJECT_BINARY_DIR}/tmp_doc/external-doc -> ${ERT_DOC_EXTERNAL_ROOT}")
+    set( ERT_DOC_LINK external-doc/index )
+else()
+    set( ERT_DOC_LINK "" )    
+endif()
+
+configure_file(index.rst.in ${PROJECT_BINARY_DIR}/tmp_doc/index.rst )
+
 add_custom_target(doc_out ALL 
                           COMMAND ${CMAKE_COMMAND}  -Dccsd=${CMAKE_CURRENT_SOURCE_DIR} -Dpbd=${PROJECT_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/build_doc.cmake 
                           DEPENDS enkf )                                  

--- a/devel/docs/Static/index.rst
+++ b/devel/docs/Static/index.rst
@@ -1,6 +1,0 @@
-First page in the static ert's documentation!
-===============================
-
-Contents:
-This is where we need to write the "manual" documentation
-

--- a/devel/docs/build_doc.cmake
+++ b/devel/docs/build_doc.cmake
@@ -1,6 +1,8 @@
-set( ENV{PYTHONPATH}  ${pbd}/python)
-
+#set( ENV{PYTHONPATH}  ${pbd}/python)
 execute_process(COMMAND cmake -E copy ${ccsd}/conf.py ${pbd}/tmp_doc/conf.py )
-execute_process(COMMAND cmake -E copy ${ccsd}/index.rst ${pbd}/tmp_doc/index.rst )
-execute_process(COMMAND sphinx-apidoc -e -o python ${pbd}/python WORKING_DIRECTORY ${pbd}/tmp_doc/)
+
+
+# The api documentation is reeferenced from code/python/index.rst, i.e. the output path used when calling
+# sphinx-apidoc must match this.
+execute_process(COMMAND sphinx-apidoc -e -o API/python ${pbd}/python WORKING_DIRECTORY ${pbd}/tmp_doc/)
 execute_process(COMMAND sphinx-build -b html -d _build/doctrees . _build WORKING_DIRECTORY ${pbd}/tmp_doc/)

--- a/devel/docs/code/C/index.rst
+++ b/devel/docs/code/C/index.rst
@@ -1,0 +1,4 @@
+Low level C libraries
+=====================
+
+How to use the C libraries

--- a/devel/docs/code/index.rst
+++ b/devel/docs/code/index.rst
@@ -1,0 +1,11 @@
+Documentation of ert code
+=========================
+
+Contents:
+
+.. toctree::
+   :maxdepth: 1
+
+   python/index
+   C/index
+

--- a/devel/docs/code/python/eclipse/API/index.rst
+++ b/devel/docs/code/python/eclipse/API/index.rst
@@ -1,0 +1,9 @@
+The ert Python API
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   ../../API/python/ert              
+   ../../API/python/ert_gui              
+

--- a/devel/docs/code/python/eclipse/index.rst
+++ b/devel/docs/code/python/eclipse/index.rst
@@ -1,0 +1,5 @@
+Using the ert.ecl classes for Eclipse manipulation
+==================================================
+
+Using the ert.ecl classes for ECLIPSE binary files
+

--- a/devel/docs/code/python/index.rst
+++ b/devel/docs/code/python/index.rst
@@ -1,0 +1,10 @@
+Python documentation
+====================
+
+.. toctree::
+   :maxdepth: 1
+
+   introduction/index
+   eclipse/index
+   ../../API/python/ert
+   ../../API/python/ert_gui

--- a/devel/docs/code/python/introduction/index.rst
+++ b/devel/docs/code/python/introduction/index.rst
@@ -1,0 +1,4 @@
+Simple introduction to Python
+=============================
+
+An introduction to Python

--- a/devel/docs/index.rst.in
+++ b/devel/docs/index.rst.in
@@ -9,12 +9,11 @@ Welcome to ert's documentation!
 Contents:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
-   Static/index
-
-   python/ert
-   python/ert_gui
+   user/index
+   code/index
+   ${ERT_DOC_LINK}
 
 
 Indices and tables

--- a/devel/docs/user/index.rst
+++ b/devel/docs/user/index.rst
@@ -1,0 +1,11 @@
+User documentation for ERT
+==========================
+
+Contents:
+
+.. toctree::
+   :maxdepth: 1
+
+   tutorial/index
+   keywords/index
+   observations/index

--- a/devel/docs/user/keywords/index.rst
+++ b/devel/docs/user/keywords/index.rst
@@ -1,0 +1,7 @@
+Keywords available in the ERT configuration
+===========================================
+
+.. toctree::
+   :maxdepth: 1
+
+Here comes keywords ...

--- a/devel/docs/user/observations/index.rst
+++ b/devel/docs/user/observations/index.rst
@@ -1,0 +1,4 @@
+Configuring observations for ERT
+================================
+
+Adding observations ...

--- a/devel/docs/user/tutorial/index.rst
+++ b/devel/docs/user/tutorial/index.rst
@@ -1,0 +1,3 @@
+ERT Tutorial
+============
+Tutorial for ert.


### PR DESCRIPTION
 - A cmake variable ERT_DOC_EXTERNAL_ROOT is added, with that setting
   external documentation can be included in the build process.

 - The top level index.rst is created using configure_file() to include
   the external documentation - if specified.

 - The documentation building is based on symlinks from the build
   directory instead of copies.