### PR TITLE
Do not copy source fs into target fs if observations inactive

### DIFF
--- a/devel/libenkf/src/enkf_main.c
+++ b/devel/libenkf/src/enkf_main.c
@@ -1387,12 +1387,7 @@ bool enkf_main_UPDATE(enkf_main_type * enkf_main , const int_vector_type * step_
                                      meas_forecast ,
                                      obs_data );
         else if (target_fs != source_fs) {
-          ert_log_add_fmt_message( 1 , stderr , "No active observations for MINISTEP: %s. Parameters copied directly: %s -> %s" , local_ministep_get_name(ministep), enkf_fs_get_case_name( enkf_main_get_fs( enkf_main )) , enkf_fs_get_case_name( target_fs));
-          enkf_main_init_case_from_existing( enkf_main ,
-                                             enkf_main_get_fs( enkf_main ) ,
-                                             0 ,
-                                             ANALYZED ,
-                                             target_fs );
+          ert_log_add_fmt_message( 1 , stderr , "No active observations for MINISTEP: %s." , local_ministep_get_name(ministep));
         }
       }
       fclose( log_stream );


### PR DESCRIPTION
If one ministep had attached observations where all become unactive, all the previous ministep updates are ignored and the target is reset to the prior base case.

The source fs had been already copied to the target as the starting point, and we do the updates only on the target. 