### PR TITLE
Removed run_arg->__ready

### DIFF
--- a/devel/libenkf/include/ert/enkf/run_arg.h
+++ b/devel/libenkf/include/ert/enkf/run_arg.h
@@ -53,7 +53,6 @@ UTIL_IS_INSTANCE_HEADER( run_arg );
   state_enum     run_arg_get_dynamic_init_state( const run_arg_type * run_arg );
   state_enum     run_arg_get_parameter_init_state( const run_arg_type * run_arg );
   int            run_arg_get_parameter_init_step( const run_arg_type * run_arg );
-  bool           run_arg_is_ready( const run_arg_type * run_arg);
   int            run_arg_get_step1( const run_arg_type * run_arg );
   int            run_arg_get_step2( const run_arg_type * run_arg );
   run_mode_type  run_arg_get_run_mode( const run_arg_type * run_arg );
@@ -62,8 +61,6 @@ UTIL_IS_INSTANCE_HEADER( run_arg );
   int            run_arg_get_iter( const run_arg_type * run_arg );
   void           run_arg_increase_submit_count( run_arg_type * run_arg );
   void           run_arg_set_queue_index( run_arg_type * run_arg , int queue_index);
-
-  void run_arg_set_ready( run_arg_type * run_arg , bool ready);
 
   void run_arg_free(run_arg_type * run_arg);
   void run_arg_free__(void * arg);

--- a/devel/libenkf/src/enkf_state.c
+++ b/devel/libenkf/src/enkf_state.c
@@ -1705,9 +1705,6 @@ void enkf_state_init_eclipse(enkf_state_type *enkf_state, const run_arg_type * r
   const member_config_type  * my_config = enkf_state->my_config;  
   const ecl_config_type * ecl_config = enkf_state->shared_info->ecl_config;
   {
-    if (!run_arg_is_ready(run_arg))
-      util_abort("%s: must initialize run parameters with enkf_state_init_run() first \n",__func__);
-    
     if (member_config_pre_clear_runpath( my_config )) 
       util_clear_directory( run_arg_get_runpath( run_arg ) , true , false );
 
@@ -1898,7 +1895,6 @@ static bool enkf_state_complete_forward_modelOK(enkf_state_type * enkf_state , r
     ert_log_add_fmt_message( 2 , NULL , "[%03d:%04d-%04d] Results loaded successfully." , iens , run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
     
     enkf_state_clear_runpath( enkf_state , run_arg );
-    run_arg_set_ready( run_arg , false );
     run_arg_complete_run(run_arg);              /* free() on runpath */
   } 
   return (0 == result) ? true : false; 

--- a/devel/libenkf/src/run_arg.c
+++ b/devel/libenkf/src/run_arg.c
@@ -32,7 +32,6 @@
 
 struct run_arg_struct {
   UTIL_TYPE_ID_DECLARATION;
-  bool                    __ready;              /* An attempt to check the internal state - not really used. */
   int                     iens;
   bool                    active;               /* Is this state object active at all - used for instance in ensemble experiments where only some of the members are integrated. */
   int                     init_step_parameters; /* The report step we initialize parameters from - will often be equal to step1, but can be different. */
@@ -182,16 +181,6 @@ int run_arg_get_iens( const run_arg_type * run_arg ) {
 
 int run_arg_get_load_start( const run_arg_type * run_arg ) {
   return run_arg->load_start;
-}
-
-
-bool run_arg_is_ready( const run_arg_type * run_arg) {
-  return run_arg->__ready;
-}
-
-
-void run_arg_set_ready( run_arg_type * run_arg , bool ready) {
-  run_arg->__ready = ready;
 }
 
 


### PR DESCRIPTION
Removed run_arg->__ready.

It is not used, and generally uninitialized, leading to undefined behavior the one time it is checked as shown by failing Debug-compiled unit-tests.