### PR TITLE
Library calls: ert/__init__ -> ert/util/__init__

### DIFF
--- a/devel/python/python/ert/CMakeLists.txt
+++ b/devel/python/python/ert/CMakeLists.txt
@@ -28,4 +28,8 @@ ENDIF()
 
 configure_file(ert_lib_path_build.py.in   ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/ert/__ert_lib_path.py )
 configure_file(ert_lib_path_install.py.in ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/ert_lib_path_install.py )
+
 install(FILES ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/ert_lib_path_install.py DESTINATION ${PYTHON_INSTALL_PREFIX}/ert RENAME __ert_lib_path.py)
+
+configure_file(__ert_version.py.in ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/__ert_version.py )
+install(FILES ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/__ert_version.py DESTINATION ${PYTHON_INSTALL_PREFIX}/ert)

--- a/devel/python/python/ert/__init__.py
+++ b/devel/python/python/ert/__init__.py
@@ -105,7 +105,22 @@ if env_lib_path:
 if ert_lib_path:
     if not os.path.exists( ert_lib_path ):
         ert_lib_path = None
-        
+
+
+
+# The version tuple should preferably be fethced from
+# ert.util.version;: the purpose with the current hoops is to to be
+# able to determine version information without import loading shared
+# libraries.
+try:
+    import __ert_version
+    major_version = __ert_version.major_version
+    minor_version = __ert_version.minor_version
+    micro_version = __ert_version.micro_version
+except ImportError:
+    major_version = None
+    minor_version = None
+    micro_version = None
 
 
 # Set the module variable ert_lib_path of the ert.cwrap.clib module;

--- a/devel/python/python/ert/__init__.py
+++ b/devel/python/python/ert/__init__.py
@@ -117,7 +117,3 @@ if sys.hexversion < required_version_hex:
 
 
 
-from ert.util import Version
-from ert.util import updateAbortSignals
-
-updateAbortSignals( )

--- a/devel/python/python/ert/util/__init__.py
+++ b/devel/python/python/ert/util/__init__.py
@@ -81,3 +81,8 @@ from .arg_pack import ArgPack
 # Check if latex functionality exists in libert_util
 if hasattr(UTIL_LIB, "latex_alloc"):
     from .latex import LaTeX
+
+updateAbortSignals( )
+
+
+    

--- a/devel/python/python/ert_gui/site_config.py.in
+++ b/devel/python/python/ert_gui/site_config.py.in
@@ -1,0 +1,1 @@
+config_file = "${SITE_CONFIG_FILE}"

--- a/devel/python/tests/core/util/test_version.py
+++ b/devel/python/tests/core/util/test_version.py
@@ -17,6 +17,7 @@
 import os.path 
 from ert.test import ExtendedTestCase , TestAreaContext
 from ert.util import Version
+import ert
 
 class VersionTest(ExtendedTestCase):
     def setUp(self):
@@ -98,3 +99,9 @@ class VersionTest(ExtendedTestCase):
         v2 = Version(1,1,2)
 
         self.assertTrue( v1 == v2 )
+        
+        v1 = globalVersion.currentVersion( )
+        self.assertEqual( v1.major , ert.major_version )
+        self.assertEqual( v1.minor , ert.minor_version )
+        self.assertEqual( v1.micro , ert.micro_version )
+        

--- a/devel/python/tests/core/util/test_version.py
+++ b/devel/python/tests/core/util/test_version.py
@@ -93,7 +93,7 @@ class VersionTest(ExtendedTestCase):
         
 
     def test_import(self):
-        from ert import Version as globalVersion
+        from ert.util import Version as globalVersion
         v1 = globalVersion(1,1,2)
         v2 = Version(1,1,2)
 


### PR DESCRIPTION
The purpose of moving these calls from the root ert package to the
subpackage ert.util is to ensure that we can call:

    import ert

without actually loading any shared libraries.