### PR TITLE
Fix debian packaging

### DIFF
--- a/devel/debian/control
+++ b/devel/debian/control
@@ -2,7 +2,7 @@ Source: ert.ecl
 Priority: extra
 Maintainer: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
 Build-Depends: debhelper (>= 8.0.0), cmake, liblapack-dev, libquadmath0,
-               iputils-ping, zlib1g-dev, git
+               iputils-ping, zlib1g-dev, git, python-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://ert.nr.no
@@ -22,5 +22,13 @@ Section: libs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: The Ensemble based Reservoir Tool
+ ERT - Ensemble based Reservoir Tool is a tool for managing en ensemble
+ of reservoir models.
+
+Package: python-ert.ecl
+Section: python
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, libert.ecl1
+Description: The Ensemble based Reservoir Tool - Python bindings
  ERT - Ensemble based Reservoir Tool is a tool for managing en ensemble
  of reservoir models.

--- a/devel/debian/python-ert.ecl.install
+++ b/devel/debian/python-ert.ecl.install
@@ -1,0 +1,1 @@
+usr/lib/python2.7/*

--- a/devel/debian/rules
+++ b/devel/debian/rules
@@ -13,4 +13,4 @@
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_SHARED_LIBS=1 -DBUILD_ECL_SUMMARY=1 -DCMAKE_BUILD_TYPE=Release
+	DESTDIR=$$(pwd)/debian/tmp dh_auto_configure -- -DBUILD_SHARED_LIBS=1 -DBUILD_ECL_SUMMARY=1 -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
this caused an empty python binding class and i didn't spot since the file was existing on my local box. thanks to @babrodtk for spotting.

please backport to the 2015.10 release branch.