### PR TITLE
Linux warnings

### DIFF
--- a/devel/libenkf/include/ert/enkf/custom_kw_config.h
+++ b/devel/libenkf/include/ert/enkf/custom_kw_config.h
@@ -21,7 +21,7 @@ extern "C" {
     char *                  custom_kw_config_get_result_file(const custom_kw_config_type * config);
     char *                  custom_kw_config_get_output_file(const custom_kw_config_type * config);
     bool                    custom_kw_config_parse_result_file(custom_kw_config_type * config, const char * result_file, stringlist_type * result);
-    void                    custom_kw_config_serialize(custom_kw_config_type * config, stringlist_type * config_set);
+    void                    custom_kw_config_serialize(const custom_kw_config_type * config, stringlist_type * config_set);
     void                    custom_kw_config_deserialize(custom_kw_config_type * config, stringlist_type * config_set);
     bool                    custom_kw_config_has_key(const custom_kw_config_type * config, const char * key);
     bool                    custom_kw_config_key_is_double(const custom_kw_config_type * config, const char * key);

--- a/devel/libenkf/src/custom_kw_config.c
+++ b/devel/libenkf/src/custom_kw_config.c
@@ -80,8 +80,9 @@ static void custom_kw_config_reset__(custom_kw_config_type * config) {
     config->key_definition_file = NULL;
 }
 
-void custom_kw_config_serialize(custom_kw_config_type * config, stringlist_type * config_set) {
-    pthread_rwlock_rdlock(& config->rw_lock);
+void custom_kw_config_serialize(const custom_kw_config_type * config, stringlist_type * config_set) {
+    pthread_rwlock_t * rw_lock = (pthread_rwlock_t *)& config->rw_lock;
+    pthread_rwlock_rdlock(rw_lock);
     {
         stringlist_clear(config_set);
 
@@ -100,7 +101,7 @@ void custom_kw_config_serialize(custom_kw_config_type * config, stringlist_type 
         stringlist_free(configured_keys);
 
     }
-    pthread_rwlock_unlock(& config->rw_lock);
+    pthread_rwlock_unlock(rw_lock);
 }
 
 void custom_kw_config_deserialize(custom_kw_config_type * config, stringlist_type * config_set) {

--- a/devel/libert_util/include/ert/util/hash.h
+++ b/devel/libert_util/include/ert/util/hash.h
@@ -49,7 +49,7 @@ bool              hash_has_key(const hash_type *, const char *);
 void            * hash_pop( hash_type * hash , const char * key);
 void            * hash_safe_get( const hash_type * hash , const char * key );
 void            * hash_get(const hash_type *, const char *);
-char            * hash_get_string(hash_type * , const char *);
+char            * hash_get_string(const hash_type * , const char *);
 void              hash_del(hash_type *, const char *);
 void              hash_safe_del(hash_type * , const char * );
 void              hash_clear(hash_type *);
@@ -75,11 +75,11 @@ hash_type       * hash_alloc_from_options(const stringlist_type *);
 bool              hash_add_option( hash_type * hash, const char * key_value);
 
 int               hash_inc_counter(hash_type * hash , const char * counter_key);
-int               hash_get_counter(hash_type * hash , const char * key);
+int               hash_get_counter(const hash_type * hash , const char * key);
 void              hash_insert_int(hash_type * , const char * , int);
-int               hash_get_int(hash_type * , const char *);
+int               hash_get_int(const hash_type * , const char *);
 void              hash_insert_double(hash_type * , const char * , double);
-double            hash_get_double(hash_type * , const char *);
+double            hash_get_double(const hash_type * , const char *);
 void              hash_apply( hash_type * hash , hash_apply_ftype * func);
 
 UTIL_IS_INSTANCE_HEADER(hash);

--- a/devel/libert_util/src/hash.c
+++ b/devel/libert_util/src/hash.c
@@ -159,8 +159,9 @@ static void * __hash_get_node_unlocked(const hash_type *__hash , const char *key
   difficult due to locking requirements.
 */
 
-static void * __hash_get_node(hash_type *hash , const char *key, bool abort_on_error) {
+static void * __hash_get_node(const hash_type *hash_in , const char *key, bool abort_on_error) {
   hash_node_type * node;
+  hash_type * hash = (hash_type *)hash_in;
   __hash_rdlock( hash );
   node = __hash_get_node_unlocked(hash , key , abort_on_error);
   __hash_unlock( hash );
@@ -168,7 +169,7 @@ static void * __hash_get_node(hash_type *hash , const char *key, bool abort_on_e
 }
 
 
-static node_data_type * hash_get_node_data(hash_type *hash , const char *key) {
+static node_data_type * hash_get_node_data(const hash_type *hash , const char *key) {
   hash_node_type * node = __hash_get_node(hash , key , true);
   return hash_node_get_data(node);
 }
@@ -356,7 +357,7 @@ void hash_insert_string(hash_type * hash , const char * key , const char * value
 }
 
 
-char * hash_get_string(hash_type * hash , const char * key) {
+char * hash_get_string(const hash_type * hash , const char * key) {
   node_data_type * node_data = hash_get_node_data(hash , key);
   return node_data_get_string( node_data );
 }
@@ -369,7 +370,7 @@ void hash_insert_int(hash_type * hash , const char * key , int value) {
 }
 
 
-int hash_get_int(hash_type * hash , const char * key) {
+int hash_get_int(const hash_type * hash , const char * key) {
   node_data_type * node_data = hash_get_node_data(hash , key);
   return node_data_get_int( node_data );
 }
@@ -400,7 +401,7 @@ int hash_inc_counter(hash_type * hash , const char * counter_key) {
    Will return 0 if the key is not in the hash.
 */
 
-int hash_get_counter(hash_type * hash , const char * key) {
+int hash_get_counter(const hash_type * hash , const char * key) {
   if (hash_has_key( hash , key ))
     return hash_get_int( hash , key );
   else
@@ -414,7 +415,7 @@ void hash_insert_double(hash_type * hash , const char * key , double value) {
   __hash_insert_node(hash , hash_node);
 }
 
-double hash_get_double(hash_type * hash , const char * key) {
+double hash_get_double(const hash_type * hash , const char * key) {
   node_data_type * node_data = hash_get_node_data(hash , key);
   return node_data_get_double( node_data );
 }

--- a/devel/libert_util/src/thread_pool_posix.c
+++ b/devel/libert_util/src/thread_pool_posix.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <signal.h>
 #include <pthread.h>
 #include <unistd.h>
 

--- a/devel/libjob_queue/include/ert/job_queue/job_queue.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue.h
@@ -61,7 +61,6 @@ extern "C" {
   void                job_queue_start_manager_thread( job_queue_type * job_queue , pthread_t * queue_thread , int job_size , bool verbose);
 
   job_status_type     job_queue_iget_job_status(job_queue_type * , int );
-  const char        * job_queue_status_name( job_status_type status );
 
   int                 job_queue_iget_status_summary( const job_queue_type * queue , job_status_type status);
   time_t              job_queue_iget_sim_start( job_queue_type * queue, int job_index);

--- a/devel/libjob_queue/include/ert/job_queue/job_queue_status.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue_status.h
@@ -24,7 +24,6 @@ extern "C" {
 #endif
 
 #include <ert/util/type_macros.h>
-#include <ert/job_queue/job_queue_status.h>
 #include <ert/job_queue/queue_driver.h>
 
   typedef struct job_queue_status_struct job_queue_status_type;
@@ -36,6 +35,7 @@ extern "C" {
   void job_queue_status_inc( job_queue_status_type * status_count , job_status_type status_type);
   bool job_queue_status_transition( job_queue_status_type * status_count , job_status_type src_status , job_status_type target_status);
   int job_queue_status_get_total_count( const job_queue_status_type * status );
+  const char * job_queue_status_name( job_status_type status );
 
   UTIL_IS_INSTANCE_HEADER( job_queue_status );
   UTIL_SAFE_CAST_HEADER( job_queue_status );

--- a/devel/libjob_queue/src/job_queue_manager.c
+++ b/devel/libjob_queue/src/job_queue_manager.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <signal.h>
 #include <pthread.h>
 #include <unistd.h>
 

--- a/devel/libjob_queue/src/job_queue_status.c
+++ b/devel/libjob_queue/src/job_queue_status.c
@@ -141,3 +141,9 @@ int job_queue_status_get_total_count( const job_queue_status_type * status ) {
     total_count += status->status_list[ index ];
   return total_count;
 }
+
+
+const char * job_queue_status_name( job_status_type status ) {
+  int index = STATUS_INDEX( status );
+  return status_name[index];
+}

--- a/devel/libjob_queue/src/job_queue_status.c
+++ b/devel/libjob_queue/src/job_queue_status.c
@@ -44,6 +44,18 @@ static const int status_index[] = {  JOB_QUEUE_NOT_ACTIVE ,  // Initial, allocat
                                      JOB_QUEUE_RUNNING_CALLBACK, // Temporary state, while running requested callbacks after an ended job  - controlled by job_queue
                                      JOB_QUEUE_FAILED };     // Job has failed, no more retries, FINAL STATE
 
+static const char* status_name[] = { "JOB_QUEUE_NOT_ACTIVE" ,
+                                     "JOB_QUEUE_WAITING"    ,
+                                     "JOB_QUEUE_SUBMITTED"  ,
+                                     "JOB_QUEUE_PENDING"    ,
+                                     "JOB_QUEUE_RUNNING"    ,
+                                     "JOB_QUEUE_DONE"       ,
+                                     "JOB_QUEUE_EXIT"       ,
+                                     "JOB_QUEUE_USER_KILLED" ,
+                                     "JOB_QUEUE_USER_EXIT"   ,
+                                     "JOB_QUEUE_SUCCESS"    ,
+                                     "JOB_QUEUE_RUNNING_CALLBACK",
+                                     "JOB_QUEUE_FAILED" };
 
 static int STATUS_INDEX( job_status_type status ) {
   int index = 0;

--- a/devel/libjob_queue/src/job_queue_status.c
+++ b/devel/libjob_queue/src/job_queue_status.c
@@ -44,18 +44,6 @@ static const int status_index[] = {  JOB_QUEUE_NOT_ACTIVE ,  // Initial, allocat
                                      JOB_QUEUE_RUNNING_CALLBACK, // Temporary state, while running requested callbacks after an ended job  - controlled by job_queue
                                      JOB_QUEUE_FAILED };     // Job has failed, no more retries, FINAL STATE
 
-static const char* status_name[] = { "JOB_QUEUE_NOT_ACTIVE" ,
-                                     "JOB_QUEUE_WAITING"    ,
-                                     "JOB_QUEUE_SUBMITTED"  ,
-                                     "JOB_QUEUE_PENDING"    ,
-                                     "JOB_QUEUE_RUNNING"    ,
-                                     "JOB_QUEUE_DONE"       ,
-                                     "JOB_QUEUE_EXIT"       ,
-                                     "JOB_QUEUE_USER_KILLED" ,
-                                     "JOB_QUEUE_USER_EXIT"   ,
-                                     "JOB_QUEUE_SUCCESS"    ,
-                                     "JOB_QUEUE_RUNNING_CALLBACK",
-                                     "JOB_QUEUE_FAILED" };
 
 static int STATUS_INDEX( job_status_type status ) {
   int index = 0;

--- a/devel/libjob_queue/src/lsf_driver.c
+++ b/devel/libjob_queue/src/lsf_driver.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <dlfcn.h>
+#include <unistd.h>
 
 #include <ert/util/util.h>
 #include <ert/util/hash.h>

--- a/devel/libjob_queue/src/rsh_driver.c
+++ b/devel/libjob_queue/src/rsh_driver.c
@@ -341,7 +341,7 @@ void rsh_driver_free__(void * __driver) {
 }
 
 
-void rsh_driver_set_host_list( rsh_driver_type * rsh_driver , hash_type * rsh_host_list) {
+void rsh_driver_set_host_list( rsh_driver_type * rsh_driver , const hash_type * rsh_host_list) {
   rsh_driver_clear_host_list( rsh_driver ); 
   if (rsh_host_list != NULL) {
     hash_iter_type * hash_iter = hash_iter_alloc( rsh_host_list );
@@ -429,7 +429,7 @@ bool rsh_driver_set_option( void * __driver , const char * option_key , const vo
       rsh_driver_add_host_from_string( driver , value );
     else if (strcmp(RSH_HOSTLIST , option_key) == 0) {      /* Set full host list - value should be hash of integers. */
       if (value != NULL) {
-        hash_type * hash_value = hash_safe_cast( value );
+        const hash_type * hash_value = hash_safe_cast_const( value );
         rsh_driver_set_host_list( driver , hash_value );
       }
     } else if (strcmp( RSH_CLEAR_HOSTLIST , option_key) == 0)

--- a/devel/libjob_queue/tests/job_status_test.c
+++ b/devel/libjob_queue/tests/job_status_test.c
@@ -94,8 +94,18 @@ void test_update() {
 }
 
 
+void test_name() {
+  test_assert_string_equal( job_queue_status_name( JOB_QUEUE_NOT_ACTIVE ) ,
+                            "JOB_QUEUE_NOT_ACTIVE" );
+  test_assert_string_equal( job_queue_status_name( JOB_QUEUE_EXIT ) ,
+                            "JOB_QUEUE_EXIT" );
+  test_assert_string_equal( job_queue_status_name( JOB_QUEUE_FAILED ) ,
+                            "JOB_QUEUE_FAILED" );
+}
+
 
 int main( int argc , char ** argv) {
   test_create();
   test_update();
+  test_name();
 }


### PR DESCRIPTION
Fixed various warnings when compiling on Linux with gcc version 4.4.7 20120313 (Red Hat 4.4.7-16) (GCC).