### PR TITLE
smspec_node supports copying

### DIFF
--- a/devel/libecl/include/ert/ecl/smspec_node.h
+++ b/devel/libecl/include/ert/ecl/smspec_node.h
@@ -103,6 +103,7 @@ typedef enum {ECL_SMSPEC_INVALID_VAR            =  0 ,
                                             float default_value);
 
   smspec_node_type *  smspec_node_alloc_new(int params_index, float default_value);
+  smspec_node_type *  smspec_node_alloc_copy( const smspec_node_type* );
 
   void                smspec_node_free( smspec_node_type * index );
   void                smspec_node_free__(void * arg);

--- a/devel/libecl/src/smspec_node.c
+++ b/devel/libecl/src/smspec_node.c
@@ -736,6 +736,40 @@ smspec_node_type * smspec_node_alloc_lgr( ecl_smspec_var_type var_type ,
   }
 }
 
+smspec_node_type* smspec_node_alloc_copy( const smspec_node_type* node ) {
+    if( !node ) return NULL;
+
+    smspec_node_type* copy = util_malloc( sizeof * copy );
+    UTIL_TYPE_ID_INIT( copy, SMSPEC_TYPE_ID );
+    copy->gen_key1 = util_alloc_string_copy( node->gen_key1 );
+    copy->gen_key2 = util_alloc_string_copy( node->gen_key2 );
+    copy->var_type = node->var_type;
+    copy->wgname = util_alloc_string_copy( node->wgname );
+    copy->keyword = util_alloc_string_copy( node->keyword );
+    copy->unit = util_alloc_string_copy( node->unit );
+    copy->num = node->num;
+
+    copy->ijk = NULL;
+    if( node->ijk ) {
+        copy->ijk = util_calloc( 3 , sizeof * node->ijk );
+        memcpy( copy->ijk, node->ijk, 3 * sizeof( * node->ijk ) );
+    }
+
+    copy->lgr_name = util_alloc_string_copy( node->lgr_name );
+    copy->lgr_ijk = NULL;
+    if( node->lgr_ijk ) {
+        copy->lgr_ijk = util_calloc( 3 , sizeof * node->lgr_ijk );
+        memcpy( copy->lgr_ijk, node->lgr_ijk, 3 * sizeof( * node->lgr_ijk ) );
+    }
+
+    copy->rate_variable = node->rate_variable;
+    copy->total_variable = node->total_variable;
+    copy->historical = node->historical;
+    copy->params_index = node->params_index;
+    copy->default_value = node->default_value;
+
+    return copy;
+}
 
 void smspec_node_free( smspec_node_type * index ) {
   util_safe_free( index->unit );

--- a/devel/libeclxx/include/ert/ecl/Smspec.hpp
+++ b/devel/libeclxx/include/ert/ecl/Smspec.hpp
@@ -11,6 +11,8 @@ namespace ERT {
 
     class smspec_node {
         public:
+            smspec_node( const smspec_node& );
+
             smspec_node(
                     ecl_smspec_var_type,
                     const std::string& wgname,

--- a/devel/libeclxx/src/Smspec.cpp
+++ b/devel/libeclxx/src/Smspec.cpp
@@ -3,6 +3,10 @@
 
 namespace ERT {
 
+    smspec_node::smspec_node( const smspec_node& rhs ) :
+        node( smspec_node_alloc_copy( rhs.node.get() ) )
+    {}
+
     static const int dummy_dims[ 3 ] = { -1, -1, -1 };
     const auto default_join = ":";
 

--- a/devel/libeclxx/tests/eclxx_smspec.cpp
+++ b/devel/libeclxx/tests/eclxx_smspec.cpp
@@ -22,6 +22,13 @@
 
 #include <ert/ecl/Smspec.hpp>
 
+void test_smspec_copy() {
+    std::string kw( "FOPT" );
+    ERT::smspec_node field( kw );
+
+    ERT::smspec_node copy( field );
+}
+
 void test_smspec_wg() {
     std::string kw( "WWCT" );
     std::string wg( "OP1" );


### PR DESCRIPTION
Introduce a copy constructor for smspec_node for better C++ interop.
This needs a definition for a lot of C++ features to be well-formed,
even though it in most cases will be optimised away.