### PR TITLE
Fix out of memory issues

### DIFF
--- a/devel/libconfig/src/config_content.c
+++ b/devel/libconfig/src/config_content.c
@@ -110,6 +110,8 @@ config_error_type * config_content_get_errors( const config_content_type * conte
 
 void config_content_free( config_content_type * content ) {
   vector_free( content->nodes );
+  vector_free( content->path_elm_stack );
+  vector_free( content->path_elm_storage );
   hash_free( content->items );
   config_error_free( content->parse_errors );
   subst_list_free( content->define_list );

--- a/devel/libconfig/src/config_parser.c
+++ b/devel/libconfig/src/config_parser.c
@@ -192,10 +192,12 @@ static config_content_node_type * config_content_item_set_arg__(subst_list_type 
       int iarg;
       for (iarg = 0; iarg < argc; iarg++) {
         int    env_offset = 0;
-        char * env_var;
-        do {
-          env_var = util_isscanf_alloc_envvar(  stringlist_iget(token_list , iarg + 1) , env_offset );
-          if (env_var != NULL) {
+        while (true) {
+          char * env_var = util_isscanf_alloc_envvar(  stringlist_iget(token_list , iarg + 1) , env_offset );
+          if (env_var == NULL)
+            break;
+
+          {
             const char * env_value = getenv( &env_var[1] );
             if (env_value != NULL) {
               char * new_value = util_string_replace_alloc( stringlist_iget( token_list , iarg + 1 ) , env_var , env_value );
@@ -205,7 +207,9 @@ static config_content_node_type * config_content_item_set_arg__(subst_list_type 
               fprintf(stderr,"** Warning: environment variable: %s is not defined \n", env_var);
             }
           }
-        } while (env_var != NULL);
+
+          free( env_var );
+        }
       }
     }
 
@@ -643,17 +647,17 @@ config_content_type * config_parse(config_parser_type * config ,
 
   config_content_type * content = config_content_alloc( );
 
-    if(pre_defined_kw_map != NULL) {
-        hash_iter_type * keys = hash_iter_alloc(pre_defined_kw_map);
+  if(pre_defined_kw_map != NULL) {
+    hash_iter_type * keys = hash_iter_alloc(pre_defined_kw_map);
 
-        while(!hash_iter_is_complete(keys)) {
-            const char * key = hash_iter_get_next_key(keys);
-            const char * value = hash_get(pre_defined_kw_map, key);
-            config_content_add_define( content , key , value );
-        }
-
-        hash_iter_free(keys);
+    while(!hash_iter_is_complete(keys)) {
+      const char * key = hash_iter_get_next_key(keys);
+      const char * value = hash_get(pre_defined_kw_map, key);
+      config_content_add_define( content , key , value );
     }
+
+    hash_iter_free(keys);
+  }
 //
 
   if (util_file_readable( filename )) {

--- a/devel/libenkf/applications/ert_tui/main.c
+++ b/devel/libenkf/applications/ert_tui/main.c
@@ -155,6 +155,7 @@ int main (int argc , char ** argv) {
     {
       char * abs_config = util_alloc_realpath( model_config_file );
       printf("model config  : %s \n\n", abs_config);
+      free(abs_config);
     }
     enkf_welcome( model_config_file );
     {

--- a/devel/libenkf/include/ert/enkf/summary_key_set.h
+++ b/devel/libenkf/include/ert/enkf/summary_key_set.h
@@ -17,7 +17,7 @@ extern "C" {
   int                      summary_key_set_get_size(summary_key_set_type * set);
   bool                     summary_key_set_add_summary_key(summary_key_set_type * set, const char * summary_key);
   bool                     summary_key_set_has_summary_key(summary_key_set_type * set, const char * summary_key);
-  stringlist_type *        summary_key_set_get_keys(summary_key_set_type * set);
+  stringlist_type *        summary_key_set_alloc_keys(summary_key_set_type * set);
   bool                     summary_key_set_is_read_only(const summary_key_set_type * set);
 
   void                     summary_key_set_fwrite(summary_key_set_type * set, const char * filename);

--- a/devel/libenkf/src/custom_kw_config_set.c
+++ b/devel/libenkf/src/custom_kw_config_set.c
@@ -103,7 +103,7 @@ void custom_kw_config_set_fwrite(custom_kw_config_set_type * set, const char * f
                 stringlist_fwrite(formatted_keys, stream);
             }
 
-            free(keys);
+            stringlist_free(keys);
             fclose(stream);
         } else {
             util_abort("%s: failed to open: %s for writing \n", __func__, filename);

--- a/devel/libenkf/src/enkf_fs.c
+++ b/devel/libenkf/src/enkf_fs.c
@@ -710,6 +710,7 @@ static void enkf_fs_umount( enkf_fs_type * fs ) {
       path_fmt_free( fs->case_tstep_fmt );
       path_fmt_free( fs->case_tstep_member_fmt );
 
+      custom_kw_config_set_free( fs->custom_kw_config_set );
       state_map_free( fs->state_map );
       summary_key_set_free(fs->summary_key_set);
       time_map_free( fs->time_map );

--- a/devel/libenkf/src/enkf_main_manage_fs.c
+++ b/devel/libenkf/src/enkf_main_manage_fs.c
@@ -521,12 +521,13 @@ enkf_fs_type * enkf_main_mount_alt_fs(const enkf_main_type * enkf_main , const c
 static void enkf_main_update_summary_config_from_fs__(enkf_main_type * enkf_main, enkf_fs_type * fs) {
     ensemble_config_type * ensemble_config = enkf_main_get_ensemble_config(enkf_main);
     summary_key_set_type * summary_key_set = enkf_fs_get_summary_key_set(fs);
-    stringlist_type * keys = summary_key_set_get_keys(summary_key_set);
+    stringlist_type * keys = summary_key_set_alloc_keys(summary_key_set);
 
     for(int i = 0; i < stringlist_get_size(keys); i++) {
         const char * key = stringlist_iget(keys, i);
         ensemble_config_add_summary(ensemble_config, key, LOAD_FAIL_SILENT);
     }
+    stringlist_free( keys );
 }
 
 

--- a/devel/libenkf/src/enkf_state.c
+++ b/devel/libenkf/src/enkf_state.c
@@ -821,6 +821,7 @@ static void enkf_state_internalize_GEN_DATA(enkf_state_type * enkf_state ,
         }
       }
     }
+    stringlist_free( keylist_GEN_DATA );
   }
 }
 

--- a/devel/libenkf/src/ert_log.c
+++ b/devel/libenkf/src/ert_log.c
@@ -63,6 +63,7 @@ void ert_log_close(){
     if (log_is_open( logh ))
       log_add_message( logh , false , NULL , "Exiting ert application normally - all is fine(?)" , false);
     log_close( logh );
+    logh = NULL;
 }
 
 bool ert_log_is_open(){

--- a/devel/libenkf/src/gen_kw.c
+++ b/devel/libenkf/src/gen_kw.c
@@ -262,13 +262,17 @@ void gen_kw_write_export_file(const gen_kw_type * gen_kw, FILE * filestream) {
     const char * parameter    = gen_kw_config_iget_name(gen_kw->config , ikw);
     int width                 = 60 - (strlen(key) + strlen(parameter) + 1);
     double transformed_value  = gen_kw_config_transform( gen_kw->config , ikw , gen_kw->data[ikw] );
-    const char * print_string = util_alloc_sprintf("%s:%s %g\n", key, parameter, width, transformed_value);
-    fprintf(filestream, "%s", print_string);
+    {
+      char * print_string       = util_alloc_sprintf("%s:%s %g\n", key, parameter, width, transformed_value);
+      fprintf(filestream, "%s", print_string);
+      free( print_string );
+    }
 
     if (gen_kw_config_should_use_log_scale(gen_kw->config, ikw)) {
       double log_transformed_value = log10(transformed_value);
-      const char * print_log_string = util_alloc_sprintf("LOG10_%s:%s %g\n", key, parameter, width, log_transformed_value);
+      char * print_log_string = util_alloc_sprintf("LOG10_%s:%s %g\n", key, parameter, width, log_transformed_value);
       fprintf(filestream, "%s", print_log_string);
+      free( print_log_string );
     }
   }
 }

--- a/devel/libenkf/src/local_config.c
+++ b/devel/libenkf/src/local_config.c
@@ -549,7 +549,7 @@ local_config_type * local_config_alloc( ) {
   local_config->updatestep_storage  = hash_alloc();
   local_config->ministep_storage    = hash_alloc();
   local_config->dataset_storage     = hash_alloc();
-  local_config->obsdata_storage      = hash_alloc();
+  local_config->obsdata_storage     = hash_alloc();
   local_config->config_files = stringlist_alloc_new();
 
   local_config_clear( local_config );
@@ -561,6 +561,7 @@ void local_config_free(local_config_type * local_config) {
   hash_free( local_config->updatestep_storage );
   hash_free( local_config->ministep_storage);
   hash_free( local_config->dataset_storage);
+  hash_free( local_config->obsdata_storage);
   stringlist_free( local_config->config_files );
   free( local_config );
 }

--- a/devel/libenkf/src/model_config.c
+++ b/devel/libenkf/src/model_config.c
@@ -534,6 +534,7 @@ void model_config_free(model_config_type * model_config) {
   util_safe_free( model_config->select_case );
   util_safe_free( model_config->case_table_file );
   util_safe_free( model_config->current_path_key);
+  util_safe_free( model_config->gen_kw_export_file_name);
 
   if (model_config->history)
     history_free(model_config->history);

--- a/devel/libenkf/src/site_config.c
+++ b/devel/libenkf/src/site_config.c
@@ -808,13 +808,14 @@ bool site_config_init(site_config_type * site_config, const config_content_type 
       const stringlist_type * tokens = config_content_iget_stringlist_ref(config, QUEUE_OPTION_KEY, i);
       const char * driver_name = stringlist_iget(tokens, 0);
       const char * option_key = stringlist_iget(tokens, 1);
-      const char * option_value = stringlist_alloc_joined_substring(tokens, 2, stringlist_get_size(tokens), " ");
+      char * option_value = stringlist_alloc_joined_substring(tokens, 2, stringlist_get_size(tokens), " ");
       /*
          If it is desirable to keep the exact number of spaces in the
          option_value it should be quoted with "" in the configuration
          file.
        */
       site_config_set_queue_option(site_config, driver_name, option_key, option_value);
+      free( option_value );
     }
   }
   return true;

--- a/devel/libenkf/src/summary_key_set.c
+++ b/devel/libenkf/src/summary_key_set.c
@@ -155,7 +155,7 @@ bool summary_key_set_fread(summary_key_set_type * set, const char * filename) {
                 stringlist_type * key_set = stringlist_fread_alloc(stream);
 
                 for (int i = 0; i < stringlist_get_size(key_set); i++) {
-                    hash_insert_int(set->key_set, stringlist_iget_copy(key_set, i), 1);
+                    hash_insert_int(set->key_set, stringlist_iget(key_set, i), 1);
                 }
                 stringlist_free(key_set);
                 fclose( stream );

--- a/devel/libenkf/src/summary_key_set.c
+++ b/devel/libenkf/src/summary_key_set.c
@@ -134,7 +134,7 @@ void summary_key_set_fwrite(summary_key_set_type * set, const char * filename) {
         if (stream) {
             stringlist_type * keys = hash_alloc_stringlist(set->key_set);
             stringlist_fwrite(keys, stream);
-            free(keys);
+            stringlist_free(keys);
             fclose( stream );
         } else {
             util_abort("%s: failed to open: %s for writing \n", __func__, filename);

--- a/devel/libenkf/src/summary_key_set.c
+++ b/devel/libenkf/src/summary_key_set.c
@@ -110,7 +110,7 @@ bool summary_key_set_has_summary_key(summary_key_set_type * set, const char * su
     return has_key;
 }
 
-stringlist_type * summary_key_set_get_keys(summary_key_set_type * set) {
+stringlist_type * summary_key_set_alloc_keys(summary_key_set_type * set) {
     stringlist_type * keys;
 
     pthread_rwlock_rdlock( &set->rw_lock );

--- a/devel/libjob_queue/include/ert/job_queue/job_queue_status.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue_status.h
@@ -36,6 +36,7 @@ extern "C" {
   bool job_queue_status_transition( job_queue_status_type * status_count , job_status_type src_status , job_status_type target_status);
   int job_queue_status_get_total_count( const job_queue_status_type * status );
   const char * job_queue_status_name( job_status_type status );
+  bool job_queue_status_get_and_clear_redisplay_status( job_queue_status_type * status );
 
   UTIL_IS_INSTANCE_HEADER( job_queue_status );
   UTIL_SAFE_CAST_HEADER( job_queue_status );

--- a/devel/libjob_queue/src/forward_model.c
+++ b/devel/libjob_queue/src/forward_model.c
@@ -155,6 +155,7 @@ void forward_model_parse_init(forward_model_type * forward_model , const char * 
         char  * arg_string          = util_alloc_substring_copy((p1 + 1) , 0 , arg_length - 1);
         ext_job_set_private_args_from_string( current_job , arg_string );
         p1 += (1 + arg_length);
+        free( arg_string );
       }
     }
     /*****************************************************************/
@@ -175,10 +176,10 @@ void forward_model_parse_init(forward_model_type * forward_model , const char * 
        or after the ')' if the job has arguments.
     */
 
-    if (*p1 == '\0') { /* we have parsed the whole string. */
-      free(job_name);
+    free(job_name);
+    if (*p1 == '\0')  /* we have parsed the whole string. */
       break;
-    }
+    
   }
 }
 

--- a/devel/libjob_queue/src/job_node.c
+++ b/devel/libjob_queue/src/job_node.c
@@ -201,6 +201,13 @@ void job_queue_node_free(job_queue_node_type * node) {
   job_queue_node_free_data(node);
   job_queue_node_free_error_info(node);
   util_safe_free(node->run_path);
+
+  // Since the type of the callback_arg is void* it should maybe be
+  // registered with a private destructor - or the type should be
+  // changed to arg_pack?
+  if (arg_pack_is_instance( node->callback_arg ))
+      arg_pack_free( node->callback_arg );
+
   free(node);
 }
 

--- a/devel/libjob_queue/src/job_queue.c
+++ b/devel/libjob_queue/src/job_queue.c
@@ -854,7 +854,12 @@ void job_queue_run_jobs(job_queue_type * queue , int num_total_run, bool verbose
     //Check if queue is open. Fails hard if not open
     job_queue_check_open(queue);
 
-    const int NUM_WORKER_THREADS = 16;
+    /*
+      The number of threads in the thread pool running callbacks. Memory consumption can
+      potentially be quite high while running the DONE callback - should therefor not use
+      too many threads.
+    */
+    const int NUM_WORKER_THREADS = 4;
     queue->running = true;
     queue->work_pool = thread_pool_alloc( NUM_WORKER_THREADS , true );
     {

--- a/devel/libjob_queue/src/job_queue.c
+++ b/devel/libjob_queue/src/job_queue.c
@@ -882,13 +882,14 @@ void job_queue_run_jobs(job_queue_type * queue , int num_total_run, bool verbose
 
         /*****************************************************************/
         {
-          bool update_status = job_queue_update_status( queue );
+          job_queue_update_status( queue );
           if (verbose) {
-            if (update_status || new_jobs)
-              job_queue_print_summary(queue , update_status );
+	    bool update_summary = job_queue_status_get_and_clear_redisplay_status( queue->status );
+            if (update_summary || new_jobs)
+              job_queue_print_summary(queue , update_summary );
             job_queue_update_spinner( &phase );
           }
-
+	  
 
           {
             int num_complete = job_queue_status_get_count(queue->status, JOB_QUEUE_SUCCESS) +

--- a/devel/libjob_queue/src/job_queue_status.c
+++ b/devel/libjob_queue/src/job_queue_status.c
@@ -28,6 +28,7 @@
 struct job_queue_status_struct {
   UTIL_TYPE_ID_DECLARATION;
   int status_list[JOB_QUEUE_MAX_STATE];
+  bool status_redisplay_required;
   pthread_mutex_t update_mutex;
 };
 
@@ -93,6 +94,7 @@ void job_queue_status_clear( job_queue_status_type * status ) {
   int index;
   for (index = 0; index < JOB_QUEUE_MAX_STATE; index++)
     status->status_list[ index ] = 0;
+  status->status_redisplay_required = false;
 }
 
 
@@ -141,6 +143,7 @@ bool job_queue_status_transition( job_queue_status_type * status_count , job_sta
   if (src_status != target_status) {
     job_queue_status_dec( status_count , src_status );
     job_queue_status_inc( status_count , target_status );
+    status_count->status_redisplay_required = true;
     return true;
   } else
     return false;
@@ -158,4 +161,12 @@ int job_queue_status_get_total_count( const job_queue_status_type * status ) {
 const char * job_queue_status_name( job_status_type status ) {
   int index = STATUS_INDEX( status );
   return status_name[index];
+}
+
+
+
+bool job_queue_status_get_and_clear_redisplay_status( job_queue_status_type * status ) {
+  bool redisplay = status->status_redisplay_required;
+  status->status_redisplay_required = false;
+  return redisplay;
 }

--- a/devel/python/python/ert/enkf/summary_key_set.py
+++ b/devel/python/python/ert/enkf/summary_key_set.py
@@ -49,6 +49,6 @@ SummaryKeySet.cNamespace().free  = cwrapper.prototype("void summary_key_set_free
 SummaryKeySet.cNamespace().size  = cwrapper.prototype("int summary_key_set_get_size(summary_key_set)")
 SummaryKeySet.cNamespace().add_key  = cwrapper.prototype("bool summary_key_set_add_summary_key(summary_key_set, char*)")
 SummaryKeySet.cNamespace().has_key  = cwrapper.prototype("bool summary_key_set_has_summary_key(summary_key_set, char*)")
-SummaryKeySet.cNamespace().keys  = cwrapper.prototype("stringlist_obj summary_key_set_get_keys(summary_key_set)")
+SummaryKeySet.cNamespace().keys  = cwrapper.prototype("stringlist_obj summary_key_set_alloc_keys(summary_key_set)")
 SummaryKeySet.cNamespace().is_read_only  = cwrapper.prototype("bool summary_key_set_is_read_only(summary_key_set)")
 SummaryKeySet.cNamespace().fwrite  = cwrapper.prototype("void summary_key_set_fwrite(summary_key_set, char*)")


### PR DESCRIPTION
1. Many small memory leaks found with `valgrind`
2. Limited the number of threads available for running callbacks to 4.
3. Unrelated: minor update in implementation to check if redisplay of queue status is required.