### PR TITLE
Eclxx summary region keyword

### DIFF
--- a/devel/libeclxx/include/ert/ecl/Smspec.hpp
+++ b/devel/libeclxx/include/ert/ecl/Smspec.hpp
@@ -25,6 +25,10 @@ namespace ERT {
                     int dims[ 3 ],
                     int ijk[ 3 ] );
 
+            smspec_node( const std::string& keyword,
+                    int dims[ 3 ],
+                    int region );
+
             const char* wgname() const;
             const char* keyword() const;
 

--- a/devel/libeclxx/src/Smspec.cpp
+++ b/devel/libeclxx/src/Smspec.cpp
@@ -37,6 +37,15 @@ namespace ERT {
     {}
 
     smspec_node::smspec_node(
+            const std::string& keyword,
+            int dims[ 3 ],
+            int region ) :
+        smspec_node(
+            ECL_SMSPEC_REGION_VAR, "", keyword.c_str(), "", default_join, dims, region
+        )
+    {}
+
+    smspec_node::smspec_node(
             ecl_smspec_var_type type,
             const char* wgname,
             const char* keyword,

--- a/devel/libeclxx/tests/eclxx_smspec.cpp
+++ b/devel/libeclxx/tests/eclxx_smspec.cpp
@@ -58,9 +58,18 @@ void test_smspec_block() {
     test_assert_true( block.keyword() == kw );
 }
 
+void test_smspec_region() {
+    std::string kw( "ROIP" );
+    int dims[ 3 ] = { 10, 10, 10 };
+    ERT::smspec_node region( kw, dims, 0 );
+
+    test_assert_true( region.keyword() == kw );
+}
+
 int main (int argc, char **argv) {
     test_smspec_copy();
     test_smspec_wg();
     test_smspec_field();
     test_smspec_block();
+    test_smspec_region();
 }

--- a/devel/libeclxx/tests/eclxx_smspec.cpp
+++ b/devel/libeclxx/tests/eclxx_smspec.cpp
@@ -53,12 +53,13 @@ void test_smspec_block() {
     int dims[ 3 ] = { 10, 10, 10 };
     int ijk[ 3 ] = { 5, 5, 5 };
 
-    ERT::smspec_node field( kw, dims, ijk );
+    ERT::smspec_node block( kw, dims, ijk );
 
-    test_assert_true( field.keyword() == kw );
+    test_assert_true( block.keyword() == kw );
 }
 
 int main (int argc, char **argv) {
+    test_smspec_copy();
     test_smspec_wg();
     test_smspec_field();
     test_smspec_block();


### PR DESCRIPTION
Add C++ bindings for the ECL_SMSPEC_REGION_VAR family of summary nodes.