### PR TITLE
Default verbose info to true from Gert

### DIFF
--- a/devel/python/python/ert/enkf/enkf_main.py
+++ b/devel/python/python/ert/enkf/enkf_main.py
@@ -32,8 +32,8 @@ def stringObj(c_ptr):
     return python_string
 
 class EnKFMain(BaseCClass):
-    def __init__(self, model_config, strict=True):
-        c_ptr = EnKFMain.cNamespace().bootstrap(model_config, strict, False)
+    def __init__(self, model_config, strict = True, verbose = True):
+        c_ptr = EnKFMain.cNamespace().bootstrap(model_config, strict, verbose)
         super(EnKFMain, self).__init__(c_ptr)
 
         # The model_config argument can be None; the only reason to

--- a/devel/python/python/ert_gui/gert_main.py
+++ b/devel/python/python/ert_gui/gert_main.py
@@ -201,6 +201,7 @@ def main(argv):
     help_center.setHelpMessageLink("welcome_to_ert")
 
     strict = True
+    verbose = True
 
     if not os.path.exists(config_file):
         print("Trying to start new config")
@@ -235,7 +236,7 @@ def main(argv):
     now = time.time()
 
 
-    ert = Ert(EnKFMain(config_file, strict=strict))
+    ert = Ert(EnKFMain(config_file, strict=strict, verbose=verbose))
     ErtConnector.setErt(ert.ert())
 
     window = GertMainWindow()


### PR DESCRIPTION
The verbose information is very valuable to detect user errors and interpretation of results. Currently, the enkf->verbose is set to true in .../ert_tui/main.c line 161, for TUI, but not for GUI.

