### PR TITLE
Improved class EclRestartFile

### DIFF
--- a/devel/libecl/include/ert/ecl/ecl_rsthead.h
+++ b/devel/libecl/include/ert/ecl/ecl_rsthead.h
@@ -77,6 +77,7 @@ extern "C" {
 
 
   void                ecl_rsthead_free( ecl_rsthead_type * rsthead );
+  ecl_rsthead_type  * ecl_rsthead_alloc_from_kw( const ecl_kw_type * intehead_kw , const ecl_kw_type * doubhead_kw , const ecl_kw_type * logihead_kw );
   ecl_rsthead_type  * ecl_rsthead_ialloc( const ecl_file_type * rst_file , int occurence);
   ecl_rsthead_type  * ecl_rsthead_alloc( const ecl_file_type * rst_file );
   ecl_rsthead_type  * ecl_rsthead_alloc_empty();

--- a/devel/libecl/include/ert/ecl/ecl_rsthead.h
+++ b/devel/libecl/include/ert/ecl/ecl_rsthead.h
@@ -30,6 +30,9 @@ extern "C" {
 
 
   typedef struct {
+    // The report step is from the SEQNUM keyword for unified files,
+    // and inferred from the filename for non unified files.
+    int    report_step;
     int    day;
     int    year;
     int    month;
@@ -77,7 +80,7 @@ extern "C" {
 
 
   void                ecl_rsthead_free( ecl_rsthead_type * rsthead );
-  ecl_rsthead_type  * ecl_rsthead_alloc_from_kw( const ecl_kw_type * intehead_kw , const ecl_kw_type * doubhead_kw , const ecl_kw_type * logihead_kw );
+  ecl_rsthead_type  * ecl_rsthead_alloc_from_kw( int report_step , const ecl_kw_type * intehead_kw , const ecl_kw_type * doubhead_kw , const ecl_kw_type * logihead_kw );
   ecl_rsthead_type  * ecl_rsthead_ialloc( const ecl_file_type * rst_file , int occurence);
   ecl_rsthead_type  * ecl_rsthead_alloc( const ecl_file_type * rst_file );
   ecl_rsthead_type  * ecl_rsthead_alloc_empty();
@@ -86,6 +89,8 @@ extern "C" {
   void                ecl_rsthead_fprintf_struct( const ecl_rsthead_type * header , FILE * stream);
   bool                ecl_rsthead_equal( const ecl_rsthead_type * header1 , const ecl_rsthead_type * header2);
   double              ecl_rsthead_get_sim_days( const ecl_rsthead_type * header );
+  int                 ecl_rsthead_get_report_step( const ecl_rsthead_type * header );
+  time_t              ecl_rsthead_get_sim_time( const ecl_rsthead_type * header );
 
 #ifdef __cplusplus
 }

--- a/devel/libecl/src/ecl_rsthead.c
+++ b/devel/libecl/src/ecl_rsthead.c
@@ -37,17 +37,25 @@ time_t ecl_rsthead_date( const ecl_kw_type * intehead_kw ) {
 }
 
 
+time_t ecl_rsthead_get_sim_time( const ecl_rsthead_type * header ) {
+  return header->sim_time;
+}
+
 double ecl_rsthead_get_sim_days( const ecl_rsthead_type * header ) {
   return header->sim_days;
 }
 
 
+int ecl_rsthead_get_report_step( const ecl_rsthead_type * header ) {
+  return header->report_step;
+}
 
 
 
 
-ecl_rsthead_type * ecl_rsthead_alloc_from_kw( const ecl_kw_type * intehead_kw , const ecl_kw_type * doubhead_kw , const ecl_kw_type * logihead_kw ) {
+ecl_rsthead_type * ecl_rsthead_alloc_from_kw( int report_step , const ecl_kw_type * intehead_kw , const ecl_kw_type * doubhead_kw , const ecl_kw_type * logihead_kw ) {
   ecl_rsthead_type * rsthead = util_malloc( sizeof * rsthead );
+  rsthead->report_step = report_step;
   {
       const int * data = (const int *) ecl_kw_get_void_ptr( intehead_kw );
 
@@ -91,10 +99,17 @@ ecl_rsthead_type * ecl_rsthead_alloc_from_kw( const ecl_kw_type * intehead_kw , 
     const ecl_kw_type * intehead_kw = ecl_file_iget_named_kw( rst_file , INTEHEAD_KW , occurence);
     const ecl_kw_type * doubhead_kw = ecl_file_iget_named_kw( rst_file , DOUBHEAD_KW , occurence);
     const ecl_kw_type * logihead_kw = NULL;
+    int report_step;
     if (ecl_file_get_num_named_kw(rst_file, LOGIHEAD_KW) > occurence)
       logihead_kw = ecl_file_iget_named_kw( rst_file , LOGIHEAD_KW , occurence);
 
-    return ecl_rsthead_alloc_from_kw( intehead_kw , doubhead_kw , logihead_kw );
+    if (ecl_file_get_num_named_kw( rst_file , SEQNUM_KW) > occurence) {
+      const ecl_kw_type * seqnum_kw = ecl_file_iget_named_kw( rst_file , SEQNUM_KW , occurence );
+      report_step = ecl_kw_iget_int( seqnum_kw , 0);
+    } else
+      ecl_util_get_file_type( ecl_file_get_src_file(rst_file) , NULL , &report_step);
+
+    return ecl_rsthead_alloc_from_kw( report_step , intehead_kw , doubhead_kw , logihead_kw );
   } else
     return NULL;
 }

--- a/devel/libecl/src/ecl_rsthead.c
+++ b/devel/libecl/src/ecl_rsthead.c
@@ -43,14 +43,12 @@ double ecl_rsthead_get_sim_days( const ecl_rsthead_type * header ) {
 
 
 
-ecl_rsthead_type * ecl_rsthead_ialloc( const ecl_file_type * rst_file , int occurence) {
-  if (ecl_file_get_num_named_kw( rst_file , INTEHEAD_KW) > occurence) {
-    const ecl_kw_type * intehead_kw = ecl_file_iget_named_kw( rst_file , INTEHEAD_KW , occurence);
-    const ecl_kw_type * doubhead_kw = ecl_file_iget_named_kw( rst_file , DOUBHEAD_KW , occurence);
 
-    ecl_rsthead_type * rsthead = util_malloc( sizeof * rsthead );
 
-    {
+
+ecl_rsthead_type * ecl_rsthead_alloc_from_kw( const ecl_kw_type * intehead_kw , const ecl_kw_type * doubhead_kw , const ecl_kw_type * logihead_kw ) {
+  ecl_rsthead_type * rsthead = util_malloc( sizeof * rsthead );
+  {
       const int * data = (const int *) ecl_kw_get_void_ptr( intehead_kw );
 
       rsthead->day       = data[INTEHEAD_DAY_INDEX];
@@ -79,24 +77,34 @@ ecl_rsthead_type * ecl_rsthead_ialloc( const ecl_file_type * rst_file , int occu
 
       // The only derived quantity
       rsthead->sim_time  = rsthead_date( rsthead->day , rsthead->month , rsthead->year );
-    }
-    rsthead->sim_days = ecl_kw_iget_double( doubhead_kw , DOUBHEAD_DAYS_INDEX );
-    if (ecl_file_get_num_named_kw(rst_file, LOGIHEAD_KW) > occurence) {
-      const ecl_kw_type * logihead_kw = ecl_file_iget_named_kw( rst_file , LOGIHEAD_KW , occurence);
-      rsthead->dualp    = ecl_kw_iget_bool( logihead_kw , LOGIHEAD_DUALP_INDEX);
-    } else
-      rsthead->dualp    = false;
+  }
+  rsthead->sim_days = ecl_kw_iget_double( doubhead_kw , DOUBHEAD_DAYS_INDEX );
+  if (logihead_kw)
+    rsthead->dualp    = ecl_kw_iget_bool( logihead_kw , LOGIHEAD_DUALP_INDEX);
+
+  return rsthead;
+}
 
 
-    return rsthead;
+ ecl_rsthead_type * ecl_rsthead_ialloc( const ecl_file_type * rst_file , int occurence) {
+  if (ecl_file_get_num_named_kw( rst_file , INTEHEAD_KW) > occurence) {
+    const ecl_kw_type * intehead_kw = ecl_file_iget_named_kw( rst_file , INTEHEAD_KW , occurence);
+    const ecl_kw_type * doubhead_kw = ecl_file_iget_named_kw( rst_file , DOUBHEAD_KW , occurence);
+    const ecl_kw_type * logihead_kw = NULL;
+    if (ecl_file_get_num_named_kw(rst_file, LOGIHEAD_KW) > occurence)
+      logihead_kw = ecl_file_iget_named_kw( rst_file , LOGIHEAD_KW , occurence);
+
+    return ecl_rsthead_alloc_from_kw( intehead_kw , doubhead_kw , logihead_kw );
   } else
     return NULL;
 }
 
 
+
 ecl_rsthead_type * ecl_rsthead_alloc( const ecl_file_type * rst_file) {
   return ecl_rsthead_ialloc( rst_file , 0 );
 }
+
 
 
 ecl_rsthead_type * ecl_rsthead_alloc_empty() {

--- a/devel/libecl/tests/ecl_rsthead.c
+++ b/devel/libecl/tests/ecl_rsthead.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'ecl_rst_header.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'ecl_rst_header.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -30,13 +30,13 @@
 void test_file( const char * filename , int occurence , bool exists , const ecl_rsthead_type * true_header) {
   ecl_file_type * rst_file = ecl_file_open( filename , 0);
   ecl_rsthead_type * rst_head = ecl_rsthead_ialloc( rst_file , occurence);
-  
+
   if (exists) {
     test_assert_not_NULL( rst_head );
-    
+
     if (occurence == 0) {
       ecl_rsthead_type * rst_head0 = ecl_rsthead_alloc( rst_file );
-      
+
       test_assert_true( ecl_rsthead_equal( rst_head , rst_head0 ));
       ecl_rsthead_free( rst_head0 );
     }
@@ -45,7 +45,7 @@ void test_file( const char * filename , int occurence , bool exists , const ecl_
     ecl_rsthead_free( rst_head );
   } else
     test_assert_NULL( rst_head );
-  
+
 }
 
 
@@ -72,7 +72,7 @@ int main(int argc , char ** argv) {
                             .nilbrz = -1,
                             .dualp  = 0,
                             .sim_days  = 0};
-  
+
   ecl_rsthead_type true2 = {.day = 22,
                             .year = 1990,
                             .month = 1,
@@ -95,14 +95,14 @@ int main(int argc , char ** argv) {
                             .nilbrz = -1,
                             .dualp  = 1,
                             .sim_days  = 21};
-  
+
   const char * unified_file = argv[1];
   const char * Xfile        = argv[2];
 
-  
+
   test_file( unified_file , 0 , true , &true1 );
   test_file( unified_file , 100 , false , NULL );
   test_file( Xfile , 0 , true , &true2 );
-  
+
   exit(0);
 }

--- a/devel/libecl/tests/ecl_rsthead.c
+++ b/devel/libecl/tests/ecl_rsthead.c
@@ -50,7 +50,8 @@ void test_file( const char * filename , int occurence , bool exists , const ecl_
 
 
 int main(int argc , char ** argv) {
-  ecl_rsthead_type true1 = {.day = 1,
+  ecl_rsthead_type true1 = {.report_step = 1,
+                            .day = 1,
                             .year = 2000,
                             .month = 1,
                             .sim_time = (time_t) 946681200,
@@ -73,7 +74,8 @@ int main(int argc , char ** argv) {
                             .dualp  = 0,
                             .sim_days  = 0};
 
-  ecl_rsthead_type true2 = {.day = 22,
+  ecl_rsthead_type true2 = {.report_step = 5,
+                            .day = 22,
                             .year = 1990,
                             .month = 1,
                             .sim_time = (time_t) 632962800,

--- a/devel/python/python/ert/ecl/ecl_file.py
+++ b/devel/python/python/ert/ecl/ecl_file.py
@@ -659,6 +659,12 @@ class EclFile(CClass):
         else:
             return False
 
+    def __contains__(self , kw):
+        """
+        Check if the current file contains keyword @kw.
+        """
+        return self.has_kw( kw )
+
     def has_report_step( self , report_step ):
         """
         Checks if the current EclFile has report step @report_step.

--- a/devel/python/python/ert/ecl/ecl_file.py
+++ b/devel/python/python/ert/ecl/ecl_file.py
@@ -38,6 +38,8 @@ implementation from the libecl library.
 import re
 import types
 import datetime
+import ctypes
+import warnings
 from ert.cwrap import CClass, CWrapper, CWrapperNameSpace
 from ert.ecl import EclKW, ECL_LIB
 from ert.util import CTime
@@ -140,7 +142,7 @@ class EclFile(CClass):
             # OK - we did not have seqnum; that might be because this
             # a non-unified restart file; or because this is not a
             # restart file at all.
-            fname = self.name
+            fname = self.getFilename( )
             matchObj = re.search("\.[XF](\d{4})$" , fname)
             if matchObj:
                 report_steps.append( int(matchObj.group(1)) )
@@ -164,7 +166,7 @@ class EclFile(CClass):
         
 
     def __str__(self):
-        return "EclFile: %s" % self.name
+        return "EclFile: %s" % self.getFilename( )
 
         
     def __init__( self , filename , flags = 0):
@@ -224,7 +226,7 @@ class EclFile(CClass):
         if cfunc.writable( self ):
             cfunc.save_kw( self , kw )
         else:
-            raise IOError("save_kw: the file:%s has been opened read only." % self.name)
+            raise IOError("save_kw: the file:%s has been opened read only." % self.getFilename( ))
         
 
     def __len__(self):
@@ -690,14 +692,20 @@ class EclFile(CClass):
         
         """
         return cfunc.iget_restart_days( self , index ) 
-    
 
-    @property
-    def name(self):
+
+    def getFilename(self):
         """
         Name of the file currently loaded.
         """
         return cfunc.get_src_file( self )
+    
+
+    @property
+    def name(self):
+        warnings.warn("The name property is deprecated - use getFilename( )")
+        return self.getFilename()
+
     
     def fwrite( self , fortio ):
         """

--- a/devel/python/python/ert/ecl/ecl_file.py
+++ b/devel/python/python/ert/ecl/ecl_file.py
@@ -41,11 +41,32 @@ import datetime
 import ctypes
 import warnings
 from ert.cwrap import CClass, CWrapper, CWrapperNameSpace
-from ert.ecl import EclKW, ECL_LIB
+from ert.ecl import ECL_LIB, EclKW, EclFileEnum
 from ert.util import CTime
 
 
 class EclFile(CClass):
+
+    @staticmethod
+    def getFileType(filename):
+        fmt_file    = ctypes.c_bool()
+        report_step = ctypes.c_int()
+
+        file_type = cfunc.get_file_type( filename , ctypes.byref( fmt_file ) , ctypes.byref(report_step)) 
+        if file_type in [EclFileEnum.ECL_RESTART_FILE , EclFileEnum.ECL_SUMMARY_FILE]:
+            report_step = report_step.value
+        else:
+            report_step = None
+
+        if file_type in [EclFileEnum.ECL_OTHER_FILE , EclFileEnum.ECL_DATA_FILE]:
+            fmt_file = None
+        else:
+            fmt_file = fmt_file.value
+
+
+        return (file_type , report_step , fmt_file )
+
+    
 
     @classmethod
     def restart_block( cls , filename , dtime = None , report_step = None):
@@ -782,5 +803,6 @@ cfunc.fwrite                      = cwrapper.prototype("void        ecl_file_fwr
 cfunc.has_instance                = cwrapper.prototype("bool        ecl_file_has_kw_ptr(ecl_file , ecl_kw)")
 cfunc.has_report_step             = cwrapper.prototype("bool        ecl_file_has_report_step( ecl_file , int)")
 cfunc.has_sim_time                = cwrapper.prototype("bool        ecl_file_has_sim_time( ecl_file , time_t )")
+cfunc.get_file_type               = cwrapper.prototype("ecl_file_enum ecl_util_get_file_type( char* , bool* , int*)")
 
 

--- a/devel/python/python/ert/ecl/ecl_init_file.py
+++ b/devel/python/python/ert/ecl/ecl_init_file.py
@@ -14,8 +14,16 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details. 
 
-from ert.ecl import EclFile, Ecl3DKW , Ecl3DFile
+from ert.ecl import EclFileEnum , EclFile, Ecl3DKW , Ecl3DFile
 
 
 class EclInitFile(Ecl3DFile):
-    pass        
+    def __init__(self , grid , filename , flags = 0):
+        file_type , report_step , fmt_file = EclFile.getFileType( filename )
+        if file_type == EclFileEnum.ECL_INIT_FILE:
+            super(EclInitFile , self).__init__( grid, filename , flags)
+        else:
+            raise ValueError("The input filename:%s does not correspond to a restart file - please follow the Eclipse naming conventions" % filename)
+            
+
+

--- a/devel/python/python/ert/ecl/ecl_restart_file.py
+++ b/devel/python/python/ert/ecl/ecl_restart_file.py
@@ -15,7 +15,7 @@
 #  for more details. 
 
 from ert.util import CTime
-from ert.ecl import ECL_LIB , EclFile, Ecl3DKW , Ecl3DFile
+from ert.ecl import ECL_LIB , EclFile, Ecl3DKW , Ecl3DFile, EclFileEnum
 from ert.cwrap import CWrapper, BaseCClass
 
 class EclRestartHead(BaseCClass):
@@ -51,17 +51,37 @@ class EclRestartHead(BaseCClass):
 class EclRestartFile(Ecl3DFile):
     
     def __init__(self , grid , filename , flags = 0):
+        """Will open an Eclipse restart file.
+
+        The EclRestartFile class will open an eclipse restart file, in
+        unified or non unified format. The constructor will infer the
+        file type based on the filename, and will raise a ValueError
+        exception if the file type is not ECL_RESTART_FILE or
+        ECL_UNIFIED_RESTART_FILE.
+
+        The EclRestartFile will use a grid reference to create Ecl3DKw
+        instances for all the keyword elements which have either
+        'nactive' or 'nx*ny*nz' elements.
+        """
+
+        file_type , report_step , fmt_file = EclFile.getFileType( filename )
+        if not file_type in [EclFileEnum.ECL_RESTART_FILE, EclFileEnum.ECL_UNIFIED_RESTART_FILE]:
+            raise ValueError("The input filename:%s does not correspond to a restart file - please follow the Eclipse naming conventions" % filename)
+            
         super(EclRestartFile , self).__init__( grid, filename , flags)
         self.rst_headers = None
-
-        if "SEQNUM" in self:
-            self.is_unified = True
-        else:
+        if file_type == EclFileEnum.ECL_RESTART_FILE:
             self.is_unified = False
+            self.report_step = report_step
+        else:
+            self.is_unified = True
 
         
         
     def unified(self):
+        """
+        Will return True if the file we have opened is unified. 
+        """
         return self.is_unified
 
     
@@ -72,7 +92,6 @@ class EclRestartFile(Ecl3DFile):
                 for index in range(self.num_named_kw("SEQNUM")):
                     self.rst_headers.append( EclRestartHead( rst_arg = (self , index )))
             else:
-                file_type , report_step , name = EclFile.getFileType( self.getFilename() )
                 intehead_kw = self["INTEHEAD"][0]
                 doubhead_kw = self["DOUBHEAD"][0]
                 if "LOGIHEAD" in self:
@@ -80,10 +99,22 @@ class EclRestartFile(Ecl3DFile):
                 else:
                     logihead_kw = None
 
-                self.rst_headers.append( EclRestartHead( kw_arg = (report_step , intehead_kw , doubhead_kw , logihead_kw) ))
+                self.rst_headers.append( EclRestartHead( kw_arg = (self.report_step , intehead_kw , doubhead_kw , logihead_kw) ))
                 
             
     def timeList(self):
+        """Will return a list of report_step, simulation time and days.
+
+        The return value will be a list tuples. For a unified restart
+        file with the three report steps {10,15,20} it can look like:
+
+           [  (10, datetime.datetime( 2010 , 1 , 1 , 0 , 0 , 0 ) , 100.0),
+              (15, datetime.datetime( 2010 , 3 , 1 , 0 , 0 , 0 ) , 160.0),
+              (20, datetime.datetime( 2010 , 5 , 1 , 0 , 0 , 0 ) , 220.0) ]
+
+        For a non-unified restart file the list will have only one element.
+        """
+
         self.assertHeaders()
         time_list = []
         for header in self.rst_headers:
@@ -102,4 +133,3 @@ EclRestartHead.cNamespace().free            = cwrapper.prototype("void ecl_rsthe
 EclRestartHead.cNamespace().get_report_step = cwrapper.prototype("int ecl_rsthead_get_report_step(ecl_rsthead)")
 EclRestartHead.cNamespace().get_sim_time    = cwrapper.prototype("time_t ecl_rsthead_get_sim_time(ecl_rsthead)")
 EclRestartHead.cNamespace().get_sim_days    = cwrapper.prototype("double ecl_rsthead_get_sim_days(ecl_rsthead)")
-            

--- a/devel/python/python/ert/ecl/ecl_restart_file.py
+++ b/devel/python/python/ert/ecl/ecl_restart_file.py
@@ -1,6 +1,6 @@
 #  Copyright (C) 2015  Statoil ASA, Norway. 
 #   
-#  The file 'ecl_init_file.py' is part of ERT - Ensemble based Reservoir Tool. 
+#  The file 'ecl_restart_file.py' is part of ERT - Ensemble based Reservoir Tool. 
 #   
 #  ERT is free software: you can redistribute it and/or modify 
 #  it under the terms of the GNU General Public License as published by 
@@ -14,8 +14,92 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details. 
 
-from ert.ecl import EclFile, Ecl3DKW , Ecl3DFile
+from ert.util import CTime
+from ert.ecl import ECL_LIB , EclFile, Ecl3DKW , Ecl3DFile
+from ert.cwrap import CWrapper, BaseCClass
 
+class EclRestartHead(BaseCClass):
+    def __init__(self , kw_arg = None , rst_arg = None):
+        if kw_arg is None and rst_arg is None:
+            raise Exception("Invalid arguments")
+
+        if not kw_arg is None:
+            report_step , intehead_kw , doubhead_kw , logihead_kw = kw_arg
+            c_ptr = EclRestartHead.cNamespace().alloc_from_kw( report_step , intehead_kw , doubhead_kw , logihead_kw )
+        else:
+            rst_file , occurence = rst_arg
+            c_ptr = EclRestartHead.cNamespace().alloc( rst_file , occurence )
+
+        super(EclRestartHead, self).__init__(c_ptr)
+
+        
+    def free(self):
+        EclRestartHead.cNamespace().free( self )
+
+    def getReportStep(self):
+        return EclRestartHead.cNamespace().get_report_step( self )
+
+    def getSimDate(self):
+        ct = CTime( EclRestartHead.cNamespace().get_sim_time( self ) )
+        return ct.datetime( )
+
+    def getSimDays(self):
+        return EclRestartHead.cNamespace().get_sim_days( self )
+        
+        
 
 class EclRestartFile(Ecl3DFile):
-    pass        
+    
+    def __init__(self , grid , filename , flags = 0):
+        super(EclRestartFile , self).__init__( grid, filename , flags)
+        self.rst_headers = None
+
+        if "SEQNUM" in self:
+            self.is_unified = True
+        else:
+            self.is_unified = False
+
+        
+        
+    def unified(self):
+        return self.is_unified
+
+    
+    def assertHeaders(self):
+        if self.rst_headers is None:
+            self.rst_headers = []
+            if self.unified():
+                for index in range(self.num_named_kw("SEQNUM")):
+                    self.rst_headers.append( EclRestartHead( rst_arg = (self , index )))
+            else:
+                file_type , report_step , name = EclFile.getFileType( self.getFilename() )
+                intehead_kw = self["INTEHEAD"][0]
+                doubhead_kw = self["DOUBHEAD"][0]
+                if "LOGIHEAD" in self:
+                    logihead_kw = self["LOGIHEAD"][0]
+                else:
+                    logihead_kw = None
+
+                self.rst_headers.append( EclRestartHead( kw_arg = (report_step , intehead_kw , doubhead_kw , logihead_kw) ))
+                
+            
+    def timeList(self):
+        self.assertHeaders()
+        time_list = []
+        for header in self.rst_headers:
+            time_list.append( (header.getReportStep() , header.getSimDate( ) , header.getSimDays( )) )
+
+        return time_list
+
+    
+
+            
+CWrapper.registerObjectType("ecl_rsthead", EclRestartHead)
+cwrapper = CWrapper(ECL_LIB)
+EclRestartHead.cNamespace().alloc           = cwrapper.prototype("c_void_p ecl_rsthead_ialloc(ecl_file , int )")
+EclRestartHead.cNamespace().alloc_from_kw   = cwrapper.prototype("c_void_p ecl_rsthead_alloc_from_kw(int , ecl_kw , ecl_kw , ecl_kw )")
+EclRestartHead.cNamespace().free            = cwrapper.prototype("void ecl_rsthead_free(ecl_rsthead)")
+EclRestartHead.cNamespace().get_report_step = cwrapper.prototype("int ecl_rsthead_get_report_step(ecl_rsthead)")
+EclRestartHead.cNamespace().get_sim_time    = cwrapper.prototype("time_t ecl_rsthead_get_sim_time(ecl_rsthead)")
+EclRestartHead.cNamespace().get_sim_days    = cwrapper.prototype("double ecl_rsthead_get_sim_days(ecl_rsthead)")
+            

--- a/devel/python/tests/core/ecl/test_deprecation.py
+++ b/devel/python/tests/core/ecl/test_deprecation.py
@@ -17,8 +17,8 @@
 import warnings
 import time
 
-from ert.test import ExtendedTestCase
-from ert.ecl import EclGrid,EclKW,EclTypeEnum,EclGrid,EclRegion
+from ert.test import ExtendedTestCase, TestAreaContext
+from ert.ecl import EclFile,EclGrid,EclKW,EclTypeEnum,EclGrid,EclRegion,FortIO, openFortIO
 from ert.util import BoolVector
 
 
@@ -47,6 +47,16 @@ class DeprecationTest(ExtendedTestCase):
             grid = EclGrid.create_rectangular( (10,20,30) , (1,1,1) )
 
 
+    # Addded in 1.9.x development
+    def test_EclFile_name_property(self):
+        with TestAreaContext("name"):
+            kw = EclKW.new("TEST", 3, EclTypeEnum.ECL_INT_TYPE)
+            with openFortIO("TEST" , mode = FortIO.WRITE_MODE) as f:
+                kw.fwrite( f )
+
+            f = EclFile( "TEST" )
+            with warnings.catch_warnings():
+                name = f.name
 
 
     # Added in 1.8.x development

--- a/devel/python/tests/core/ecl/test_ecl_file.py
+++ b/devel/python/tests/core/ecl/test_ecl_file.py
@@ -19,17 +19,35 @@ import os.path
 from unittest import skipIf
 
 from ert.ecl import EclFile, FortIO, EclKW , openFortIO , openEclFile
-from ert.ecl import EclFileFlagEnum, EclTypeEnum
+from ert.ecl import EclFileFlagEnum, EclTypeEnum, EclFileEnum
 
 from ert.test import ExtendedTestCase , TestAreaContext
 
+
+    
 
 class EclFileTest(ExtendedTestCase):
     def setUp(self):
         self.test_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.UNRST")
         self.test_fmt_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.FUNRST")
 
-    
+    def assertFileType(self , filename , expected):
+        file_type , step , fmt_file = EclFile.getFileType(filename)
+        self.assertEqual( file_type , expected[0] )
+        self.assertEqual( fmt_file , expected[1] )
+        self.assertEqual( step , expected[2] )
+
+        
+        
+    def test_file_type(self):
+        self.assertFileType( "ECLIPSE.UNRST" , (EclFileEnum.ECL_UNIFIED_RESTART_FILE , False , None))
+        self.assertFileType( "ECLIPSE.X0030" , (EclFileEnum.ECL_RESTART_FILE , False , 30 ))
+        self.assertFileType( "ECLIPSE.DATA" , (EclFileEnum.ECL_DATA_FILE , None , None ))
+        self.assertFileType( "ECLIPSE.FINIT" , (EclFileEnum.ECL_INIT_FILE , True , None ))
+        self.assertFileType( "ECLIPSE.A0010" , (EclFileEnum.ECL_SUMMARY_FILE , True , 10 ))
+        self.assertFileType( "ECLIPSE.EGRID" , (EclFileEnum.ECL_EGRID_FILE , False  , None ))
+
+        
     def test_restart_days(self):
         rst_file = EclFile( self.test_file )
         self.assertAlmostEqual(  0.0 , rst_file.iget_restart_sim_days(0) )

--- a/devel/python/tests/core/ecl/test_ecl_init_file.py
+++ b/devel/python/tests/core/ecl/test_ecl_init_file.py
@@ -22,6 +22,12 @@ class InitFileTest(ExtendedTestCase):
     def setUp(self):
         self.grid_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.EGRID")
         self.init_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.INIT")
+
+        
+    def test_wrong_type(self):
+        g = EclGrid( self.grid_file )
+        with self.assertRaises(ValueError):
+            f = EclInitFile( g , self.grid_file )
         
 
     def test_load(self):

--- a/devel/python/tests/core/ecl/test_ecl_restart_file.py
+++ b/devel/python/tests/core/ecl/test_ecl_restart_file.py
@@ -13,20 +13,23 @@
 #   
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
-
+import datetime
 
 from ert.test import ExtendedTestCase
 from ert.ecl import Ecl3DKW , EclKW, EclTypeEnum, EclRestartFile , EclFile, FortIO, EclFileFlagEnum , EclGrid
 
 class RestartFileTest(ExtendedTestCase):
     def setUp(self):
-        self.grid_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.EGRID")
-        self.rst_file  = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.UNRST")
+        self.grid_file =   self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.EGRID")
+        self.unrst_file   = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.UNRST")
+        self.xrst_file0   = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.X0000")
+        self.xrst_file10  = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.X0010")
+        self.xrst_file20  = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.X0020")
         
 
     def test_load(self):
         g = EclGrid( self.grid_file )
-        f = EclRestartFile( g , self.rst_file )
+        f = EclRestartFile( g , self.unrst_file )
 
         head = f["INTEHEAD"][0]
         self.assertTrue( isinstance( head , EclKW ))
@@ -36,6 +39,23 @@ class RestartFileTest(ExtendedTestCase):
         
         pressure = f["PRESSURE"][0]
         self.assertTrue( isinstance( pressure , Ecl3DKW ))
+
         
+    def test_unified(self):
+        g = EclGrid( self.grid_file )
+        f_unrst = EclRestartFile( g , self.unrst_file )
+        f_x0 = EclRestartFile( g , self.xrst_file0 )
+        f_x10 = EclRestartFile( g , self.xrst_file10 )
+        f_x20 = EclRestartFile( g , self.xrst_file20 )
         
+        self.assertTrue( f_unrst.unified() )
+        self.assertFalse( f_x0.unified() )
+        self.assertFalse( f_x10.unified() )
+        self.assertFalse( f_x20.unified() )
+        
+        self.assertEqual( [(10 , datetime.datetime( 2000 , 10 , 1 , 0 , 0 , 0 ) , 274.0)] , f_x10.timeList())
+
+        unrst_timeList = f_unrst.timeList()
+        self.assertEqual( len(unrst_timeList) , 63 ) 
+        self.assertEqual( (62 , datetime.datetime( 2004 , 12 , 31 , 0 , 0 , 0 ) , 1826.0) , unrst_timeList[62]);
 

--- a/devel/python/tests/core/ecl/test_ecl_restart_file.py
+++ b/devel/python/tests/core/ecl/test_ecl_restart_file.py
@@ -40,7 +40,13 @@ class RestartFileTest(ExtendedTestCase):
         pressure = f["PRESSURE"][0]
         self.assertTrue( isinstance( pressure , Ecl3DKW ))
 
-        
+
+    def test_type(self):
+        g = EclGrid( self.grid_file )
+        with self.assertRaises(ValueError):
+            f = EclRestartFile( g , "NOT_A_RESTART_FILE")
+
+            
     def test_unified(self):
         g = EclGrid( self.grid_file )
         f_unrst = EclRestartFile( g , self.unrst_file )


### PR DESCRIPTION
The main new content in this PR is wrapping of the C class ecl_rsthead - which holds header information from an Eclipse restart file.