### PR TITLE
fixed: install buffer_string.h

### DIFF
--- a/devel/libert_util/src/CMakeLists.txt
+++ b/devel/libert_util/src/CMakeLists.txt
@@ -67,6 +67,7 @@ set(header_files
     type_vector_functions.h
     ui_return.h
     struct_vector.h
+    buffer_string.h
 )
 
 set( test_source test_util.c )


### PR DESCRIPTION
installation broke a few weeks back with the introduction of buffer_string.h.