### PR TITLE
ERT-904: Possibility to add local obs nodes without time step range

### DIFF
--- a/devel/libenkf/include/ert/enkf/local_obsdata_node.h
+++ b/devel/libenkf/include/ert/enkf/local_obsdata_node.h
@@ -43,6 +43,7 @@ extern "C" {
   bool                        local_obsdata_node_all_timestep_active( const local_obsdata_node_type * node);
   bool                        local_obsdata_node_has_tstep( const local_obsdata_node_type * node , int tstep);
   void                        local_obsdata_node_reset_tstep_list( local_obsdata_node_type * node , const int_vector_type * step_list);
+  void                        local_obsdata_node_set_all_timestep_active( local_obsdata_node_type * node, bool flag);
 
   UTIL_IS_INSTANCE_HEADER( local_obsdata_node );
   UTIL_SAFE_CAST_HEADER( local_obsdata_node );

--- a/devel/libenkf/src/local_obsdata_node.c
+++ b/devel/libenkf/src/local_obsdata_node.c
@@ -164,3 +164,7 @@ void local_obsdata_node_add_range( local_obsdata_node_type * node, int step1 , i
   for (tstep = step1; tstep <= step2; tstep++)
     local_obsdata_node_add_tstep( node , tstep );
 }
+
+void local_obsdata_node_set_all_timestep_active( local_obsdata_node_type * node, bool flag) {
+ node->all_timestep_active = flag;
+}

--- a/devel/python/python/ert/enkf/local_obsdata.py
+++ b/devel/python/python/ert/enkf/local_obsdata.py
@@ -1,5 +1,6 @@
 from ert.cwrap import BaseCClass, CWrapper
 from ert.enkf import ENKF_LIB, LocalObsdataNode 
+from sphinx.util import nodes
 
 
 class LocalObsdata(BaseCClass):
@@ -74,31 +75,31 @@ object as:
         else:
             raise KeyError("Unknown key:%s" % key)                
     
-    def addNode(self, key):           
+    def addNode(self, key, add_all_timesteps = False):
+        """ @rtype: LocalObsdataNode """           
         assert isinstance(key, str)
         if key in self.obs:
             node = LocalObsdataNode(key) 
             if node not in self:
                 node.convertToCReference(self)
+                node.setAllTimeStepActive( add_all_timesteps )
                 LocalObsdata.cNamespace().add_node(self, node)
+                return node
             else:
                 raise KeyError("Tried to add existing observation key:%s " % key)
-                return False
         else:
             raise KeyError("The observation node: %s is not recognized observation key" % key)
-            return False
-        
-        # No time step list defined
-        self[key].setAllTimeStepActive(False)
-        return True
 
-    def addNodeAndRange(self, key, step_1, step_2):        
+
+    def addNodeAndRange(self, key, step_1, step_2):
+        """ @rtype: LocalObsdataNode """        
         """ The time range will be removed in the future... """
         assert isinstance(key, str)
         assert isinstance(step_1, int)
         assert isinstance(step_2, int)                     
-        if self.addNode( key ):
-            self[key].addRange(step_1, step_2)
+        node = self.addNode( key )
+        node.addRange(step_1, step_2)
+        return node
 
     
     def clear(self):        

--- a/devel/python/python/ert/enkf/local_obsdata.py
+++ b/devel/python/python/ert/enkf/local_obsdata.py
@@ -107,7 +107,7 @@ object as:
 
         
     def addObsVector(self , obs_vector):
-        self.addNode( obs_vector.createLocalObs() )
+        self.addNode( obs_vector.createLocalObs().getKey() )
 
         
     def getName(self):

--- a/devel/python/python/ert/enkf/local_obsdata.py
+++ b/devel/python/python/ert/enkf/local_obsdata.py
@@ -74,25 +74,31 @@ object as:
         else:
             raise KeyError("Unknown key:%s" % key)                
     
-    def addNode(self, node):        
-        assert isinstance(node, LocalObsdataNode)
-        if node.getKey() in self.obs:
+    def addNode(self, key):           
+        assert isinstance(key, str)
+        if key in self.obs:
+            node = LocalObsdataNode(key) 
             if node not in self:
                 node.convertToCReference(self)
                 LocalObsdata.cNamespace().add_node(self, node)
             else:
-                raise KeyError("Tried to add existing observation key:%s " % node.getKey())
-            
+                raise KeyError("Tried to add existing observation key:%s " % key)
+                return False
         else:
-            raise KeyError("The observation node: %s is not recognized observation key" % node.getKey())
+            raise KeyError("The observation node: %s is not recognized observation key" % key)
+            return False
+        
+        # No time step list defined
+        self[key].setAllTimeStepActive(False)
+        return True
 
-    def addNodeAndRange(self, key, step_1, step_2):
+    def addNodeAndRange(self, key, step_1, step_2):        
+        """ The time range will be removed in the future... """
         assert isinstance(key, str)
         assert isinstance(step_1, int)
-        assert isinstance(step_2, int)        
-        node = LocalObsdataNode(key)                
-        self.addNode( node )
-        node.addRange(step_1, step_2)
+        assert isinstance(step_2, int)                     
+        if self.addNode( key ):
+            self[key].addRange(step_1, step_2)
 
     
     def clear(self):        

--- a/devel/python/python/ert/enkf/local_obsdata_node.py
+++ b/devel/python/python/ert/enkf/local_obsdata_node.py
@@ -38,7 +38,8 @@ class LocalObsdataNode(BaseCClass):
     def allTimeStepActive(self):
         return LocalObsdataNode.cNamespace().all_timestep_active( self )
 
-    
+    def setAllTimeStepActive(self, flag):
+        return LocalObsdataNode.cNamespace().set_all_timestep_active( self, flag )
 
 cwrapper = CWrapper(ENKF_LIB)
 cwrapper.registerObjectType("local_obsdata_node", LocalObsdataNode)
@@ -51,5 +52,6 @@ LocalObsdataNode.cNamespace().add_step         = cwrapper.prototype("void local_
 LocalObsdataNode.cNamespace().get_step_list    = cwrapper.prototype("int_vector_ref local_obsdata_node_get_tstep_list(local_obsdata_node)")
 LocalObsdataNode.cNamespace().get_active_list  = cwrapper.prototype("active_list_ref local_obsdata_node_get_active_list(local_obsdata_node)")
 LocalObsdataNode.cNamespace().all_timestep_active  = cwrapper.prototype("bool local_obsdata_node_all_timestep_active(local_obsdata_node)")
+LocalObsdataNode.cNamespace().set_all_timestep_active  = cwrapper.prototype("void local_obsdata_node_set_all_timestep_active(local_obsdata_node, bool)")
 
 

--- a/devel/python/tests/ert/enkf/test_enkf_obs.py
+++ b/devel/python/tests/ert/enkf/test_enkf_obs.py
@@ -35,8 +35,8 @@ class EnKFObsTest(ExtendedTestCase):
             node1.addRange( 50 , 50 )
             node2 = LocalObsdataNode( "WWCT:OP_1_50" )
             node2.addRange( 50 , 50 )
-            local_obsdata.addNode( node1 )
-            local_obsdata.addNode( node2 )
+            local_obsdata.addNode( node1.getKey() )
+            local_obsdata.addNode( node2.getKey() )
 
             mask = BoolVector( default_value = True )
             mask[2] = True

--- a/devel/python/tests/ert/enkf/test_local_config.py
+++ b/devel/python/tests/ert/enkf/test_local_config.py
@@ -113,6 +113,9 @@ class LocalConfigTest(ExtendedTestCase):
         data_scale_get = ministep["DATA_SCALE"]
         self.assertTrue( "PERLIN_PARAM" in data_scale_get )
 
+        # Error when adding existing data node
+        with self.assertRaises(KeyError):
+            data_scale.addNode("PERLIN_PARAM")
         
 
         
@@ -123,6 +126,7 @@ class LocalConfigTest(ExtendedTestCase):
         local_obs_data_1 = local_config.createObsdata("OBSSET_1") 
         self.assertTrue(isinstance(local_obs_data_1, LocalObsdata))
 
+        # Add node with range
         with self.assertRaises(KeyError):
             local_obs_data_1.addNodeAndRange("MISSING_KEY" , 0 , 1 )
             
@@ -139,6 +143,13 @@ class LocalConfigTest(ExtendedTestCase):
         node = local_obs_data_1["GEN_PERLIN_2"]
         self.assertTrue(isinstance(node, LocalObsdataNode))
 
+        # Add node again with no range and check return type
+        node_again = local_obs_data_1.addNode("GEN_PERLIN_1")
+        self.assertTrue(isinstance(node_again, LocalObsdataNode))
+        
+        # Error when adding existing obs node
+        with self.assertRaises(KeyError):
+            local_obs_data_1.addNode("GEN_PERLIN_1")
 
             
     def AttachObsData( self , local_config):          


### PR DESCRIPTION
The time range in local obs nodes is currently overridden by the input time steps for ES methods. 

Moving away from iterative methods imply that addNodeAndRange() will be discontinued. 

I propose this 'forward compatibility fix' to create nodes with addNode with no time step list specification. 

This is to simplify the localization setup by removing the already unused ranges.

