### PR TITLE
Added observations, ensemble and grid to local_config

### DIFF
--- a/devel/python/python/ert/enkf/enkf_main.py
+++ b/devel/python/python/ert/enkf/enkf_main.py
@@ -102,7 +102,7 @@ class EnKFMain(BaseCClass):
         """ @rtype: Log """
         return EnKFMain.cNamespace().get_logh(self).setParent(self)
 
-    def local_config(self):
+    def getLocalConfig(self):
         """ @rtype: LocalConfig """
         config = EnKFMain.cNamespace().get_local_config(self).setParent(self)
         config.initAttributes( self.ensembleConfig() , self.getObservations() , self.eclConfig().get_grid() )

--- a/devel/python/python/ert/enkf/enkf_main.py
+++ b/devel/python/python/ert/enkf/enkf_main.py
@@ -104,8 +104,11 @@ class EnKFMain(BaseCClass):
 
     def local_config(self):
         """ @rtype: LocalConfig """
-        return EnKFMain.cNamespace().get_local_config(self).setParent(self)
-
+        config = EnKFMain.cNamespace().get_local_config(self).setParent(self)
+        config.initAttributes( self.ensembleConfig() , self.getObservations() , self.eclConfig().get_grid() )
+        return config
+    
+    
     def siteConfig(self):
         """ @rtype: SiteConfig """
         return EnKFMain.cNamespace().get_site_config(self).setParent(self)

--- a/devel/python/python/ert/enkf/local_obsdata.py
+++ b/devel/python/python/ert/enkf/local_obsdata.py
@@ -10,6 +10,9 @@ class LocalObsdata(BaseCClass):
         c_pointer = LocalObsdata.cNamespace().alloc(name)
         super(LocalObsdata, self).__init__(c_pointer)
 
+    def initObservations(self , obs):
+        self.obs = obs
+        
     def __len__(self):
         """ @rtype: int """
         return LocalObsdata.cNamespace().size(self)
@@ -53,16 +56,22 @@ class LocalObsdata(BaseCClass):
     def addNode(self, node):
         """ @rtype: bool """
         assert isinstance(node, LocalObsdataNode)
-        node.convertToCReference(self)
-        already_exists_node_for_key = LocalObsdata.cNamespace().add_node(self, node)
-        return already_exists_node_for_key
-          
+        if node.getKey() in self.obs:
+            node.convertToCReference(self)
+            already_exists_node_for_key = LocalObsdata.cNamespace().add_node(self, node)
+            return already_exists_node_for_key
+        else:
+            raise KeyError("The observation node: %s is not recognized observation key" % node.getKey())
+        
+    
     def clear(self):        
         LocalObsdata.cNamespace().clear(self)        
-    
+
+        
     def addObsVector(self , obs_vector):
         self.addNode( obs_vector.createLocalObs() )
-    
+
+        
     def addNodeAndRange(self, key, step_1, step_2):
         """ @rtype: bool """
         assert isinstance(key, str)
@@ -71,10 +80,10 @@ class LocalObsdata(BaseCClass):
         
         node = LocalObsdataNode(key)  
         node.addRange(step_1, step_2)      
-        node.convertToCReference(self)
-        already_exists_node_for_key = LocalObsdata.cNamespace().add_node(self, node)
-        return already_exists_node_for_key
+        return self.addNode( node )
 
+
+        
     def getName(self):
         """ @rtype: str """
         return LocalObsdata.cNamespace().name(self)

--- a/devel/python/tests/ert/enkf/test_local_config.py
+++ b/devel/python/tests/ert/enkf/test_local_config.py
@@ -21,7 +21,7 @@ class LocalConfigTest(ExtendedTestCase):
             main = test_context.getErt()
             self.assertTrue(main, "Load failed")
             
-            local_config = main.local_config()  
+            local_config = main.getLocalConfig()  
             
             
             self.UpdateStep(local_config)

--- a/devel/python/tests/ert/enkf/test_local_config.py
+++ b/devel/python/tests/ert/enkf/test_local_config.py
@@ -67,37 +67,40 @@ class LocalConfigTest(ExtendedTestCase):
         
         self.assertEqual( len(updatestep) , 1 )            
 
