### PR TITLE
Ert 998 workflow arg type

### DIFF
--- a/devel/libjob_queue/src/workflow_job.c
+++ b/devel/libjob_queue/src/workflow_job.c
@@ -229,7 +229,7 @@ int workflow_job_get_max_arg( const workflow_job_type * workflow_job ) {
 }
 
 config_item_types workflow_job_iget_argtype( const workflow_job_type * workflow_job, int index) {
-    return int_vector_iget( workflow_job->arg_types , index );
+  return int_vector_safe_iget( workflow_job->arg_types , index );
 }
 
 

--- a/devel/python/tests/ert/job_queue/test_workflow_job.py
+++ b/devel/python/tests/ert/job_queue/test_workflow_job.py
@@ -74,7 +74,8 @@ class WorkflowJobTest(ExtendedTestCase):
             job = alloc_from_file("DUMP", config, "dump_job")
 
             self.assertFalse(job.isInternal())
-
+            argTypes = job.argumentTypes()
+            self.assertEqual( argTypes , [str , str] )
             self.assertIsNone(job.run(None, ["test", "text"]))
 
             with open("test", "r") as f:

--- a/devel/python/tests/ert/job_queue/workflow_common.py
+++ b/devel/python/tests/ert/job_queue/workflow_common.py
@@ -11,7 +11,6 @@ class WorkflowCommon(object):
             f.write("MIN_ARG 2\n")
             f.write("MAX_ARG 2\n")
             f.write("ARG_TYPE 0 STRING\n")
-            f.write("ARG_TYPE 1 STRING\n")
 
 
         with open("dump.py", "w") as f:


### PR DESCRIPTION
Ensure that the arg_type can be safely called. Intend to backport the first commit to to the stable series.