### PR TITLE
Added stubs to get cell dx and dy.

### DIFF
--- a/devel/libecl/include/ert/ecl/ecl_grid.h
+++ b/devel/libecl/include/ert/ecl/ecl_grid.h
@@ -56,6 +56,10 @@ extern "C" {
   void            ecl_grid_get_cell_corner_xyz1(const ecl_grid_type * grid , int global_index , int corner_nr , double * xpos , double * ypos , double * zpos );
   void            ecl_grid_get_corner_xyz(const ecl_grid_type * grid , int i , int j , int k, double * xpos , double * ypos , double * zpos );
 
+  double          ecl_grid_get_cell_dx1( const ecl_grid_type * grid , int global_index );
+  double          ecl_grid_get_cell_dx3( const ecl_grid_type * grid , int i , int j , int k);
+  double          ecl_grid_get_cell_dy1( const ecl_grid_type * grid , int global_index );
+  double          ecl_grid_get_cell_dy3( const ecl_grid_type * grid , int i , int j , int k);
   double          ecl_grid_get_cell_thickness3( const ecl_grid_type * grid , int i , int j , int k);
   double          ecl_grid_get_cell_thickness1( const ecl_grid_type * grid , int global_index );
   double          ecl_grid_get_cdepth1(const ecl_grid_type * grid , int global_index);

--- a/devel/libecl/src/ecl_grid.c
+++ b/devel/libecl/src/ecl_grid.c
@@ -4332,9 +4332,8 @@ double ecl_grid_get_cell_dy1( const ecl_grid_type * grid , int global_index ) {
 
 
 double ecl_grid_get_cell_dy3( const ecl_grid_type * grid , int i , int j , int k) {
-  fprintf(stderr , "** WARNING: The ecl_grid_get_cell_dy1() function is only a stub returning -1.\n");
-  fprintf(stderr , "            If you need a correct value for cell dy you must update rebuild a new ert version.\n");
-  return ecl_grid_get_cell_dy1( grid , global_index );
+  const int global_index = ecl_grid_get_global_index3(grid , i,j,k);
+  return ecl_grid_get_cell_dx1( grid , global_index );
 }
 
 

--- a/devel/libecl/src/ecl_grid.c
+++ b/devel/libecl/src/ecl_grid.c
@@ -4311,19 +4311,36 @@ double ecl_grid_get_cell_thickness3( const ecl_grid_type * grid , int i , int j 
 
 
 
+double ecl_grid_get_cell_dx1( const ecl_grid_type * grid , int global_index ) {
+  fprintf(stderr , "** WARNING: The ecl_grid_get_cell_dx1() function is only a stub returning -1.\n");
+  fprintf(stderr , "            If you need a correct value for cell dx you must rebuild a new ert version.\n");
+  return -1;
+}
+
+
+double ecl_grid_get_cell_dx3( const ecl_grid_type * grid , int i , int j , int k) {
+  const int global_index = ecl_grid_get_global_index3(grid , i,j,k);
+  return ecl_grid_get_cell_dx1( grid , global_index );
+}
+
+
+double ecl_grid_get_cell_dy1( const ecl_grid_type * grid , int global_index ) {
+  fprintf(stderr , "** WARNING: The ecl_grid_get_cell_dy1() function is only a stub returning -1.\n");
+  fprintf(stderr , "            If you need a correct value for cell dy you must update rebuild a new ert version.\n");
+  return -1;
+}
+
+
 
 const nnc_info_type * ecl_grid_get_cell_nnc_info1( const ecl_grid_type * grid , int global_index) {
   const ecl_cell_type * cell = ecl_grid_get_cell( grid , global_index);
   return cell->nnc_info;
 }
 
-
-
 const nnc_info_type * ecl_grid_get_cell_nnc_info3( const ecl_grid_type * grid , int i , int j , int k) {
   const int global_index = ecl_grid_get_global_index3(grid , i,j,k);
   return ecl_grid_get_cell_nnc_info1(grid, global_index);
 }
-
 
 
 /*****************************************************************/

--- a/devel/libecl/src/ecl_grid.c
+++ b/devel/libecl/src/ecl_grid.c
@@ -4331,6 +4331,13 @@ double ecl_grid_get_cell_dy1( const ecl_grid_type * grid , int global_index ) {
 }
 
 
+double ecl_grid_get_cell_dy3( const ecl_grid_type * grid , int i , int j , int k) {
+  fprintf(stderr , "** WARNING: The ecl_grid_get_cell_dy1() function is only a stub returning -1.\n");
+  fprintf(stderr , "            If you need a correct value for cell dy you must update rebuild a new ert version.\n");
+  return ecl_grid_get_cell_dy1( grid , global_index );
+}
+
+
 
 const nnc_info_type * ecl_grid_get_cell_nnc_info1( const ecl_grid_type * grid , int global_index) {
   const ecl_cell_type * cell = ecl_grid_get_cell( grid , global_index);


### PR DESCRIPTION
opm-parser development will in the immediate future need functions `ecl_grid_get_cell_dx()`. The stubs are inserted here just to make sure that the 2015.10 release of ert will continue to *build* with development versions of opm-parser also after the release.

