### PR TITLE
Ert util deprecate method

### DIFF
--- a/devel/libecl/applications/sum_write.c
+++ b/devel/libecl/applications/sum_write.c
@@ -106,7 +106,8 @@
    5. The header contains a "TIME" variable; to some extent this looks
       like just any other variable, but it must be present in the
       SMSPEC header. In the example above the first element in every
-      data block is the current time (in days) for that datablock.
+      data block is the current time (in days) for that datablock; if
+      labunits is used the stored value is the elapsed time in hours.
 
    6. In the ecl_sum library the concept of a 'gen_key' is used quite
       extensively. The gen_key is a string combination of the KEYWORD,
@@ -190,7 +191,8 @@ int main( int argc , char ** argv) {
 
       6-8: Grid dimensions.
   */
-  ecl_sum_type * ecl_sum = ecl_sum_alloc_writer( "/tmp/CASE" , false , true , ":" , start_time , nx , ny , nz );
+  bool time_in_days = true;
+  ecl_sum_type * ecl_sum = ecl_sum_alloc_writer( "/tmp/CASE" , false , true , ":" , start_time , time_in_days , nx , ny , nz );
 
 
   /*

--- a/devel/libecl/applications/sum_write.c
+++ b/devel/libecl/applications/sum_write.c
@@ -1,18 +1,18 @@
 /*
-   Copyright (C) 2012  Statoil ASA, Norway. 
-   The file 'sum_write' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+   The file 'sum_write' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
@@ -58,7 +58,7 @@
 
 
              CASE.SMSPEC                      CASE.S0001                         CASE.S0002
-   ------------------------------       --------------------------       --------------------------------------- 
+   ------------------------------       --------------------------       ---------------------------------------
    | KEYWORD |  WGNAMES  | NUMS |       | MINISTEP 1|  MINISTEP 2|       | MINISTEP 3|  MINISTEP 4|  MINISTEP 5|
    +----------------------------+       +------------------------+       +-------------------------------------+
    | TIME    |           |      |  -->  |           |            |  -->  |           |            |            |
@@ -114,7 +114,7 @@
       relevant elements are combined when forming a gen_key; i.e. for
       the example above we will have:
 
-        ------------------------------        
+        ------------------------------
         | KEYWORD |  WGNAMES  | NUMS |        General key
         +----------------------------+        ------------
         | TIME    |           |      |  -->   TIME
@@ -122,7 +122,7 @@
         | GOPR    | P-North   |      |  -->   GOPR:P-North
         | BPR     |           | 5423 |  -->   BPR:5423 , BPR:i,j,k
         | WGPR    | GasW      |      |  -->   WGPR:GasW
-        +----------------------------+       
+        +----------------------------+
 
      Note the following:
 
@@ -132,7 +132,7 @@
         never inverted, so the join string can be arbitrary.
 
       o For the block quantities, like the BPR in the example above
-        the NUMS value is the cell number in (i,j,k) ordering: 
+        the NUMS value is the cell number in (i,j,k) ordering:
 
                  NUMS = i + (j - 1)*nx + (k-1)*nx*ny
 
@@ -148,11 +148,11 @@
 
     2. Use your simulator to step forward in time, and add timesteps
        with ecl_sum_add_tstep().
-  
+
    Now - the important thing is that steps 1 and 2 two can not be
-   interchanged, that will lead to crash and burn.  
+   interchanged, that will lead to crash and burn.
 */
-  
+
 
 
 int main( int argc , char ** argv) {
@@ -160,7 +160,7 @@ int main( int argc , char ** argv) {
   int nx = 10;
   int ny = 10;
   int nz = 10;
-  
+
 
   smspec_node_type * wwct_wellx;
   smspec_node_type * wopr_wellx;
@@ -173,7 +173,7 @@ int main( int argc , char ** argv) {
 
       1: The case - this an ECLIPSE basename, with an optional leading
          path component. Can later be modified with ecl_sum_set_case().
-         
+
       2: Should formatted files be used? Can be modified with
          ecl_sum_set_fmt_output().
 
@@ -196,12 +196,12 @@ int main( int argc , char ** argv) {
   /*
     We add the variables we wish to measure. Due to the rather
     inflexible nature of the format we must add all the variables we
-    are interested in before we start adding data. 
-    
+    are interested in before we start adding data.
+
     The arguments to this function are:
 
       1. self / this
-      
+
       2. The KEYWORD value for the variable we are considering; the
          function ecl_smspec_identify_var_type() will be called with
          this string - i.e. you must follow the ECLIPSE rules (see
@@ -216,7 +216,7 @@ int main( int argc , char ** argv) {
       4. The NUMS value for this variable.
 
       5. The unit for this variable.
-      
+
       6. A defualt value for this variable.
 
     Observe that as an alternative to ecl_sum_add_var() you can use
@@ -229,11 +229,11 @@ int main( int argc , char ** argv) {
     This is an alternative when e.g. the name of wells is not known in
     advance.
   */
-  ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 ); 
+  ecl_sum_add_var( ecl_sum , "FOPT" , NULL   , 0   , "Barrels" , 99.0 );
   ecl_sum_add_var( ecl_sum , "BPR"  , NULL   , 567 , "BARS"    , 0.0  );
   ecl_sum_add_var( ecl_sum , "WWCT" , "OP-1" , 0   , "(1)"     , 0.0  );
   ecl_sum_add_var( ecl_sum , "WOPR" , "OP-1" , 0   , "Barrels" , 0.0  );
-  
+
 
   /*
     The return value from the ecl_sum_add_var() function is an
@@ -246,15 +246,15 @@ int main( int argc , char ** argv) {
        1. You can just ignore it - that is not very clean; in this
           case you must make an assumption of gen_key format at a
           later stage.
-          
+
        2. You can use the smspec_node_get_gen_key1() or
           smspec_node_get_params_index() and hold on to the gen_key or
           params_index values. You will need these later.
 
        3. You can hold on to the complete smspec_node instance, and
           then later on call one of the smspec_node_get_params_index()
-          or smspec_node_get_gen_key1() functions. 
-          
+          or smspec_node_get_gen_key1() functions.
+
           If you wish to change the WGNAME value with
           ecl_sum_update_wgname() a later stage you must hold on to
           the smspec_node instance.
@@ -277,7 +277,7 @@ int main( int argc , char ** argv) {
     Here we add a collection of ten variables which are not
     initialized. Before they can be actually used you must initialize
     them with:
-    
+
        ecl_sum_init_var( ecl_sum , node , keyword , wgname , num , unit );
 
     If you do not init them at all they will appear in the SMSPEC file
@@ -291,9 +291,9 @@ int main( int argc , char ** argv) {
       vector_append_ref( blank_nodes , blank_node );
     }
   }
-  
-  
-  
+
+
+
   {
     int num_dates = 10;
     int num_step = 10;
@@ -325,7 +325,7 @@ int main( int argc , char ** argv) {
           */
           ecl_sum_tstep_type * tstep = ecl_sum_add_tstep( ecl_sum , report_step + 1 , sim_days );
 
-          
+
           /*
             We can just set a value by it's index using the
             ecl_sum_tstep_iset() function. The index value should come

--- a/devel/libecl/applications/view_summary.c
+++ b/devel/libecl/applications/view_summary.c
@@ -144,10 +144,9 @@ int main(int argc , char ** argv) {
     bool           report_only     = false;
     bool           list_mode       = false;
     bool           include_restart = true;
-    ecl_sum_fmt_type fmt;
+    bool           print_header    = true;
     int            arg_offset      = 1;
 
-    ecl_sum_fmt_init_summary_x( &fmt );
 #ifdef HAVE_GETOPT
     if (argc == 1)
       print_help_and_exit();
@@ -180,7 +179,7 @@ int main(int argc , char ** argv) {
           list_mode = true;
           break;
         case 'x':
-          fmt.print_header = false;
+          print_header = false;
           break;
         case 'h':
           print_help_and_exit();
@@ -238,8 +237,15 @@ int main(int argc , char ** argv) {
           stringlist_free( keys );
         } else {
           /* Normal operation print results for the various keys on stdout. */
+          ecl_sum_fmt_type fmt;
           stringlist_type * key_list = stringlist_alloc_new( );
           build_key_list( ecl_sum , key_list , num_keys , arg_list);
+
+          if (print_header)
+            ecl_sum_fmt_init_summary_x(ecl_sum , &fmt );
+          else
+            fmt.print_header = false;
+
           ecl_sum_fprintf(ecl_sum , stdout , key_list , report_only , &fmt);
 
           stringlist_free( key_list );

--- a/devel/libecl/applications/view_summary.c
+++ b/devel/libecl/applications/view_summary.c
@@ -1,18 +1,18 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-   The file 'view_summary.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+   The file 'view_summary.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
@@ -34,7 +34,7 @@
 void install_SIGNALS(void) {
   signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
   signal(SIGINT  , util_abort_signal);    /* Control C */
-  signal(SIGTERM , util_abort_signal);    /* If killing the program with SIGTERM (the default kill signal) you will get a backtrace. 
+  signal(SIGTERM , util_abort_signal);    /* If killing the program with SIGTERM (the default kill signal) you will get a backtrace.
                                              Killing with SIGKILL (-9) will not give a backtrace.*/
 }
 
@@ -145,22 +145,22 @@ int main(int argc , char ** argv) {
     bool           list_mode       = false;
     bool           include_restart = true;
     ecl_sum_fmt_type fmt;
-    int            arg_offset      = 1;  
+    int            arg_offset      = 1;
 
     ecl_sum_fmt_init_summary_x( &fmt );
 #ifdef HAVE_GETOPT
     if (argc == 1)
       print_help_and_exit();
     else {
-      
+
       static struct option long_options[] = {
         {"no-restart"  , 0 , 0 , 'n'} ,
         {"list"        , 0 , 0 , 'l'} ,
         {"report-only" , 0 , 0 , 'r'} ,
-        {"no-header"   , 0 , 0 , 'x'} , 
+        {"no-header"   , 0 , 0 , 'x'} ,
         {"help"        , 0 , 0 , 'h'} ,
         { 0            , 0 , 0 ,   0} };
-      
+
       while (1) {
         int c;
         int option_index = 0;
@@ -193,38 +193,38 @@ int main(int argc , char ** argv) {
       arg_offset = optind;  /* External static variable in the getopt scope*/
     }
 #endif
-    
+
     if (arg_offset >= argc)
       print_help_and_exit();
 
     {
       char         * data_file = argv[arg_offset];
       ecl_sum_type * ecl_sum;
-      int            num_keys  = argc - arg_offset - 1;  
+      int            num_keys  = argc - arg_offset - 1;
       const char  ** arg_list  = (const char **) &argv[arg_offset + 1];
-      
-      
+
+
       ecl_sum = ecl_sum_fread_alloc_case__( data_file , ":" , include_restart);
       /** If no keys have been presented the function will list available keys. */
       if (num_keys == 0)
         list_mode = true;
-      
+
       if (ecl_sum != NULL) {
         if (list_mode) {
-          /* 
+          /*
              The program is called in list mode, we only print the
              (matching) keys in a table on stdout. If no arguments
              have been given on the commandline, all internalized keys
-             will be printed. 
+             will be printed.
           */
-             
+
           stringlist_type * keys = stringlist_alloc_new();
           if (num_keys == 0) {
             ecl_sum_select_matching_general_var_list( ecl_sum , "*" , keys);
             stringlist_sort(keys , NULL );
-          } else 
+          } else
             build_key_list( ecl_sum , keys , num_keys , arg_list);
-          
+
           {
             int columns = 5;
             int i;
@@ -245,7 +245,7 @@ int main(int argc , char ** argv) {
           stringlist_free( key_list );
         }
         ecl_sum_free(ecl_sum);
-      } else 
+      } else
         fprintf(stderr,"summary.x: No summary data found for case:%s\n", data_file );
     }
   }

--- a/devel/libecl/include/ert/ecl/ecl_smspec.h
+++ b/devel/libecl/include/ert/ecl/ecl_smspec.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'ecl_smspec.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'ecl_smspec.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef __ECL_SMSPEC__
@@ -31,7 +31,7 @@ extern "C" {
 
 #include <ert/ecl/smspec_node.h>
 
-typedef struct ecl_smspec_struct ecl_smspec_type; 
+typedef struct ecl_smspec_struct ecl_smspec_type;
 
 
 /**
@@ -45,7 +45,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
 */
   const int_vector_type * ecl_smspec_get_index_map( const ecl_smspec_type * smspec );
   void                ecl_smspec_index_node( ecl_smspec_type * ecl_smspec , smspec_node_type * smspec_node);
-  void                ecl_smspec_insert_node(ecl_smspec_type * ecl_smspec, smspec_node_type * smspec_node);  
+  void                ecl_smspec_insert_node(ecl_smspec_type * ecl_smspec, smspec_node_type * smspec_node);
   void                ecl_smspec_add_node( ecl_smspec_type * ecl_smspec , smspec_node_type * smspec_node );
   ecl_smspec_var_type ecl_smspec_iget_var_type( const ecl_smspec_type * smspec , int index );
   bool                ecl_smspec_needs_num( ecl_smspec_var_type var_type );
@@ -54,10 +54,10 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   ecl_smspec_var_type ecl_smspec_identify_var_type(const char * var);
   ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , time_t sim_start , int nx , int ny , int nz);
   void                ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case , bool fmt_file );
-  
+
   ecl_smspec_type *        ecl_smspec_fread_alloc(const char *header_file, const char * key_join_string , bool include_restart);
   void                     ecl_smspec_free( ecl_smspec_type *);
-  
+
   int                      ecl_smspec_get_sim_days_index( const ecl_smspec_type * smspec );
   int                      ecl_smspec_get_date_day_index( const ecl_smspec_type * smspec );
   int                      ecl_smspec_get_date_month_index( const ecl_smspec_type * smspec );
@@ -79,7 +79,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   const smspec_node_type * ecl_smspec_get_region_var_node(const ecl_smspec_type * ecl_smspec , const char *region_var , int region_nr);
   int                      ecl_smspec_get_region_var_params_index(const ecl_smspec_type * ecl_smspec , const char * region_var , int region_nr);
   bool                     ecl_smspec_has_region_var(const ecl_smspec_type * ecl_smspec , const char * region_var , int region_nr);
-  
+
   const smspec_node_type * ecl_smspec_get_misc_var_node(const ecl_smspec_type * ecl_smspec , const char *var);
   int                      ecl_smspec_get_misc_var_params_index(const ecl_smspec_type * ecl_smspec , const char *var);
   bool                     ecl_smspec_has_misc_var(const ecl_smspec_type * ecl_smspec , const char *var);
@@ -87,21 +87,21 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   const smspec_node_type * ecl_smspec_get_block_var_node(const ecl_smspec_type * ecl_smspec , const char * block_var , int block_nr);
   int                      ecl_smspec_get_block_var_params_index(const ecl_smspec_type * ecl_smspec , const char * block_var , int block_nr);
   bool                     ecl_smspec_has_block_var(const ecl_smspec_type * ecl_smspec , const char * block_var , int block_nr);
-      
+
   const smspec_node_type * ecl_smspec_get_block_var_node_ijk(const ecl_smspec_type * ecl_smspec , const char * block_var , int i , int j , int k);
   int                      ecl_smspec_get_block_var_params_index_ijk(const ecl_smspec_type * ecl_smspec , const char * block_var , int i , int j , int k);
   bool                     ecl_smspec_has_block_var_ijk(const ecl_smspec_type * ecl_smspec , const char * block_var , int i , int j , int k);
-  
+
   const smspec_node_type * ecl_smspec_get_well_completion_var_node(const ecl_smspec_type * ecl_smspec , const char * well , const char *var, int cell_nr);
   int                      ecl_smspec_get_well_completion_var_params_index(const ecl_smspec_type * ecl_smspec , const char * well , const char *var, int cell_nr);
   bool                     ecl_smspec_has_well_completion_var(const ecl_smspec_type * ecl_smspec , const char * well , const char *var, int cell_nr);
-  
+
   const smspec_node_type * ecl_smspec_get_general_var_node( const ecl_smspec_type * smspec , const char * lookup_kw );
   int                      ecl_smspec_get_general_var_params_index(const ecl_smspec_type * ecl_smspec , const char * lookup_kw);
   bool                     ecl_smspec_has_general_var(const ecl_smspec_type * ecl_smspec , const char * lookup_kw);
   const char             * ecl_smspec_get_general_var_unit( const ecl_smspec_type * ecl_smspec , const char * lookup_kw);
 
-  
+
   //bool                ecl_smspec_general_is_total(const ecl_smspec_type * ecl_smspec , const char * gen_key);
   //bool                ecl_smspec_is_rate(const ecl_smspec_type * smspec , int kw_index);
   //ecl_smspec_var_type ecl_smspec_iget_var_type( const ecl_smspec_type * smspec , int index );
@@ -109,11 +109,11 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   //int                 ecl_smspec_iget_num( const ecl_smspec_type * smspec , int index );
   //const char *        ecl_smspec_iget_wgname( const ecl_smspec_type * smspec , int index );
   //const char *        ecl_smspec_iget_keyword( const ecl_smspec_type * smspec , int index );
-  
 
 
 
-  void              ecl_smspec_init_var( ecl_smspec_type * ecl_smspec , smspec_node_type * smspec_node , const char * keyword , const char * wgname , int num, const char * unit );  
+
+  void              ecl_smspec_init_var( ecl_smspec_type * ecl_smspec , smspec_node_type * smspec_node , const char * keyword , const char * wgname , int num, const char * unit );
   void              ecl_smspec_select_matching_general_var_list( const ecl_smspec_type * smspec , const char * pattern , stringlist_type * keys);
   stringlist_type * ecl_smspec_alloc_matching_general_var_list(const ecl_smspec_type * smspec , const char * pattern);
 

--- a/devel/libecl/include/ert/ecl/ecl_smspec.h
+++ b/devel/libecl/include/ert/ecl/ecl_smspec.h
@@ -52,13 +52,12 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   bool                ecl_smspec_needs_wgname( ecl_smspec_var_type var_type );
   const char        * ecl_smspec_get_var_type_name( ecl_smspec_var_type var_type );
   ecl_smspec_var_type ecl_smspec_identify_var_type(const char * var);
-  ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , time_t sim_start , int nx , int ny , int nz);
+  ecl_smspec_type   * ecl_smspec_alloc_writer( const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   void                ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case , bool fmt_file );
 
   ecl_smspec_type *        ecl_smspec_fread_alloc(const char *header_file, const char * key_join_string , bool include_restart);
   void                     ecl_smspec_free( ecl_smspec_type *);
 
-  int                      ecl_smspec_get_sim_days_index( const ecl_smspec_type * smspec );
   int                      ecl_smspec_get_date_day_index( const ecl_smspec_type * smspec );
   int                      ecl_smspec_get_date_month_index( const ecl_smspec_type * smspec );
   int                      ecl_smspec_get_date_year_index( const ecl_smspec_type * smspec );
@@ -117,6 +116,7 @@ typedef struct ecl_smspec_struct ecl_smspec_type;
   void              ecl_smspec_select_matching_general_var_list( const ecl_smspec_type * smspec , const char * pattern , stringlist_type * keys);
   stringlist_type * ecl_smspec_alloc_matching_general_var_list(const ecl_smspec_type * smspec , const char * pattern);
 
+  int               ecl_smspec_get_time_seconds( const ecl_smspec_type * ecl_smspec );
   int               ecl_smspec_get_time_index( const ecl_smspec_type * ecl_smspec );
   time_t            ecl_smspec_get_start_time(const ecl_smspec_type * );
   /*****************************************************************/

--- a/devel/libecl/include/ert/ecl/ecl_sum.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum.h
@@ -53,11 +53,12 @@ extern "C" {
   } ecl_sum_fmt_type;
 
   void ecl_sum_fmt_init_csv( ecl_sum_fmt_type * fmt );
-  void ecl_sum_fmt_init_summary_x( ecl_sum_fmt_type * fmt );
+
   /*****************************************************************/
 
 typedef struct ecl_sum_struct       ecl_sum_type;
 
+  void           ecl_sum_fmt_init_summary_x( const ecl_sum_type * ecl_sum , ecl_sum_fmt_type * fmt );
   double         ecl_sum_get_from_sim_time( const ecl_sum_type * ecl_sum , time_t sim_time , const smspec_node_type * node);
   double         ecl_sum_get_from_sim_days( const ecl_sum_type * ecl_sum , double sim_days , const smspec_node_type * node);
   double         ecl_sum_time2days( const ecl_sum_type * ecl_sum , time_t sim_time);

--- a/devel/libecl/include/ert/ecl/ecl_sum.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum.h
@@ -190,14 +190,14 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   int                   ecl_sum_iget_report_end( const ecl_sum_type * ecl_sum , int report_step );
   int                   ecl_sum_iget_report_start( const ecl_sum_type * ecl_sum , int report_step );
 
-  ecl_sum_type        * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , int nx , int ny , int nz);
+  ecl_sum_type        * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz);
   void                  ecl_sum_set_case( ecl_sum_type * ecl_sum , const char * ecl_case);
   void                  ecl_sum_fwrite( const ecl_sum_type * ecl_sum );
   void                  ecl_sum_fwrite_smspec( const ecl_sum_type * ecl_sum );
   smspec_node_type    * ecl_sum_add_var( ecl_sum_type * ecl_sum , const char * keyword , const char * wgname , int num , const char * unit , float default_value);
   smspec_node_type    * ecl_sum_add_blank_var( ecl_sum_type * ecl_sum , float default_value);
   void                  ecl_sum_init_var( ecl_sum_type * ecl_sum , smspec_node_type * smspec_node , const char * keyword , const char * wgname , int num , const char * unit);
-  ecl_sum_tstep_type  * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step , double sim_days);
+  ecl_sum_tstep_type  * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step , double sim_seconds);
   void                  ecl_sum_update_wgname( ecl_sum_type * ecl_sum , smspec_node_type * node , const char * wgname );
 
   bool                  ecl_sum_is_oil_producer( const ecl_sum_type * ecl_sum , const char * well);

