### PR TITLE
Remove job_list debug setting.

### DIFF
--- a/devel/libjob_queue/src/job_list.c
+++ b/devel/libjob_queue/src/job_list.c
@@ -77,7 +77,6 @@ int job_list_get_size( const job_list_type * job_list ) {
 /*
   This takes ownership to the job node instance.
 */
-#define QUEUE_DEBUG 1
 void job_list_add_job( job_list_type * job_list , job_queue_node_type * job_node ) {
   if (job_list->alloc_size == job_list->active_size) {
 


### PR DESCRIPTION
The function job_list_add_job( ) has had a QUEUE_DEBUG setting which
takes a 'stupid' codepath in an attempt provoke more bugs. With this
commit we will use the more sane natural path.