### PR TITLE
Call ert.util.installAbortSignals() in ert/__init__.py

### DIFF
--- a/devel/libert_util/include/ert/util/util.h
+++ b/devel/libert_util/include/ert/util/util.h
@@ -300,6 +300,7 @@ typedef enum {left_pad   = 0,
   void    util_abort__(const char * file , const char * function , int line , const char * fmt , ...);
 
   void    util_abort_signal(int );
+  void    util_update_signals(void);
   void    util_install_signals(void);
   void    util_abort_append_version_info(const char * );
   void    util_abort_free_version_info();

--- a/devel/libert_util/src/util.c
+++ b/devel/libert_util/src/util.c
@@ -4867,6 +4867,32 @@ void util_install_signals(void) {
   signal(SIGFPE  , util_abort_signal);    /* Floating point exception */
 }
 
+/*
+   Will install the util_abort signal handler for all signals which
+   have not been modified from the default state.
+*/
+
+static void update_signal( int signal_nr ) {
+  sighandler_t current_handler = signal(signal_nr , SIG_DFL);
+  if (current_handler == SIG_DFL)
+    signal( signal_nr , util_abort_signal );
+  else
+    signal( signal_nr , current_handler );
+}
+
+
+
+void util_update_signals(void) {
+#ifdef HAVE_SIGBUS
+  update_signal(SIGBUS );
+#endif
+
+  update_signal(SIGSEGV );
+  update_signal(SIGTERM );
+  update_signal(SIGABRT );
+  update_signal(SIGILL  );
+  update_signal(SIGFPE  );
+}
 
 
 void util_exit(const char * fmt , ...) {

--- a/devel/python/python/ert/__init__.py
+++ b/devel/python/python/ert/__init__.py
@@ -118,3 +118,6 @@ if sys.hexversion < required_version_hex:
 
 
 from ert.util import Version
+from ert.util import updateAbortSignals
+
+updateAbortSignals( )

--- a/devel/python/python/ert/util/__init__.py
+++ b/devel/python/python/ert/util/__init__.py
@@ -74,7 +74,7 @@ from .substitution_list import SubstitutionList
 from .ui_return import UIReturn
 from .thread_pool import ThreadPool
 from .cthread_pool import CThreadPool , startCThreadPool
-from .install_abort_signals import installAbortSignals
+from .install_abort_signals import installAbortSignals, updateAbortSignals
 from .profiler import Profiler
 from .arg_pack import ArgPack
 

--- a/devel/python/python/ert/util/install_abort_signals.py
+++ b/devel/python/python/ert/util/install_abort_signals.py
@@ -4,6 +4,13 @@ from ert.cwrap import CWrapper
 def installAbortSignals():
     install_signals()
 
+
+def updateAbortSignals():
+    """
+    Will install the util_abort_signal for all UNMODIFIED signals.
+    """
+    update_signals()
     
 cwrapper = CWrapper(UTIL_LIB)
 install_signals = cwrapper.prototype("void util_install_signals()")
+update_signals = cwrapper.prototype("void util_update_signals()")

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -10,3 +10,6 @@ supported transformations.
 [Feature] Set the the verbose flag from the environment variable ERT_VERBOSE.
 
 [Feature] Added function ecl_grid_cell_invalid / EclGrid.validCellGeometry( ). Typically interesting for GRID files where not necessarily all cells are entered.
+
+[Feature] Added function util_update_signalse() which will install util_abort_signal() signal handler for all fatal signals in default state; using new function from python ert/__init__py.
+


### PR DESCRIPTION
With this PR the `util_abort` traceback should come for any failing Python process.

