### PR TITLE
ERT-882: ext_job - will not search PATH

### DIFF
--- a/devel/libenkf/include/ert/enkf/config_keys.h
+++ b/devel/libenkf/include/ert/enkf/config_keys.h
@@ -177,6 +177,7 @@ extern "C" {
 #define  STOP_LONG_RUNNING_KEY             "STOP_LONG_RUNNING"
 #define  MAX_RUNTIME_KEY                   "MAX_RUNTIME"
 #define  TIME_MAP_KEY                      "TIME_MAP"
+#define  EXT_JOB_SEARCH_PATH_KEY           "EXT_JOB_SEARCH_PATH"
 
 
 #define CONFIG_BOOL_STRING( var ) (var) ? "TRUE" : "FALSE"

--- a/devel/libenkf/include/ert/enkf/site_config.h
+++ b/devel/libenkf/include/ert/enkf/site_config.h
@@ -83,6 +83,7 @@ typedef struct site_config_struct site_config_type;
 
   void                     site_config_set_rsh_command( site_config_type * site_config , const char * rsh_command);
   const char             * site_config_get_rsh_command( const site_config_type * site_config );
+  void                     site_config_set_ext_job_search_path(site_config_type * site_config, bool search_path);
 
 
   bool                     site_config_set_job_script( site_config_type * site_config , const char * job_script );

--- a/devel/libjob_queue/include/ert/job_queue/ext_job.h
+++ b/devel/libjob_queue/include/ert/job_queue/ext_job.h
@@ -46,12 +46,12 @@ void                    ext_job_set_private_arg(ext_job_type * , const char *  ,
 
 void                    ext_job_set_argc(ext_job_type *   , const char ** , int);
 void                    ext_job_python_fprintf(const ext_job_type * , FILE * , const subst_list_type *);
-ext_job_type          * ext_job_fscanf_alloc(const char * , const char * , bool private_job , const char *);
+ext_job_type          * ext_job_fscanf_alloc(const char * , const char * , bool private_job , const char *, bool search_path);
 const stringlist_type * ext_job_get_arglist( const ext_job_type * ext_job );
 bool                    ext_job_is_shared( const ext_job_type * ext_job );
 bool                    ext_job_is_private( const ext_job_type * ext_job );
 
-void                    ext_job_set_executable(ext_job_type * ext_job, const char * executable, const char * execuatble_raw);
+void                    ext_job_set_executable(ext_job_type * ext_job, const char * executable, const char * execuatble_raw,bool search_path);
 const char *            ext_job_get_executable(const ext_job_type * ext_job);
 
 

--- a/devel/libjob_queue/include/ert/job_queue/ext_joblist.h
+++ b/devel/libjob_queue/include/ert/job_queue/ext_joblist.h
@@ -41,7 +41,7 @@ ext_job_type     * ext_joblist_get_job_copy(const ext_joblist_type *  , const ch
 bool               ext_joblist_has_job(const ext_joblist_type *  , const char * );
 stringlist_type  * ext_joblist_alloc_list( const ext_joblist_type * joblist);
 bool               ext_joblist_del_job( ext_joblist_type * joblist , const char * job_name );
-void               ext_joblist_add_jobs_in_directory(ext_joblist_type * joblist  , const char * path, const char * license_root_path, bool user_mode );
+void               ext_joblist_add_jobs_in_directory(ext_joblist_type * joblist  , const char * path, const char * license_root_path, bool user_mode, bool search_path );
 
 #ifdef __cplusplus
 }

--- a/devel/libjob_queue/src/ext_joblist.c
+++ b/devel/libjob_queue/src/ext_joblist.c
@@ -152,7 +152,7 @@ hash_type * ext_joblist_get_jobs( const ext_joblist_type * joblist ) {
   return joblist->jobs;
 }
 
-void ext_joblist_add_jobs_in_directory(ext_joblist_type * joblist  , const char * path, const char * license_root_path, bool user_mode ) {
+void ext_joblist_add_jobs_in_directory(ext_joblist_type * joblist  , const char * path, const char * license_root_path, bool user_mode, bool search_path ) {
   DIR * dirH = opendir( path );
   if (dirH) {
     while (true) {
@@ -161,7 +161,7 @@ void ext_joblist_add_jobs_in_directory(ext_joblist_type * joblist  , const char 
         if ((strcmp(entry->d_name , ".") != 0) && (strcmp(entry->d_name , "..") != 0)) {
           char * full_path = util_alloc_filename( path , entry->d_name , NULL );
           if (util_is_file( full_path )) {
-              ext_job_type * new_job = ext_job_fscanf_alloc(entry->d_name, license_root_path, user_mode, full_path);
+              ext_job_type * new_job = ext_job_fscanf_alloc(entry->d_name, license_root_path, user_mode, full_path, search_path);
               if (new_job != NULL) {
                 ext_joblist_add_job(joblist, entry->d_name, new_job);
               }

--- a/devel/libjob_queue/tests/ext_joblist_test.c
+++ b/devel/libjob_queue/tests/ext_joblist_test.c
@@ -22,7 +22,7 @@
 
 void load_job_directory(ext_joblist_type * joblist , const char * path, const char * license_root_path) {
   bool user_mode = false;
-  ext_joblist_add_jobs_in_directory(joblist  , path, license_root_path, user_mode );
+  ext_joblist_add_jobs_in_directory(joblist  , path, license_root_path, user_mode, true );
   test_assert_true( ext_joblist_has_job(joblist, "SYMLINK"));
 }
 


### PR DESCRIPTION
If the executable given in the forward model specification is not found
at the path given in the input specification the ext_job code will by
default NOT search the $PATH variable. This is to support heterogenous
environments where the PATH is different on submission host and the
cluster.