### PR TITLE
Manually ensure module/library load order

### DIFF
--- a/devel/python/python/ert/analysis/__init__.py
+++ b/devel/python/python/ert/analysis/__init__.py
@@ -16,6 +16,8 @@
 
 
 import ert.cwrap.clib as clib
+import ert.util
+
 ANALYSIS_LIB = clib.ert_load("libanalysis")
 
 from .enums import AnalysisModuleOptionsEnum, AnalysisModuleLoadStatusEnum

--- a/devel/python/python/ert/cwrap/clib.py
+++ b/devel/python/python/ert/cwrap/clib.py
@@ -13,8 +13,21 @@
 #   
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details. 
-"""
-Convenience module for loading shared library.
+"""Convenience module for loading shared library.
+
+Observe that to ensure that all libraries are loaded through the same
+code path, all required libraries should be loaded explicitly through
+the use of import statements; i.e. the ert.geo package requires the
+libert_util librarary, to ensure that the correct version of the
+libert_util.so library file is loaded we should manually load that
+first as:
+
+   import ert.util
+   GEO_LIB = clib.ert_load("libert_geometry")
+
+Otherwise the standard operating system dependency resolve code will
+be invoked when loading libert_geometry, and that could in principle
+lead to loading a different version of libert_util.so
 """
 
 import platform

--- a/devel/python/python/ert/ecl/__init__.py
+++ b/devel/python/python/ert/ecl/__init__.py
@@ -75,7 +75,6 @@ import ert.util
 import ert.geo
 
 
-
 ECL_LIB = clib.ert_load("libecl")
 
 from .ecl_sum import EclSum #, EclSumVector, EclSumNode, EclSMSPECNode

--- a/devel/python/python/ert/enkf/__init__.py
+++ b/devel/python/python/ert/enkf/__init__.py
@@ -16,6 +16,16 @@
 
 
 import ert.cwrap.clib as clib
+import ert.util
+import ert.geo
+import ert.ecl
+import ert.rms
+import ert.analysis
+import ert.sched
+import ert.config
+import ert.job_queue
+
+
 
 ENKF_LIB = clib.ert_load("libenkf")
 

--- a/devel/python/python/ert/job_queue/__init__.py
+++ b/devel/python/python/ert/job_queue/__init__.py
@@ -55,6 +55,7 @@ external commands.
 
 import os
 import ert.util
+import ert.config
 import ert.cwrap.clib as clib
 
 

--- a/devel/python/python/ert/rms/__init__.py
+++ b/devel/python/python/ert/rms/__init__.py
@@ -1,4 +1,7 @@
 from ert.cwrap import clib
 
+import ert.util
+import ert.geo
+import ert.ecl
 
 RMS_LIB = clib.ert_load("librms")

--- a/devel/python/python/ert/well/__init__.py
+++ b/devel/python/python/ert/well/__init__.py
@@ -1,4 +1,7 @@
 import ert.cwrap.clib as clib
+import ert.util
+import ert.geo
+import ert.ecl
 
 ECL_WELL_LIB = clib.ert_load("libecl_well")
 


### PR DESCRIPTION
This PR ensures that modules/libraries are loaded in a deterministic (correct) order.