### PR TITLE
update redhat packaging

### DIFF
--- a/devel/redhat/ert.ecl.spec
+++ b/devel/redhat/ert.ecl.spec
@@ -5,7 +5,7 @@
 %define tag final2
 
 Name:           ert.ecl
-Version:        2013.10
+Version:        2015.10
 Release:        0
 Summary:        ERT - Ensemble based Reservoir Tool - ECL library
 License:        GPL-3+
@@ -14,7 +14,9 @@ Url:            http://ert.nr.no
 Source0:        https://github.com/OPM/%{name}/archive/release/%{version}/%{tag}.tar.gz#/%{name}-%{version}.tar.gz
 BuildRequires:  lapack-devel zlib-devel iputils
 BuildRequires:  gcc
-BuildRequires:  cmake28 
+%{?!el6:BuildRequires: python-devel}
+%{?el6:BuildRequires:  cmake28}
+%{?!el6:BuildRequires:  cmake}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       libert.ecl1 = %{version}
 
@@ -27,7 +29,19 @@ tool to do assisted history matching with Ensemble Kalman Filter
 %package -n libert.ecl1
 Summary:        ERT - Ensemble based Reservoir Tool - ECL library
 Group:          System/Libraries
-%{?el5:BuildArch: %{_arch}}
+
+%{?!el6:
+%package -n python-ert.ecl
+Summary:        ERT - Ensemble based Reservoir Tool - Python bindings
+Group:          Python/Libraries
+Requires:       libert.ecl1
+
+%description -n python-ert.ecl
+ERT - Ensemble based Reservoir Tool is a tool for managing en ensemble
+of reservoir models. The initial motivation for creating ERT was a as
+tool to do assisted history matching with Ensemble Kalman Filter
+(EnKF). This package contains the Python bindings.
+}
 
 %description -n libert.ecl1
 ERT - Ensemble based Reservoir Tool is a tool for managing en ensemble
@@ -41,7 +55,6 @@ Group:          Development/Libraries/C and C++
 Requires:       %{name} = %{version}
 Requires:       lapack-devel
 Requires:       libert.ecl1 = %{version}
-%{?el5:BuildArch: 	%{_arch}}
 
 %description devel
 This package contains the development and header files for ert.ecl
@@ -51,7 +64,7 @@ This package contains the development and header files for ert.ecl
 
 %build
 cd devel
-cmake28 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DBUILD_ECL_SUMMARY=1
+DESTDIR=${RPM_BUILD_ROOT} %{?el6:cmake28} %{?!el6:cmake} -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DBUILD_ECL_SUMMARY=1 %{?el6:-DBUILD_PYTHON=0}
 make
 
 %install
@@ -77,3 +90,9 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{_libdir}/*.so
 %{_includedir}/*
+
+%{?!el6:
+%files -n python-ert.ecl
+%defattr(-,root,root,-)
+/usr/lib/python2.7/site-packages/ert/*
+}


### PR DESCRIPTION
- remove el5 support
- package python-ert.ecl on el7 (skipped on el6 since it requires python 2.7)