+
     def LocalDataset( self, local_config ):                        
-                  
         # Data
         data_scale = local_config.createDataset("DATA_SCALE")
-        data_scale.addNode("SCALE")
-        active_list = data_scale.getActiveList("SCALE")
-        self.assertTrue(isinstance(active_list, ActiveList))
-        
-        active_list.addActiveIndex(0)            
-                    
-        data_offset = local_config.createDataset("DATA_OFFSET")
-        data_offset.addNodeWithIndex("OFFSET", 1)
+        with self.assertRaises(KeyError):
+            data_scale.addNode("MISSING")
 
+        data_scale.addNode("PERLIN_PARAM")
+        active_list = data_scale.getActiveList("PERLIN_PARAM")
+        self.assertTrue(isinstance(active_list, ActiveList))
+        active_list.addActiveIndex(0)            
+
+        
     def LocalObsdata( self, local_config ):              
         
           
         # Creating
         local_obs_data_1 = local_config.createObsdata("OBSSET_1") 
         self.assertTrue(isinstance(local_obs_data_1, LocalObsdata))
-                                                   
-        local_obs_data_1.addNodeAndRange("GENPERLIN_1", 0, 1)
-        local_obs_data_1.addNodeAndRange("GENPERLIN_2", 0, 1)            
+
+        with self.assertRaises(KeyError):
+            local_obs_data_1.addNodeAndRange("MISSING_KEY" , 0 , 1 )
+            
+        local_obs_data_1.addNodeAndRange("GEN_PERLIN_1", 0, 1)
+        local_obs_data_1.addNodeAndRange("GEN_PERLIN_2", 0, 1)            
         
         self.assertEqual( len(local_obs_data_1) , 2 )
                 
         # Delete node        
-        del local_obs_data_1["GENPERLIN_1"]
+        del local_obs_data_1["GEN_PERLIN_1"]
         self.assertEqual( len(local_obs_data_1) , 1 )  
 
         # Get node
-        node = local_obs_data_1["GENPERLIN_2"]
+        node = local_obs_data_1["GEN_PERLIN_2"]
         self.assertTrue(isinstance(node, LocalObsdataNode))
 
 
@@ -108,8 +111,8 @@ class LocalConfigTest(ExtendedTestCase):
         self.assertTrue(isinstance(local_obs_data_1, LocalObsdata))
         
         # Obsdata                                           
-        local_obs_data_1.addNodeAndRange("GENPERLIN_1", 0, 1)
-        local_obs_data_1.addNodeAndRange("GENPERLIN_2", 0, 1)  
+        local_obs_data_1.addNodeAndRange("GEN_PERLIN_1", 0, 1)
+        local_obs_data_1.addNodeAndRange("GEN_PERLIN_2", 0, 1)  
         
         # Ministep                                      
         ministep = local_config.createMinistep("MINISTEP")


### PR DESCRIPTION
__background:__ When creating a configuration for local updates observations and parameter which should be used are added based on string keys:

```Python
1:  local_config = ert.local_config()
2:  obs_set = local_config.createObsData("RandomObsKey")  
3:  obs_set.addNode("WWCT:OP_1")                        
4: 
5:  data_set = local_config.createDataSet("RandomDataKey")
6:  data_set.addNode("MULTFLT")
``` 

The strings used in line 3 and 6 above must correspond to valid observation and data keys respectively - however that is *not checked in any way*, and if invalid keys are used this will blow up hard in subsequent update step. The purpose of this PR is to check the keys used in the methodcalls in line 3 and 6 - and raise a `KeyError()` exception if the keys are invalid.

__Solution:__ The underlying C datastructure `local_config_type` does *not* have access to the ensemble configuration and observation datastructures, and giving that access becomes quite convoluted due to circular dependencies - it is therefor not possible to validate this at the lowest level. 

The solution chosen here is that the Python `LocalConfig` object is decorated with references to `EnsembleConfig` and `EnkfObs` - this works, but it breaks the pattern of "one Pythhon class <-> one C struct" - and it is not very clear to read from the `local_config.py` implementation that the `LocalConfig` instances *should* have members `ensemble_config, grid` and `obs`. 