--- a/devel/libecl/include/ert/ecl/ecl_sum.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'ecl_sum.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'ecl_sum.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef __ECL_SUM_H__
@@ -51,7 +51,7 @@ extern "C" {
     char * date_dash;
     char * value_dash;
   } ecl_sum_fmt_type;
-    
+
   void ecl_sum_fmt_init_csv( ecl_sum_fmt_type * fmt );
   void ecl_sum_fmt_init_summary_x( ecl_sum_fmt_type * fmt );
   /*****************************************************************/
@@ -61,7 +61,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   double         ecl_sum_get_from_sim_time( const ecl_sum_type * ecl_sum , time_t sim_time , const smspec_node_type * node);
   double         ecl_sum_get_from_sim_days( const ecl_sum_type * ecl_sum , double sim_days , const smspec_node_type * node);
   double         ecl_sum_time2days( const ecl_sum_type * ecl_sum , time_t sim_time);
-  
+
   void           ecl_sum_set_unified( ecl_sum_type * ecl_sum , bool unified );
   void           ecl_sum_set_fmt_case( ecl_sum_type * ecl_sum , bool fmt_case );
 
@@ -93,39 +93,39 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   ecl_sum_type   * ecl_sum_fread_alloc_case(const char *  , const char * key_join_string);
   ecl_sum_type   * ecl_sum_fread_alloc_case__(const char *  , const char * key_join_string , bool include_restart);
   bool             ecl_sum_case_exists( const char * input_file );
