### PR TITLE
Deprecated active_mask

### DIFF
--- a/devel/python/python/ert/util/bool_vector.py
+++ b/devel/python/python/ert/util/bool_vector.py
@@ -17,6 +17,7 @@
 
 from ert.cwrap import CWrapper
 from ert.util import UTIL_LIB, VectorTemplate
+import warnings
 
 
 class BoolVector(VectorTemplate):
@@ -45,6 +46,25 @@ class BoolVector(VectorTemplate):
         The empty list will evaluate to false
         @rtype: BoolVector
         """
+        return cls.cNamespace().create_active_mask(range_string)
+
+    @classmethod
+    def active_mask(cls, range_string):
+        """
+        Will create a BoolVector instance with the values from @range_string.
+
+        The range_string input should be of the type "1,3-5,9,17",
+        i.e. integer values separated by commas, and dashes to
+        represent ranges. If the input string contains ANY invalid
+        characters the returned active list will be empty:
+
+           "1,4-7,10"  =>  {F,T,F,F,T,T,T,T,F,F,T}
+           "1,4-7,10X" =>  {}
+
+        The empty list will evaluate to false
+        @rtype: BoolVector
+        """
+        warnings.warn("The active_mask(cls, rangs_string) method has been renamed: createActiveMask(cls, rangs_string)" , DeprecationWarning)
         return cls.cNamespace().create_active_mask(range_string)
 
     @classmethod

--- a/devel/python/test/ert_tests/ecl/test_deprecation.py
+++ b/devel/python/test/ert_tests/ecl/test_deprecation.py
@@ -19,6 +19,7 @@ import time
 
 from ert.test import ExtendedTestCase
 from ert.ecl import EclGrid,EclKW,EclTypeEnum,EclGrid,EclRegion
+from ert.util import BoolVector
 
 
 class DeprecationTest(ExtendedTestCase):
@@ -60,3 +61,10 @@ class DeprecationTest(ExtendedTestCase):
 
         with warnings.catch_warnings():
             region.active_list
+
+
+
+    # Deprecated method from 1.8.4
+    def test_BoolVector_active_mask(self):
+        with warnings.catch_warnings():
+            active_vector = BoolVector.active_mask("1,1,1,1,1,1")


### PR DESCRIPTION
Renaming of method BoolVector.active_mask() to BoolVector.createActiveMask() led to trouble in ert-statoil load_rms script.
Solution: Keep both methods; but deprecate active_mask. 

