### PR TITLE
Util abort python cxx

### DIFF
--- a/devel/libert_util/src/util_abort_gnu.c
+++ b/devel/libert_util/src/util_abort_gnu.c
@@ -73,7 +73,7 @@ static bool util_addr2line_lookup__(const void * bt_addr , char ** func_name , c
           util_spawn_blocking("addr2line", 3, (const char **) argv, stdout_file, NULL);
           util_free_stringlist(argv , 3);
         }
-        
+
         /* 2: Parse stdout output */
         {
           bool at_eof;
@@ -84,9 +84,9 @@ static bool util_addr2line_lookup__(const void * bt_addr , char ** func_name , c
             char * stdout_file_name = util_fscanf_alloc_line(stream , &at_eof);
             char * line_string = NULL;
             util_binary_split_string( stdout_file_name , ":" , false , file_name , &line_string);
-            if (line_string && util_sscanf_int( line_string , line_nr)) 
+            if (line_string && util_sscanf_int( line_string , line_nr))
               address_found = true;
-            
+
             free( stdout_file_name );
             util_safe_free( line_string );
           }
@@ -95,8 +95,8 @@ static bool util_addr2line_lookup__(const void * bt_addr , char ** func_name , c
         }
         util_unlink_existing(stdout_file);
         free( stdout_file );
-      } 
-    } 
+      }
+    }
     return address_found;
 #endif
   }
@@ -159,7 +159,7 @@ static void util_fprintf_backtrace(FILE * stream) {
     char * func_name;
     char * file_name;
     char * padding = NULL;
-    
+
     if (util_addr2line_lookup(bt_addr[i] , &func_name , &file_name , &line_nr)) {
       int pad_length;
       char * function;
@@ -182,7 +182,7 @@ static void util_fprintf_backtrace(FILE * stream) {
         fprintf(stream , unknown_format , i , padding);
       }
     }
-    
+
     util_safe_free( func_name );
     util_safe_free( file_name );
     util_safe_free( padding );
@@ -198,7 +198,7 @@ char * util_alloc_dump_filename() {
     uid_t uid = getuid();
     struct passwd *pwd = getpwuid(uid);
     char * filename;
-    
+
     if (pwd)
       filename = util_alloc_sprintf("/tmp/ert_abort_dump.%s.%s.log", pwd->pw_name, day);
     else
@@ -235,15 +235,15 @@ void util_abort__(const char * file , const char * function , int line , const c
     char * filename = NULL;
     FILE * abort_dump = NULL;
 
-    if (!getenv("ERT_SHOW_BACKTRACE")) 
+    if (!getenv("ERT_SHOW_BACKTRACE"))
       filename = util_alloc_dump_filename();
 
     if (filename)
       abort_dump = fopen(filename, "w");
-    
-    if (abort_dump == NULL) 
+
+    if (abort_dump == NULL)
       abort_dump   = stderr;
-    
+
     va_list ap;
 
     va_start(ap , fmt);
@@ -296,7 +296,7 @@ void util_abort__(const char * file , const char * function , int line , const c
 
     free(filename);
   }
-  
+
   pthread_mutex_unlock(&__abort_mutex);
   signal(SIGABRT, SIG_DFL);
   abort();

--- a/devel/libert_util/src/util_abort_gnu.c
+++ b/devel/libert_util/src/util_abort_gnu.c
@@ -146,8 +146,8 @@ static void util_fprintf_backtrace(FILE * stream) {
   const char * func_format        = " #%02d %s(..) %s in ???\n";
   const char * unknown_format     = " #%02d ???? \n";
 
-  const int max_bt = 50;
-  const int max_func_length = 60;
+  const int max_bt = 100;
+  const int max_func_length = 70;
   void *bt_addr[max_bt];
   int    size,i;
 
@@ -160,7 +160,7 @@ static void util_fprintf_backtrace(FILE * stream) {
     char * file_name;
     char * padding = NULL;
 
-    if (util_addr2line_lookup(bt_addr[i] , &func_name , &file_name , &line_nr)) {
+    if (util_addr2line_lookup(bt_addr[i], &func_name , &file_name , &line_nr)) {
       int pad_length;
       char * function;
       // Seems it can return true - but with func_name == NULL?! Static/inlinded functions?
@@ -174,7 +174,7 @@ static void util_fprintf_backtrace(FILE * stream) {
       fprintf(stream , with_linenr_format , i , function , padding , file_name , line_nr);
     } else {
       if (func_name != NULL) {
-        int pad_length = 2 + max_func_length - strlen(func_name);
+        int pad_length = util_int_max( 2 , 2 + max_func_length - strlen(func_name));
         padding = realloc_padding( padding , pad_length);
         fprintf(stream , func_format , i , func_name , padding);
       } else {


### PR DESCRIPTION
The backtrace printing had issues with very long function names.