-  
+
   /* Accessor functions : */
   double            ecl_sum_get_well_var(const ecl_sum_type * ecl_sum , int time_index , const char * well , const char *var);
   bool              ecl_sum_has_well_var(const ecl_sum_type * ecl_sum , const char * well , const char *var);
   double            ecl_sum_get_well_var_from_sim_days( const ecl_sum_type * ecl_sum , double sim_days , const char * well , const char * var);
   double            ecl_sum_get_well_var_from_sim_time( const ecl_sum_type * ecl_sum , time_t sim_time , const char * well , const char * var);
-  
+
   double            ecl_sum_get_group_var(const ecl_sum_type * ecl_sum , int time_index , const char * group , const char *var);
   bool              ecl_sum_has_group_var(const ecl_sum_type * ecl_sum , const char * group , const char *var);
-  
+
   double            ecl_sum_get_field_var(const ecl_sum_type * ecl_sum , int time_index , const char *var);
   bool              ecl_sum_has_field_var(const ecl_sum_type * ecl_sum , const char *var);
   double            ecl_sum_get_field_var_from_sim_days( const ecl_sum_type * ecl_sum , double sim_days , const char * var);
   double            ecl_sum_get_field_var_from_sim_time( const ecl_sum_type * ecl_sum , time_t sim_time , const char * var);
