### PR TITLE
Use CMake command option to change directory

### DIFF
--- a/devel/libenkf/applications/ert_tui/CMakeLists.txt
+++ b/devel/libenkf/applications/ert_tui/CMakeLists.txt
@@ -28,7 +28,8 @@ string(STRIP ${BUILD_TIME} BUILD_TIME)
 # but on git version 1.83 that switch is not recognized.
 find_package(Git)
 if(GIT_EXECUTABLE)
-   execute_process(COMMAND ${GIT_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}" rev-parse HEAD
+   execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    OUTPUT_VARIABLE GIT_COMMIT)
    string(STRIP "${GIT_COMMIT}" GIT_COMMIT)
 else()


### PR DESCRIPTION
Specifying the path without the -C option will give error messages like "git: 'devel/libenkf/applications/ert_tui' is not a git command.", but the -C option is not available in older Git versions (it was introduced in 1.8.5).

Use the WORKING_DIRECTORY option of the EXECUTE_PROCESS command instead to change into the source directory and run the git process there.