### PR TITLE
ERT-904: Memory leak in enkf_main_analysis_update

### DIFF
--- a/devel/libenkf/src/enkf_main.c
+++ b/devel/libenkf/src/enkf_main.c
@@ -1243,6 +1243,7 @@ static void enkf_main_analysis_update( enkf_main_type * enkf_main ,
   matrix_free( R );
   matrix_free( dObs );
   matrix_free( X );
+  matrix_free( A );
 }
 
 


### PR DESCRIPTION
Matrix A was not freed. I have tested the matrix_free( A ) and it seems to work fine now on my test case. Memory not exploding anymore. 