-  
+
   double            ecl_sum_get_block_var(const ecl_sum_type * ecl_sum , int time_index , const char * block_var , int block_nr);
   int               ecl_sum_get_block_var_index(const ecl_sum_type * ecl_sum , const char * block_var , int block_nr);
   bool              ecl_sum_has_block_var(const ecl_sum_type * ecl_sum , const char * block_var , int block_nr);
   double            ecl_sum_get_block_var_ijk(const ecl_sum_type * ecl_sum , int time_index , const char * block_var , int i , int j , int k);
   int               ecl_sum_get_block_var_index_ijk(const ecl_sum_type * ecl_sum , const char * block_var , int i , int j , int k);
   bool              ecl_sum_has_block_var_ijk(const ecl_sum_type * ecl_sum , const char * block_var , int i , int j , int k);
-  
+
   double            ecl_sum_get_region_var(const ecl_sum_type * ecl_sum , int time_index , const char *var , int region_nr);
   bool              ecl_sum_has_region_var(const ecl_sum_type * ecl_sum ,  const char *var , int region_nr);
-  
+
   double            ecl_sum_get_misc_var(const ecl_sum_type * ecl_sum , int time_index , const char *var);
   int               ecl_sum_get_misc_var_index(const ecl_sum_type * ecl_sum , const char *var);
   bool              ecl_sum_has_misc_var(const ecl_sum_type * ecl_sum , const char *var);
-  
+
   double            ecl_sum_get_well_completion_var(const ecl_sum_type * ecl_sum , int time_index  , const char * well , const char *var, int cell_nr);
   int               ecl_sum_get_well_completion_var_index(const ecl_sum_type * ecl_sum , const char * well , const char *var, int cell_nr);
   bool              ecl_sum_has_well_completion_var(const ecl_sum_type * ecl_sum , const char * well , const char *var, int cell_nr);
-  
+
   double            ecl_sum_get_general_var(const ecl_sum_type * ecl_sum , int time_index , const char * lookup_kw);
   int               ecl_sum_get_general_var_params_index(const ecl_sum_type * ecl_sum , const char * lookup_kw);
   const smspec_node_type * ecl_sum_get_general_var_node(const ecl_sum_type * ecl_sum , const char * lookup_kw);
@@ -139,9 +139,9 @@ typedef struct ecl_sum_struct       ecl_sum_type;
 
 
 
-  
+
   /* Time related functions */
-  int    ecl_sum_get_first_gt( const ecl_sum_type * ecl_sum , int param_index , double limit); 
+  int    ecl_sum_get_first_gt( const ecl_sum_type * ecl_sum , int param_index , double limit);
   int    ecl_sum_get_first_lt( const ecl_sum_type * ecl_sum , int param_index , double limit);
   int    ecl_sum_get_last_report_step( const ecl_sum_type * ecl_sum );
   int    ecl_sum_get_first_report_step( const ecl_sum_type * ecl_sum );
@@ -152,8 +152,8 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   int    ecl_sum_iget_report_step( const ecl_sum_type * ecl_sum , int internal_index );
   int    ecl_sum_iget_mini_step( const ecl_sum_type * ecl_sum , int internal_index );
   double ecl_sum_iget_general_var(const ecl_sum_type * ecl_sum , int internal_index , const char * lookup_kw);
-  
-  
+
+
   void                 ecl_sum_init_data_vector( const ecl_sum_type * ecl_sum , double_vector_type * data_vector , int data_index , bool report_only );
   double_vector_type * ecl_sum_alloc_data_vector( const ecl_sum_type * ecl_sum  , int data_index , bool report_only);
   time_t_vector_type * ecl_sum_alloc_time_vector( const ecl_sum_type * ecl_sum  , bool report_only);
@@ -167,7 +167,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   const char * ecl_sum_get_abs_path(const ecl_sum_type * ecl_sum );
   const char * ecl_sum_get_case(const ecl_sum_type * );
   bool         ecl_sum_same_case( const ecl_sum_type * ecl_sum , const char * input_file );
-  
+
   void ecl_sum_resample_from_sim_days( const ecl_sum_type * ecl_sum , const double_vector_type * sim_days , double_vector_type * value , const char * gen_key);
   void ecl_sum_resample_from_sim_time( const ecl_sum_type * ecl_sum , const time_t_vector_type * sim_time , double_vector_type * value , const char * gen_key);
   time_t ecl_sum_time_from_days( const ecl_sum_type * ecl_sum , double sim_days );
@@ -179,14 +179,14 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   stringlist_type     * ecl_sum_alloc_well_list( const ecl_sum_type * ecl_sum , const char * pattern);
   stringlist_type     * ecl_sum_alloc_group_list( const ecl_sum_type * ecl_sum , const char * pattern);
   stringlist_type     * ecl_sum_alloc_well_var_list( const ecl_sum_type * ecl_sum );
-  stringlist_type     * ecl_sum_alloc_matching_general_var_list(const ecl_sum_type * ecl_sum , const char * pattern);  
+  stringlist_type     * ecl_sum_alloc_matching_general_var_list(const ecl_sum_type * ecl_sum , const char * pattern);
   void                  ecl_sum_select_matching_general_var_list( const ecl_sum_type * ecl_sum , const char * pattern , stringlist_type * keys);
   const ecl_smspec_type * ecl_sum_get_smspec( const ecl_sum_type * ecl_sum );
   ecl_smspec_var_type   ecl_sum_identify_var_type(const char * var);
   ecl_smspec_var_type   ecl_sum_get_var_type( const ecl_sum_type * ecl_sum , const char * gen_key);
   bool                  ecl_sum_var_is_rate( const ecl_sum_type * ecl_sum , const char * gen_key);
   bool                  ecl_sum_var_is_total( const ecl_sum_type * ecl_sum , const char * gen_key);
