### PR TITLE
ERT-988: Changed to use BaseCEnum

### DIFF
--- a/devel/libecl/include/ert/ecl/ecl_util.h
+++ b/devel/libecl/include/ert/ecl/ecl_util.h
@@ -175,7 +175,6 @@ ert_ecl_unit_enum   ecl_util_get_unit_set(const char * data_file);
 bool            ecl_util_valid_basename_fmt( const char * basename_fmt );
 bool            ecl_util_valid_basename( const char * basename );
 const char *    ecl_util_get_phase_name( ecl_phase_enum phase );
-const char *    ecl_util_file_enum_iget( int index, int * value);
 
 int             ecl_util_select_filelist( const char * path , const char * base , ecl_file_enum file_type , bool fmt_file , stringlist_type * filelist);
 void            ecl_util_append_month_range( time_t_vector_type * date_list , time_t start_date , time_t end_date , bool force_append_end);

--- a/devel/libecl/src/ecl_file.c
+++ b/devel/libecl/src/ecl_file.c
@@ -1129,12 +1129,4 @@ bool ecl_file_save_kw( const ecl_file_type * ecl_file , const ecl_kw_type * ecl_
   }
 }
 
-/* Small function to support Python based enum introspection. */
-
-
-const char * ecl_util_file_flags_enum_iget( int index , int * value) {
-  return util_enum_iget( index , ECL_FILE_FLAGS_ENUM_SIZE , (const util_enum_element_type []) { ECL_FILE_FLAGS_ENUM_DEFS }, value);
-}
-
-
 

--- a/devel/libecl/src/ecl_util.c
+++ b/devel/libecl/src/ecl_util.c
@@ -1526,17 +1526,4 @@ void ecl_util_set_date_values(time_t t , int * mday , int * month , int * year) 
     return util_set_date_values(t,mday,month,year);
 }
 
-/*****************************************************************/
-/* Small functions to support enum introspection. */
-
-
-const char * ecl_util_phase_enum_iget( int index, int * value) {
-  return util_enum_iget( index , ECL_PHASE_ENUM_SIZE , (const util_enum_element_type []) { ECL_PHASE_ENUM_DEFS }, value);
-}
-
-const char * ecl_util_type_enum_iget( int index, int * value) {
-  return util_enum_iget( index , ECL_TYPE_ENUM_SIZE , (const util_enum_element_type []) { ECL_TYPE_ENUM_DEFS }, value);
-}
-
-
 

--- a/devel/python/python/ert/ecl/ecl.py
+++ b/devel/python/python/ert/ecl/ecl.py
@@ -117,17 +117,6 @@ class default_wrapper(object):
 ecl_default = default_wrapper()
 
 
-from .ecl_util import EclFileFlagEnum, EclPhaseEnum, EclTypeEnum, EclUtil
-    
-for enum in EclFileFlagEnum.enum_names:
-    globals()[enum] = getattr(EclFileFlagEnum, enum)
-
-for enum in EclPhaseEnum.enum_names:
-    globals()[enum] = getattr(EclPhaseEnum, enum)
-
-for enum in EclTypeEnum.enum_names:
-    globals()[enum] = getattr(EclTypeEnum, enum)
-
 
         
 

--- a/devel/python/python/ert/ecl/ecl_kw.py
+++ b/devel/python/python/ert/ecl/ecl_kw.py
@@ -344,16 +344,16 @@ class EclKW(CClass):
 
     def __init(self):
         self.data_ptr   = None
-        self.ecl_type = cfunc.get_type( self )
-        if self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+        ecl_type = cfunc.get_type( self )
+        if ecl_type == EclTypeEnum.ECL_INT_TYPE:
             self.data_ptr = cfunc.int_ptr( self )
             self.dtype    = numpy.int32        
             self.str_fmt  = "%8d"
-        elif self.ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
             self.data_ptr = cfunc.float_ptr( self )
             self.dtype    = numpy.float32
             self.str_fmt  = "%13.4f"
-        elif self.ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
             self.data_ptr = cfunc.double_ptr( self )
             self.dtype    = numpy.float64        
             self.str_fmt  = "%13.4f"
@@ -361,9 +361,9 @@ class EclKW(CClass):
             # Iteration not supported for CHAR / BOOL
             self.data_ptr = None
             self.dtype    = None
-            if self.ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
+            if ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
                 self.str_fmt  = "%8s"
-            elif self.ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
+            elif ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
                 self.str_fmt  = "%d"
             else:
                 self.str_fmt = "%s"  #"Message type"
