### PR TITLE
Properly check return value of pthread_create()

### DIFF
--- a/devel/libjob_queue/tests/job_status_test.c
+++ b/devel/libjob_queue/tests/job_status_test.c
@@ -99,6 +99,11 @@ void test_update() {
         break;
     }
   }
+  if ((num_done_threads + num_exit_threads) == 0) {
+    fprintf(stderr, "Hmmm - not a single thread created - very suspicious \n");
+    exit(1);
+  }
+
   for (int i=0; i < num_done_threads + num_exit_threads; i++)
     pthread_join( thread_list[i] , NULL );
 

--- a/devel/libjob_queue/tests/job_status_test.c
+++ b/devel/libjob_queue/tests/job_status_test.c
@@ -66,28 +66,45 @@ void * user_done( void * arg ) {
 void test_update() {
   int N = 15000;
   pthread_t * thread_list = util_malloc( 2*N*sizeof * thread_list);
-
+  int num_exit_threads = 0;
+  int num_done_threads = 0;
   job_queue_status_type * status = job_queue_status_alloc();
+
   test_assert_int_equal( 0 , job_queue_status_get_total_count( status ));
   for (int i=0; i < 2*N; i++)
-     pthread_create( &thread_list[i] , NULL , add_sim , status );
-
-  for (int i=0; i < 2*N; i++)
-    pthread_join( thread_list[i] , NULL );
-
+    add_sim( status );
   test_assert_int_equal( 2*N , job_queue_status_get_count( status , JOB_QUEUE_WAITING ));
-  for (int i=0; i < 2*N; i++) {
-    if ((i % 2) == 0)
-      pthread_create( &thread_list[i] , NULL , user_exit , status );
-    else
-      pthread_create( &thread_list[i] , NULL , user_done , status );
+
+  {
+    int i = 0;
+    while (true) {
+      int thread_status;
+
+      if ((i % 2) == 0) {
+        thread_status = pthread_create( &thread_list[i] , NULL , user_exit , status );
+        if (thread_status == 0)
+          num_exit_threads++;
+        else
+          break;
+      }  else {
+        thread_status = pthread_create( &thread_list[i] , NULL , user_done , status );
+        if (thread_status == 0)
+          num_done_threads++;
+        else
+          break;
+      }
+
+      i++;
+      if (i == N)
+        break;
+    }
   }
-  for (int i=0; i < 2*N; i++)
+  for (int i=0; i < num_done_threads + num_exit_threads; i++)
     pthread_join( thread_list[i] , NULL );
 
-  test_assert_int_equal( 0 , job_queue_status_get_count( status , JOB_QUEUE_WAITING ));
-  test_assert_int_equal( N , job_queue_status_get_count( status , JOB_QUEUE_USER_EXIT ));
-  test_assert_int_equal( N , job_queue_status_get_count( status , JOB_QUEUE_DONE ));
+  test_assert_int_equal( 2*N - num_done_threads - num_exit_threads , job_queue_status_get_count( status , JOB_QUEUE_WAITING ));
+  test_assert_int_equal( num_exit_threads , job_queue_status_get_count( status , JOB_QUEUE_USER_EXIT ));
+  test_assert_int_equal( num_done_threads , job_queue_status_get_count( status , JOB_QUEUE_DONE ));
 
   test_assert_int_equal( 2*N , job_queue_status_get_total_count( status ));
   job_queue_status_free( status );
@@ -105,6 +122,7 @@ void test_name() {
 
 
 int main( int argc , char ** argv) {
+  util_install_signals();
   test_create();
   test_update();
   test_name();


### PR DESCRIPTION
Will properly check the return value of `pthread_create()` when adding test jobs.