-  
+
   int                   ecl_sum_iget_report_end( const ecl_sum_type * ecl_sum , int report_step );
   int                   ecl_sum_iget_report_start( const ecl_sum_type * ecl_sum , int report_step );
 

--- a/devel/libecl/include/ert/ecl/ecl_sum_data.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_data.h
@@ -83,7 +83,7 @@ typedef struct ecl_sum_data_struct ecl_sum_data_type ;
   int                      ecl_sum_data_iget_mini_step(const ecl_sum_data_type * data , int internal_index);
   int                      ecl_sum_data_iget_report_end( const ecl_sum_data_type * data , int report_step );
   int                      ecl_sum_data_iget_report_start( const ecl_sum_data_type * data , int report_step );
-  ecl_sum_tstep_type     * ecl_sum_data_add_new_tstep( ecl_sum_data_type * data , int report_step , double sim_days);
+  ecl_sum_tstep_type     * ecl_sum_data_add_new_tstep( ecl_sum_data_type * data , int report_step , double sim_seconds);
   bool                     ecl_sum_data_report_step_equal( const ecl_sum_data_type * data1 , const ecl_sum_data_type * data2);
   bool                     ecl_sum_data_report_step_compatible( const ecl_sum_data_type * data1 , const ecl_sum_data_type * data2);
   void                     ecl_sum_data_write_csv_file(const ecl_sum_data_type * data , time_t sim_time, const ecl_sum_vector_type * keylist, FILE *fp);

--- a/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
@@ -1,19 +1,19 @@
  /*
-   Copyright (C) 2012  Statoil ASA, Norway. 
-    
-   The file 'ecl_sum_tstep.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'ecl_sum_tstep.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef __ECL_SUM_TSTEP_H__
@@ -35,12 +35,12 @@ typedef struct ecl_sum_tstep_struct ecl_sum_tstep_type;
   void ecl_sum_tstep_free__( void * __ministep);
   ecl_sum_tstep_type * ecl_sum_tstep_alloc_from_file(int report_step    ,
                                                      int ministep_nr            ,
-                                                     const ecl_kw_type * params_kw , 
-                                                     const char * src_file , 
+                                                     const ecl_kw_type * params_kw ,
+                                                     const char * src_file ,
                                                      const ecl_smspec_type * smspec);
-  
+
   ecl_sum_tstep_type * ecl_sum_tstep_alloc_new( int report_step , int ministep , float sim_days , const ecl_smspec_type * smspec );
-  
+
   double ecl_sum_tstep_iget(const ecl_sum_tstep_type * ministep , int index);
   time_t ecl_sum_tstep_get_sim_time(const ecl_sum_tstep_type * ministep);
   double ecl_sum_tstep_get_sim_days(const ecl_sum_tstep_type * ministep);

--- a/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
@@ -39,11 +39,13 @@ typedef struct ecl_sum_tstep_struct ecl_sum_tstep_type;
                                                      const char * src_file ,
                                                      const ecl_smspec_type * smspec);
 
-  ecl_sum_tstep_type * ecl_sum_tstep_alloc_new( int report_step , int ministep , float sim_days , const ecl_smspec_type * smspec );
+  ecl_sum_tstep_type * ecl_sum_tstep_alloc_new( int report_step , int ministep , float sim_seconds , const ecl_smspec_type * smspec );
 
   double ecl_sum_tstep_iget(const ecl_sum_tstep_type * ministep , int index);
   time_t ecl_sum_tstep_get_sim_time(const ecl_sum_tstep_type * ministep);
   double ecl_sum_tstep_get_sim_days(const ecl_sum_tstep_type * ministep);
+  double ecl_sum_tstep_get_sim_seconds(const ecl_sum_tstep_type * ministep);
+
   int  ecl_sum_tstep_get_report(const ecl_sum_tstep_type * ministep);
   int  ecl_sum_tstep_get_ministep(const ecl_sum_tstep_type * ministep);
 

--- a/devel/libecl/src/ecl_smspec.c
+++ b/devel/libecl/src/ecl_smspec.c
@@ -120,6 +120,7 @@ struct ecl_smspec_struct {
 
   /*-----------------------------------------------------------------*/
 
+  int               time_seconds;
   int               grid_dims[3];                 /* Grid dimensions - in DIMENS[1,2,3] */
   int               num_regions;
   int               Nwells , param_offset;