@@ -400,9 +400,10 @@ class EclKW(CClass):
                 if self.data_ptr:
                     return self.data_ptr[ index ]
                 else:
-                    if self.ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
+                    ecl_type = self.getEclType( )
+                    if ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
                         return cfunc.iget_bool( self, index)
-                    elif self.ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
+                    elif ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
                         return cfunc.iget_char_ptr( self , index )
                     else:
                         raise TypeError("Internal implementation error ...")
@@ -428,9 +429,10 @@ class EclKW(CClass):
                 if self.data_ptr:
                     self.data_ptr[ index ] = value
                 else:
-                    if self.ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
+                    ecl_type = self.getEclType( )
+                    if ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
                         cfunc.iset_bool( self , index , value)
-                    elif self.ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
+                    elif ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
                         return cfunc.iset_char_ptr( self , index , value)
                     else:
                         raise SystemError("Internal implementation error ...")
@@ -460,8 +462,9 @@ class EclKW(CClass):
             else:
                 if not mul:
                     factor = 1.0 / factor
-                    
-                if self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+
+                ecl_type = self.getEclType( )
+                if ecl_type == EclTypeEnum.ECL_INT_TYPE:
                     if isinstance( factor , int ):
                         cfunc.scale_int( self , factor )
                     else:
@@ -493,7 +496,8 @@ class EclKW(CClass):
                 else:
                     sign = -1
 
-                if self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+                ecl_type = self.getEclType( )
+                if ecl_type == EclTypeEnum.ECL_INT_TYPE:
                     if isinstance( delta , int ):
                         cfunc.shift_int( self , delta * sign)
                     else:
@@ -571,15 +575,16 @@ class EclKW(CClass):
         String: Raise ValueError exception.
         Bool:   The number of true values
         """
-        if self.ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
+        ecl_type = self.getEclType( )
+        if ecl_type == EclTypeEnum.ECL_CHAR_TYPE:
             raise ValueError("The keyword:%s is of string type - sum is not implemented" % self.get_name())
-        elif self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_INT_TYPE:
             return cfunc.int_sum( self )
-        elif self.ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
             return cfunc.float_sum( self )
-        elif self.ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
             return cfunc.float_sum( self )
-        elif self.ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_BOOL_TYPE:
             sum = 0
             for elm in self:
                 if elm:
@@ -648,7 +653,8 @@ class EclKW(CClass):
                 if mask:
                     mask.set_kw( self , value , force_active )
                 else:
-                    if self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+                    ecl_type = self.getEclType( )
+                    if ecl_type == EclTypeEnum.ECL_INT_TYPE:
                         if isinstance( value , int ):
                             cfunc.set_int( self , value )
                         else:
@@ -830,15 +836,16 @@ class EclKW(CClass):
         Will raise TypeError exception if the keyword is not of
         numerical type.
         """
-        if self.ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
+        ecl_type = self.getEclType( )
+        if ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
             min = ctypes.c_float()
             max = ctypes.c_float()
             cfunc.max_min_float( self , ctypes.byref( max ) , ctypes.byref( min ))
-        elif self.ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
             min = ctypes.c_double()
             max = ctypes.c_double()
             cfunc.max_min_double( self , ctypes.byref( max ) , ctypes.byref( min ))
-        elif self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_INT_TYPE:
             min = ctypes.c_int()
             max = ctypes.c_int()
             cfunc.max_min_int( self , ctypes.byref( max ) , ctypes.byref( min ))
@@ -860,11 +867,12 @@ class EclKW(CClass):
 
     @property
     def numeric(self):
-        if self.ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
+        ecl_type = self.getEclType( )
+        if ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
             return True
-        if self.ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
+        if ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
             return True
-        if self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+        if ecl_type == EclTypeEnum.ECL_INT_TYPE:
             return True
         return False
 
@@ -878,10 +886,10 @@ class EclKW(CClass):
         return self.typeName( )
 
     def typeName(self):
-        return EclUtil.type_name( self.ecl_type )
+        return EclUtil.type_name( self.getEclType( ))
 
     def getEclType(self):
-        return self.ecl_type
+        return cfunc.get_type( self )
 
         
 
@@ -1032,11 +1040,12 @@ class EclKW(CClass):
 
 
     def getDataPtr(self):
-        if self.ecl_type == EclTypeEnum.ECL_INT_TYPE:
+        ecl_type = self.getEclType( )
+        if ecl_type == EclTypeEnum.ECL_INT_TYPE:
             return cfunc.int_ptr( self )
