### PR TITLE
Removed csv export test from Statoil.

### DIFF
--- a/devel/python/tests/core/ecl/test_sum_statoil.py
+++ b/devel/python/tests/core/ecl/test_sum_statoil.py
@@ -379,18 +379,6 @@ class SumTest(ExtendedTestCase):
             sum.get_interp( "FOPT" , date = t )
         
 
-        with TestAreaContext("csv/export"):
-            sum.exportCSV("file.csv")
-            input_file = csv.DictReader( open("file.csv"))
-            for row in input_file:
-                keys = sum.keys( pattern = "W*")
-                keys |= sum.keys( pattern = "G")
-                
-                for key in keys:
-                    self.assertTrue( key in row )
-                break
-
-            
 
     def test_regularProduction(self):
         sum = EclSum(self.case)


### PR DESCRIPTION
This test used a too large dataset (for the CSV reader??). The functionality is tested in a simpler test anyway.