### PR TITLE
Fix compilation on Windows

### DIFF
--- a/devel/libert_util/src/util.c
+++ b/devel/libert_util/src/util.c
@@ -4873,6 +4873,10 @@ void util_install_signals(void) {
 */
 
 static void update_signal( int signal_nr ) {
+  /* Redefining sighandler_t in case it isn't defined (Windows).
+     This is harmless on other platforms. */
+  typedef void (*sighandler_t)(int);
+
   sighandler_t current_handler = signal(signal_nr , SIG_DFL);
   if (current_handler == SIG_DFL)
     signal( signal_nr , util_abort_signal );


### PR DESCRIPTION
Add typedef for sighandler_t, since it is not defined on Windows. This should also be harmless on other platforms.