-        elif self.ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_FLOAT_TYPE:
             return cfunc.float_ptr( self )
-        elif self.ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
+        elif ecl_type == EclTypeEnum.ECL_DOUBLE_TYPE:
             return cfunc.double_ptr( self )
         else:
             raise ValueError("Only numeric types can export data pointer")
@@ -1058,14 +1067,14 @@ cfunc.fseek_grdecl               = cwrapper.prototype("bool     ecl_kw_grdecl_fs
 cfunc.fprintf_grdecl             = cwrapper.prototype("void     ecl_kw_fprintf_grdecl( ecl_kw , FILE )")
 cfunc.fprintf_data               = cwrapper.prototype("void     ecl_kw_fprintf_data( ecl_kw , char* , FILE )")
 
-cfunc.alloc_new                  = cwrapper.prototype("c_void_p ecl_kw_alloc( char* , int , int )")
+cfunc.alloc_new                  = cwrapper.prototype("c_void_p ecl_kw_alloc( char* , int , ecl_type_enum )")
 cfunc.copyc                      = cwrapper.prototype("c_void_p ecl_kw_alloc_copy( ecl_kw )")
 cfunc.sub_copy                   = cwrapper.prototype("c_void_p ecl_kw_alloc_sub_copy( ecl_kw , char*, int , int)")
 cfunc.slice_copyc                = cwrapper.prototype("c_void_p ecl_kw_alloc_slice_copy( ecl_kw , int , int , int )")
 cfunc.fread_alloc                = cwrapper.prototype("c_void_p ecl_kw_fread_alloc( fortio )")
 cfunc.get_size                   = cwrapper.prototype("int      ecl_kw_get_size( ecl_kw )")
 cfunc.get_fortio_size            = cwrapper.prototype("size_t   ecl_kw_fortio_size( ecl_kw )")
-cfunc.get_type                   = cwrapper.prototype("int      ecl_kw_get_type( ecl_kw )")
+cfunc.get_type                   = cwrapper.prototype("ecl_type_enum ecl_kw_get_type( ecl_kw )")
 cfunc.iget_char_ptr              = cwrapper.prototype("char*    ecl_kw_iget_char_ptr( ecl_kw , int )")
 cfunc.iset_char_ptr              = cwrapper.prototype("void     ecl_kw_iset_char_ptr( ecl_kw , int , char*)")
 cfunc.iget_bool                  = cwrapper.prototype("bool     ecl_kw_iget_bool( ecl_kw , int)")

--- a/devel/python/python/ert/ecl/ecl_util.py
+++ b/devel/python/python/ert/ecl/ecl_util.py
@@ -55,16 +55,53 @@ EclFileEnum.addEnum("ECL_DATA_FILE", 512)
 
 EclFileEnum.registerEnum(ECL_LIB, "ecl_file_enum")
 
+#-----------------------------------------------------------------
 
-# ecl_phase_enum from ecl_util.h
-EclPhaseEnum = create_enum(ECL_LIB, "ecl_util_phase_enum_iget", "ecl_phase_enum")
+class EclPhaseEnum(BaseCEnum):
+    ECL_OIL_PHASE = None
+    ECL_GAS_PHASE = None
+    ECL_WATER_PHASE = None
 
-# ecl_type_enum defintion from ecl_util.h
-EclTypeEnum = create_enum(ECL_LIB, "ecl_util_type_enum_iget", "ecl_type_enum")
+EclPhaseEnum.addEnum("ECL_OIL_PHASE" , 1 )
+EclPhaseEnum.addEnum("ECL_GAS_PHASE" , 2 )
+EclPhaseEnum.addEnum("ECL_WATER_PHASE" , 4 )
 
-# ecl_file_flag_type defintion from ecl_file.h
-EclFileFlagEnum = create_enum(ECL_LIB, "ecl_util_file_flags_enum_iget", "ecl_file_flag_enum")
+EclPhaseEnum.registerEnum(ECL_LIB, "ecl_phase_enum")
 
+#-----------------------------------------------------------------
+
+class EclTypeEnum(BaseCEnum):
+    ECL_CHAR_TYPE   = None
+    ECL_FLOAT_TYPE  = None
+    ECL_DOUBLE_TYPE = None
+    ECL_INT_TYPE    = None
+    ECL_BOOL_TYPE   = None
+    ECL_MESS_TYPE   = None
+  
+EclTypeEnum.addEnum("ECL_CHAR_TYPE" , 0 )
+EclTypeEnum.addEnum("ECL_FLOAT_TYPE" , 1 )
+EclTypeEnum.addEnum("ECL_DOUBLE_TYPE" , 2 )
+EclTypeEnum.addEnum("ECL_INT_TYPE" , 3 )
+EclTypeEnum.addEnum("ECL_BOOL_TYPE" , 4 )
+EclTypeEnum.addEnum("ECL_MESS_TYPE" , 5 )
+
+
+EclTypeEnum.registerEnum(ECL_LIB, "ecl_type_enum")
+
+#-----------------------------------------------------------------
+
+class EclFileFlagEnum(BaseCEnum):
+    ECL_FILE_CLOSE_STREAM = None
+    ECL_FILE_WRITABLE = None
+
+EclFileFlagEnum.addEnum("ECL_FILE_CLOSE_STREAM" , 1 )
+EclFileFlagEnum.addEnum("ECL_FILE_WRITABLE" , 2 )
+
+
+EclFileFlagEnum.registerEnum(ECL_LIB, "ecl_file_flag_enum")
+
+
+#-----------------------------------------------------------------
 
 cwrapper = CWrapper(ECL_LIB)
 cfunc = CWrapperNameSpace("ecl_util")

--- a/devel/python/tests/core/ecl/test_ecl_util.py
+++ b/devel/python/tests/core/ecl/test_ecl_util.py
@@ -14,7 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
 
-from ert.ecl import EclUtil, EclTypeEnum , EclFileEnum
+from ert.ecl import EclUtil, EclTypeEnum , EclFileEnum, EclPhaseEnum
 from ert.test import ExtendedTestCase 
 
 
@@ -23,8 +23,10 @@ class EclUtilTest(ExtendedTestCase):
     def test_enums(self):
         source_file_path = "libecl/include/ert/ecl/ecl_util.h"
         self.assertEnumIsFullyDefined(EclFileEnum, "ecl_file_enum", source_file_path)
-    
-    
+        self.assertEnumIsFullyDefined(EclPhaseEnum, "ecl_phase_enum", source_file_path)
+        self.assertEnumIsFullyDefined(EclTypeEnum, "ecl_type_enum", source_file_path)
+
+        
     def test_file_type(self):
         file_type , fmt , report = EclUtil.inspectExtension("CASE.X0078")
         self.assertEqual( file_type , EclFileEnum.ECL_RESTART_FILE )

--- a/devel/python/tests/core/ecl/test_legacy_ecl.py
+++ b/devel/python/tests/core/ecl/test_legacy_ecl.py
@@ -58,20 +58,7 @@ class LegacyEclTest(TestCase):
         except ImportError:
             pass
 
-                
-    def test_enums(self):
-        self.assertEqual(ecl.ECL_FLOAT_TYPE, EclTypeEnum.ECL_FLOAT_TYPE)
-        self.assertEqual(ecl.ECL_CHAR_TYPE, EclTypeEnum.ECL_CHAR_TYPE)
-        self.assertEqual(ecl.ECL_DOUBLE_TYPE, EclTypeEnum.ECL_DOUBLE_TYPE)
-        self.assertEqual(ecl.ECL_BOOL_TYPE, EclTypeEnum.ECL_BOOL_TYPE)
-        self.assertEqual(ecl.ECL_CHAR_TYPE, EclTypeEnum.ECL_CHAR_TYPE)
-
-        self.assertEqual(ecl.ECL_FILE_WRITABLE, EclFileFlagEnum.ECL_FILE_WRITABLE)
-
-        self.assertEqual(ecl.ECL_OIL_PHASE, EclPhaseEnum.ECL_OIL_PHASE)
-        self.assertEqual(ecl.ECL_GAS_PHASE, EclPhaseEnum.ECL_GAS_PHASE)
-        self.assertEqual(ecl.ECL_WATER_PHASE, EclPhaseEnum.ECL_WATER_PHASE)
-
+        
     def test_ecl_defaults(self):
         # Should be either non-null, or throw an NotImplementedError.
         try:


### PR DESCRIPTION
Changed the implementation of the Ecl enums EclFileEnum, EclTypeEnum,
EclPhaseEnum and EclFileFlagEnum to use BaseCEnum. Observe that a
consequency of this change is that the the old style
'ecl.ECL_FLOAT_TYPE' will not longer work.

Have also removed the ecl_type attribute of the EclKW class, asking the
C layer each time instead.