@@ -258,11 +259,12 @@ static ecl_smspec_type * ecl_smspec_alloc_empty(bool write_mode , const char * k
 
   ecl_smspec->smspec_nodes                   = vector_alloc_new();
 
-  ecl_smspec->time_index  = -1;
-  ecl_smspec->day_index   = -1;
-  ecl_smspec->year_index  = -1;
-  ecl_smspec->month_index = -1;
-  ecl_smspec->locked      = false;
+  ecl_smspec->time_index   = -1;
+  ecl_smspec->day_index    = -1;
+  ecl_smspec->year_index   = -1;
+  ecl_smspec->month_index  = -1;
+  ecl_smspec->locked       = false;
+  ecl_smspec->time_seconds = -1;
 
   ecl_smspec->index_map = int_vector_alloc(0,0);
   ecl_smspec->restart_list = stringlist_alloc_new();
@@ -432,7 +434,7 @@ void ecl_smspec_fwrite( const ecl_smspec_type * smspec , const char * ecl_case ,
   free( filename );
 }
 
-ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , time_t sim_start , int nx , int ny , int nz) {
+ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
   ecl_smspec_type * ecl_smspec = ecl_smspec_alloc_empty( true , key_join_string );
 
   ecl_smspec->grid_dims[0] = nx;
@@ -441,15 +443,31 @@ ecl_smspec_type * ecl_smspec_alloc_writer( const char * key_join_string , time_t
   ecl_smspec->sim_start_time = sim_start;
 
   {
-    smspec_node_type * time_node = smspec_node_alloc( ECL_SMSPEC_MISC_VAR ,
-                                                      NULL ,
-                                                      "TIME" ,
-                                                      "DAYS" , // There are significant hardcoded assumptions of days around; would have been cool to be able to set seconds.
-                                                      key_join_string ,
-                                                      ecl_smspec->grid_dims ,
-                                                      0  ,
-                                                      -1 ,
-                                                      0 );
+    smspec_node_type * time_node;
+    if (time_in_days) {
+      time_node = smspec_node_alloc( ECL_SMSPEC_MISC_VAR ,
+                                     NULL ,
+                                     "TIME" ,
+                                     "DAYS" ,
+                                     key_join_string ,
+                                     ecl_smspec->grid_dims ,
+                                     0  ,
+                                     -1 ,
+                                     0 );
+      ecl_smspec->time_seconds = 3600 * 24;
+    } else {
+      time_node = smspec_node_alloc( ECL_SMSPEC_MISC_VAR ,
+                                     NULL ,
+                                     "TIME" ,
+                                     "HOURS" ,
+                                     key_join_string ,
+                                     ecl_smspec->grid_dims ,
+                                     0  ,
+                                     -1 ,
+                                     0 );
+      ecl_smspec->time_seconds = 3600;
+    }
+
     ecl_smspec_add_node( ecl_smspec , time_node );
     ecl_smspec->time_index = smspec_node_get_params_index( time_node );
   }
@@ -1166,8 +1184,18 @@ ecl_smspec_type * ecl_smspec_fread_alloc(const char *header_file, const char * k
 
   if (ecl_smspec_fread_header(ecl_smspec , header_file , include_restart)) {
 
-    if (hash_has_key( ecl_smspec->misc_var_index , "TIME"))
-      ecl_smspec->time_index = smspec_node_get_params_index( hash_get(ecl_smspec->misc_var_index , "TIME") );
+    if (hash_has_key( ecl_smspec->misc_var_index , "TIME")) {
+      const smspec_node_type * time_node = hash_get(ecl_smspec->misc_var_index , "TIME");
+      const char * time_unit = smspec_node_get_unit( time_node );
+      ecl_smspec->time_index = smspec_node_get_params_index( time_node );
+
+      if (util_string_equal( time_unit , "DAYS"))
+        ecl_smspec->time_seconds = 3600 * 24;
+      else if (util_string_equal( time_unit , "HOURS"))
+        ecl_smspec->time_seconds = 3600;
+      else
+        util_abort("%s: time_unit:%s not recognized \n",__func__ , time_unit);
+    }
 
     if (hash_has_key(ecl_smspec->misc_var_index , "DAY")) {
       ecl_smspec->day_index   = smspec_node_get_params_index( hash_get(ecl_smspec->misc_var_index , "DAY") );
@@ -1549,6 +1577,10 @@ const char * ecl_smspec_get_general_var_unit( const ecl_smspec_type * ecl_smspec
 
 /*****************************************************************/
 
+int ecl_smspec_get_time_seconds( const ecl_smspec_type * ecl_smspec ) {
+  return ecl_smspec->time_seconds;
+}
+
 int ecl_smspec_get_time_index( const ecl_smspec_type * ecl_smspec ) {
   return ecl_smspec->time_index;
 }
@@ -1601,9 +1633,6 @@ void ecl_smspec_free__(void * __ecl_smspec) {
   ecl_smspec_free( ecl_smspec );
 }
 
-int ecl_smspec_get_sim_days_index( const ecl_smspec_type * smspec ) {
-  return smspec->time_index;
-}
 
 int ecl_smspec_get_date_day_index( const ecl_smspec_type * smspec ) {
   return smspec->day_index;

--- a/devel/libecl/src/ecl_sum.c
+++ b/devel/libecl/src/ecl_sum.c
@@ -884,12 +884,17 @@ void ecl_sum_fmt_init_csv( ecl_sum_fmt_type * fmt ) {
 
 
 
-void ecl_sum_fmt_init_summary_x( ecl_sum_fmt_type * fmt ) {
+void ecl_sum_fmt_init_summary_x( const ecl_sum_type * ecl_sum , ecl_sum_fmt_type * fmt ) {
   fmt->locale     = NULL;
   fmt->sep        = "";
   fmt->date_fmt   = "%d/%m/%Y   ";
   fmt->value_fmt  = " %15.6g ";
-  fmt->days_fmt   = "%7.2f   ";
+
+  if (util_string_equal( ecl_sum_get_unit( ecl_sum , "TIME") , "DAYS"))
+    fmt->days_fmt   = "%7.2f   ";
+  else
+    fmt->days_fmt   = "%7.4f   ";
+
   fmt->header_fmt = " %15s ";
 
   fmt->newline = "\n";

--- a/devel/libecl/src/ecl_sum.c
+++ b/devel/libecl/src/ecl_sum.c
@@ -284,17 +284,17 @@ smspec_node_type * ecl_sum_add_blank_var( ecl_sum_type * ecl_sum , float default
 
 
 
-ecl_sum_tstep_type * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step , double sim_days) {
-  return ecl_sum_data_add_new_tstep( ecl_sum->data , report_step , sim_days );
+ecl_sum_tstep_type * ecl_sum_add_tstep( ecl_sum_type * ecl_sum , int report_step , double sim_seconds) {
+  return ecl_sum_data_add_new_tstep( ecl_sum->data , report_step , sim_seconds );
 }
 
 
-ecl_sum_type * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , int nx , int ny , int nz) {
+ecl_sum_type * ecl_sum_alloc_writer( const char * ecl_case , bool fmt_output , bool unified , const char * key_join_string , time_t sim_start , bool time_in_days , int nx , int ny , int nz) {
   ecl_sum_type * ecl_sum = ecl_sum_alloc__( ecl_case , key_join_string );
   ecl_sum_set_unified( ecl_sum , unified );
   ecl_sum_set_fmt_case( ecl_sum , fmt_output );
 
-  ecl_sum->smspec = ecl_smspec_alloc_writer( key_join_string , sim_start , nx , ny , nz );
+  ecl_sum->smspec = ecl_smspec_alloc_writer( key_join_string , sim_start , time_in_days , nx , ny , nz );
   ecl_sum->data   = ecl_sum_data_alloc_writer( ecl_sum->smspec );
 
   return ecl_sum;

--- a/devel/libecl/src/ecl_sum_data.c
+++ b/devel/libecl/src/ecl_sum_data.c
@@ -798,9 +798,9 @@ static void ecl_sum_data_build_index( ecl_sum_data_type * sum_data ) {
   ecl_sum_tstep_iset() to set elements in the tstep.
 */
 
-ecl_sum_tstep_type * ecl_sum_data_add_new_tstep( ecl_sum_data_type * data , int report_step , double sim_days) {
+ecl_sum_tstep_type * ecl_sum_data_add_new_tstep( ecl_sum_data_type * data , int report_step , double sim_seconds) {
   int ministep_nr = vector_get_size( data->data );
-  ecl_sum_tstep_type * tstep = ecl_sum_tstep_alloc_new( report_step , ministep_nr , sim_days , data->smspec );
+  ecl_sum_tstep_type * tstep = ecl_sum_tstep_alloc_new( report_step , ministep_nr , sim_seconds , data->smspec );
   ecl_sum_tstep_type * prev_tstep = NULL;
 
   if (vector_get_size( data->data ) > 0)

--- a/devel/libecl/src/ecl_sum_tstep.c
+++ b/devel/libecl/src/ecl_sum_tstep.c
@@ -1,19 +1,19 @@
  /*
-   Copyright (C) 2012  Statoil ASA, Norway. 
-    
-   The file 'ecl_sum_tstep.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'ecl_sum_tstep.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <time.h>
@@ -35,19 +35,19 @@
   summary information for all summary vectors at one instant in
   time. If we view the summary data as this:
 
-  
-Header direction: ecl_smspec   DAYS     WWCT:OP_3     FOPT     BPR:15,10,25     
+
+Header direction: ecl_smspec   DAYS     WWCT:OP_3     FOPT     BPR:15,10,25
                                --------------------------------------------
   /|\                           0.00    0.00          0.00           256.00   <-- One timestep ecl_sum_tstep
    |                           10.00    0.56         10.00           255.00
  Time direction: ecl_sum_data  20.00    0.61         18.70           253.00
    |                           30.00    0.63         21.20           251.00
    |                           ...
-  \|/                          90.00    0.80         39.70           244.00  
+  \|/                          90.00    0.80         39.70           244.00
                                --------------------------------------------
 
   The ecl_sum_tstep structure corresponds to one 'horizontal line' in
-  the summary data. 
+  the summary data.
 
   These timesteps correspond exactly to the simulators timesteps,
   i.e. when convergence is poor they are closely spaced. In the
@@ -59,13 +59,13 @@ Header direction: ecl_smspec   DAYS     WWCT:OP_3     FOPT     BPR:15,10,25
 struct ecl_sum_tstep_struct {
   UTIL_TYPE_ID_DECLARATION;
   float                  * data;            /* A memcpy copy of the PARAMS vector in ecl_kw instance - the raw data. */
-  time_t                   sim_time;        /* The true time (i.e. 20.th of october 2010) of corresponding to this timestep. */ 
+  time_t                   sim_time;        /* The true time (i.e. 20.th of october 2010) of corresponding to this timestep. */
   int                      ministep;        /* The ECLIPSE internal time-step number; one ministep per numerical timestep. */
   int                      report_step;     /* The report step this time-step is part of - in general there can be many timestep for each report step. */
   double                   sim_days;        /* Accumulated simulation time up to this ministep. */
   int                      data_size;       /* Number of elements in data - only used for checking indices. */
   int                      internal_index;  /* Used for lookups of the next / previous ministep based on an existing ministep. */
-  const ecl_smspec_type  * smspec;          /* The smespec header information for this tstep - must be compatible. */         
+  const ecl_smspec_type  * smspec;          /* The smespec header information for this tstep - must be compatible. */
 };
 
 
@@ -76,7 +76,7 @@ static ecl_sum_tstep_type * ecl_sum_tstep_alloc( int report_step , int ministep_
   tstep->report_step = report_step;
   tstep->ministep    = ministep_nr;
   tstep->data_size   = ecl_smspec_get_params_size( smspec );
-  tstep->data        = util_calloc( tstep->data_size , sizeof * tstep->data ); 
+  tstep->data        = util_calloc( tstep->data_size , sizeof * tstep->data );
   return tstep;
 }
 
@@ -106,13 +106,13 @@ void ecl_sum_tstep_free__( void * __ministep) {
    element like e.g. the FOPT or GGPR:NAME - on the other hand the
    time information is strictly required and the summary file will
    fall to pieces if it is missing.
-   
+
    The time can be provided in using (at least) two different
    keywords:
 
       DAYS: The data vector will contain the number of days since the
             simulation start.
-            
+
       DAY,MONTH,YEAR: The data vector will contain the true date of
            the tstep.
 
@@ -147,11 +147,11 @@ static void ecl_sum_tstep_set_time_info( ecl_sum_tstep_type * tstep , const ecl_
     int sec  = 0;
     int min  = 0;
     int hour = 0;
-    
+
     int day   = util_roundf(tstep->data[date_day_index]);
     int month = util_roundf(tstep->data[date_month_index]);
     int year  = util_roundf(tstep->data[date_year_index]);
-    
+
     time_t sim_time = util_make_datetime(sec , min , hour , day , month , year);
     ecl_sum_tstep_set_time_info_from_date( tstep , sim_start , sim_time );
   } else
@@ -169,19 +169,19 @@ static void ecl_sum_tstep_set_time_info( ecl_sum_tstep_type * tstep , const ecl_
 
 ecl_sum_tstep_type * ecl_sum_tstep_alloc_from_file( int report_step    ,
                                                     int ministep_nr    ,
-                                                    const ecl_kw_type * params_kw , 
-                                                    const char * src_file , 
+                                                    const ecl_kw_type * params_kw ,
+                                                    const char * src_file ,
                                                     const ecl_smspec_type * smspec) {
 
   int data_size = ecl_kw_get_size( params_kw );
-  
+
   if (data_size == ecl_smspec_get_params_size( smspec )) {
     ecl_sum_tstep_type * ministep = ecl_sum_tstep_alloc( report_step , ministep_nr , smspec);
     ecl_kw_get_memcpy_data( params_kw , ministep->data );
     ecl_sum_tstep_set_time_info( ministep , smspec );
     return ministep;
   } else {
-    /* 
+    /*
        This is actually a fatal error / bug; the difference in smspec
        header structure should have been detected already in the
        ecl_smspec_load_restart() function and the restart case

--- a/devel/libert_util/include/ert/util/util.h
+++ b/devel/libert_util/include/ert/util/util.h
@@ -110,6 +110,7 @@ typedef enum {left_pad   = 0,
   time_t       util_make_date(int , int , int);
   time_t       util_make_pure_date(time_t t);
   void         util_inplace_forward_days(time_t *  , double);
+  void         util_inplace_forward_seconds(time_t * t , double seconds);
   time_t       util_file_mtime(const char * file);
   double       util_difftime(time_t  , time_t  , int *  , int *  , int *  , int *);
   double       util_difftime_days(time_t  , time_t );

--- a/devel/libert_util/src/util.c
+++ b/devel/libert_util/src/util.c
@@ -3142,6 +3142,16 @@ char * util_alloc_date_stamp( ) {
 }
 
 
+void util_inplace_forward_seconds(time_t * t , double seconds) {
+  struct tm ts;
+  int isdst;
+
+  util_localtime(t , &ts);
+  isdst = ts.tm_isdst;
+  (*t) += ( time_t ) (seconds);
+  util_localtime(t , &ts);
+  (*t) += 3600 * (isdst - ts.tm_isdst);  /* Extra adjustment of +/- one hour if we have crossed exactly one daylight savings border. */
+}
 /*
    This function takes a pointer to a time_t instance, and shifts the
    value days forward. Observe the calls to localtime_r() which give
@@ -3154,14 +3164,7 @@ char * util_alloc_date_stamp( ) {
 */
 
 void util_inplace_forward_days(time_t * t , double days) {
-  struct tm ts;
-  int isdst;
-
-  util_localtime(t , &ts);
-  isdst = ts.tm_isdst;
-  (*t) += ( time_t ) (days * 3600 * 24);
-  util_localtime(t , &ts);
-  (*t) += 3600 * (isdst - ts.tm_isdst);  /* Extra adjustment of +/- one hour if we have crossed exactly one daylight savings border. */
+  util_inplace_forward_seconds( t , days * 3600 * 24 );
 }
 
 

--- a/devel/python/python/ert/ecl/ecl_sum.py
+++ b/devel/python/python/ert/ecl/ecl_sum.py
@@ -107,11 +107,11 @@ class EclSum(BaseCClass):
 
 
     @staticmethod
-    def writer(case , start_time , nx,ny,nz , fmt_output = False , unified = True , key_join_string = ":"):
+    def writer(case , start_time , nx,ny,nz , fmt_output = False , unified = True , time_in_days = True , key_join_string = ":"):
         """
         The writer is not generally usable.
         """
-        return EclSum.cNamespace().create_writer( case , fmt_output , unified , key_join_string , CTime(start_time) , nx , ny , nz)
+        return EclSum.cNamespace().create_writer( case , fmt_output , unified , key_join_string , CTime(start_time) , time_in_days , nx , ny , nz)
 
 
     def addVariable(self , variable , wgname = None , num = 0 , unit = "None" , default_value = 0):
@@ -793,13 +793,7 @@ ime_index.
 
     @property 
     def sim_length( self ):
-        """
-        The length of the current dataset in simulation days.
-
-        Will include the length of a leading restart section,
-        irrespective of whether we have data for this or not.
-        """
-        return EclSum.cNamespace().sim_length( self )
+        return self.getSimulationLength( )
 
     @property
     def start_date(self):
@@ -838,7 +832,7 @@ ime_index.
         """
         The time of the last (loaded) time step.
         """
-        return CTime(EclSum.cNamespace().get_end_date( self )).datetime()
+        return self.getEndTime()
 
     
     @property
@@ -854,6 +848,22 @@ ime_index.
         """
         return CTime( EclSum.cNamespace().get_start_date( self ) ).datetime()
 
+
+    def getEndTime(self):
+        """
+        A Python datetime instance with the last loaded time.
+        """
+        return CTime(EclSum.cNamespace().get_end_date( self )).datetime()
+
+    def getSimulationLength(self):
+        """
+        The length of the current dataset in simulation days.
+
+        Will include the length of a leading restart section,
+        irrespective of whether we have data for this or not.
+        """
+        return EclSum.cNamespace().sim_length( self )
+        
 
 
     @property
@@ -1020,7 +1030,7 @@ EclSum.cNamespace().get_var_node                  = cwrapper.prototype("smspec_n
 EclSum.cNamespace().create_well_list              = cwrapper.prototype("stringlist_obj ecl_sum_alloc_well_list( ecl_sum , char* )")
 EclSum.cNamespace().create_group_list             = cwrapper.prototype("stringlist_obj ecl_sum_alloc_group_list( ecl_sum , char* )")
 
-EclSum.cNamespace().create_writer                 = cwrapper.prototype("ecl_sum_obj  ecl_sum_alloc_writer( char* , bool , bool , char* , time_t , int , int , int)")
+EclSum.cNamespace().create_writer                 = cwrapper.prototype("ecl_sum_obj  ecl_sum_alloc_writer( char* , bool , bool , char* , time_t , bool , int , int , int)")
 EclSum.cNamespace().add_variable                  = cwrapper.prototype("void         ecl_sum_add_var(ecl_sum , char* , char* , int , char*, double)")
 EclSum.cNamespace().add_tstep                     = cwrapper.prototype("c_void_p     ecl_sum_add_tstep(ecl_sum , int , double)")
 

--- a/devel/python/python/ert/util/bool_vector.py
+++ b/devel/python/python/ert/util/bool_vector.py
@@ -17,6 +17,7 @@
 
 from ert.cwrap import CWrapper
 from ert.util import UTIL_LIB, VectorTemplate
+import warnings
 
 
 class BoolVector(VectorTemplate):
@@ -45,6 +46,25 @@ class BoolVector(VectorTemplate):
         The empty list will evaluate to false
         @rtype: BoolVector
         """
+        return cls.cNamespace().create_active_mask(range_string)
+
+    @classmethod
+    def active_mask(cls, range_string):
+        """
+        Will create a BoolVector instance with the values from @range_string.
+
+        The range_string input should be of the type "1,3-5,9,17",
+        i.e. integer values separated by commas, and dashes to
+        represent ranges. If the input string contains ANY invalid
+        characters the returned active list will be empty:
+
+           "1,4-7,10"  =>  {F,T,F,F,T,T,T,T,F,F,T}
+           "1,4-7,10X" =>  {}
+
+        The empty list will evaluate to false
+        @rtype: BoolVector
+        """
+        warnings.warn("The active_mask(cls, rangs_string) method has been renamed: createActiveMask(cls, rangs_string)" , DeprecationWarning)
         return cls.cNamespace().create_active_mask(range_string)
 
     @classmethod

--- a/devel/python/test/CMakeLists.txt
+++ b/devel/python/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TEST_SOURCES
     ert_tests/ecl/test_indexed_read.py
 
     ert_tests/enkf/__init__.py
+    ert_tests/enkf/test_labscale.py
     ert_tests/enkf/test_ert_context.py
     ert_tests/enkf/test_enkf.py
     ert_tests/enkf/test_enkf_fs.py
@@ -332,6 +333,10 @@ add_test( NAME python.tests.ert.enkf.plot.plot_block_data
 add_test( NAME python.tests.ert.enkf.ert_test_context
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
           COMMAND ctest_run.py ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX} ert_tests.enkf.test_ert_context.ErtTestContextTest)
+
+add_test( NAME python.tests.ert.enkf.labscale
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+          COMMAND ctest_run.py ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX} ert_tests.enkf.test_labscale.LabScaleTest)
 
 add_test( NAME python.tests.ert.enkf.run_arg
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -792,6 +797,7 @@ set_property( TEST python.tests.ert.enkf.ert_test_context     PROPERTY LABELS Py
 set_property( TEST python.tests.ert.enkf.plot.plot_block_data PROPERTY LABELS Python:StatoilData )
 set_property( TEST python.tests.ert.enkf.data.gen_data_config PROPERTY LABELS Python:StatoilData )
 set_property( TEST python.tests.ert.enkf.data.gen_data        PROPERTY LABELS Python:StatoilData )
+set_property( TEST python.tests.ert.enkf.labscale             PROPERTY LABELS Python:StatoilData )
 set_property( TEST python.tests.ert.enkf.update               PROPERTY LABELS Python:StatoilData )
 set_property( TEST python.tests.ert.enkf.summary_key_set      PROPERTY LABELS Python:StatoilData )
 set_property( TEST python.tests.ert.enkf.data.gen_kw_config   PROPERTY LABELS Python:StatoilData )

--- a/devel/python/test/ert_tests/ecl/test_deprecation.py
+++ b/devel/python/test/ert_tests/ecl/test_deprecation.py
@@ -19,6 +19,7 @@ import time
 
 from ert.test import ExtendedTestCase
 from ert.ecl import EclGrid,EclKW,EclTypeEnum,EclGrid,EclRegion
+from ert.util import BoolVector
 
 
 class DeprecationTest(ExtendedTestCase):
@@ -60,3 +61,10 @@ class DeprecationTest(ExtendedTestCase):
 
         with warnings.catch_warnings():
             region.active_list
+
+
+
+    # Deprecated method from 1.8.4
+    def test_BoolVector_active_mask(self):
+        with warnings.catch_warnings():
+            active_vector = BoolVector.active_mask("1,1,1,1,1,1")

--- a/devel/python/test/ert_tests/ecl/test_ecl_sum.py
+++ b/devel/python/test/ert_tests/ecl/test_ecl_sum.py
@@ -125,4 +125,13 @@ class EclSumTest(ExtendedTestCase):
             with self.assertRaises(IOError):
                 EclSum( "ECLIPSE" )
 
+
     
+                
+    def test_labscale(self):
+        case = self.createTestPath("Statoil/ECLIPSE/LabScale/HDMODEL")
+        sum = EclSum( case )
+        self.assertEqual( sum.getStartTime( ) , datetime.datetime(2013,1,1,0,0,0))
+        self.assertEqual( sum.getEndTime( )   , datetime.datetime(2013,1,1,19,30,0))
+        self.assertFloatEqual( sum.getSimulationLength() , 0.8125 )
+        

--- a/devel/python/test/ert_tests/enkf/test_labscale.py
+++ b/devel/python/test/ert_tests/enkf/test_labscale.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#  Copyright (C) 2015  Statoil ASA, Norway.
+#
+#  The file 'test_labscale.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+
+from ert.enkf import ObsVector
+from ert.test import ExtendedTestCase , ErtTestContext
+
+
+
+class LabScaleTest(ExtendedTestCase):
+    def setUp(self):
+        self.config_file = self.createTestPath("Statoil/config/labscale/config")
+
+
+    def testObs(self):
+        with ErtTestContext("labscale", self.config_file) as test_context:
+            ert = test_context.getErt()
+            obs = ert.getObservations()
+
+            self.assertEqual(4, len(obs))
+            for v in obs:
+                self.assertTrue(isinstance(v, ObsVector))
+
+            v1 = obs["WWCT_1"]
+            self.assertEqual( v1.activeStep() , 5 )
+            node = v1.getNode( 5 )
+            self.assertFloatEqual( node.getValue() , 0.00)
+
+            v2 = obs["WWCT_2"]
+            self.assertEqual( v2.activeStep() , 31 )
+            node = v2.getNode( 31 )
+            self.assertFloatEqual( node.getValue() , 0.575828)
+
+            v3 = obs["WWCT_3"]
+            self.assertEqual( v3.activeStep() , 73 )
+            node = v3.getNode( 73 )
+            self.assertFloatEqual( node.getValue() , 1.00)
+
+
+            bpr = obs["BPR"]
+            self.assertEqual( bpr.activeStep() , 31 )
+            node = bpr.getNode( 31 )
+            self.assertFloatEqual( node.getValue(0) , 10.284)
+


### PR DESCRIPTION
Renaming of method BoolVector.active_mask() to BoolVector.createActiveMask() led to trouble in ert-statoil load_rms script.
Solution: Keep both methods; but deprecate active_mask. 

