### PR TITLE
Changed timeRange() to use getDataStartTime().

### DIFF
--- a/devel/python/python/ert/ecl/ecl_sum.py
+++ b/devel/python/python/ert/ecl/ecl_sum.py
@@ -412,7 +412,7 @@ class EclSum(BaseCClass):
         (num , timeUnit) = TimeVector.parseTimeUnit( interval )
 
         if start is None:
-            start = self.start_time
+            start = self.getDataStartTime( )
         if isinstance(start , datetime.date):
             start = datetime.datetime( start.year , start.month , start.day , 0 , 0 , 0 )
                 


### PR DESCRIPTION
In the case where we have restarted, and not loaded the historical part
of the simulation, there will be a window of time at the beginning of
the simulation where we do not have data. By using getDataStartTime() we
start right at the first datapoint.