### PR TITLE
don't use reserved names for the guard macros

### DIFF
--- a/devel/VisualStudio/stdbool.h
+++ b/devel/VisualStudio/stdbool.h
@@ -13,8 +13,8 @@
   include directory as used by VisualStudio. 
 */
 
-#ifndef __STDBOOL_H__
-#define __STDBOOL_H__
+#ifndef ERT_STDBOOL_H
+#define ERT_STDBOOL_H
 
 #ifndef __cplusplus
 typedef int bool;

--- a/devel/libanalysis/include/ert/analysis/analysis_module.h
+++ b/devel/libanalysis/include/ert/analysis/analysis_module.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ANALYSIS_MODULE_H__
-#define __ANALYSIS_MODULE_H__
+#ifndef ERT_ANALYSIS_MODULE_H
+#define ERT_ANALYSIS_MODULE_H
 #ifdef  __cplusplus
 extern "C" {
 #endif

--- a/devel/libanalysis/include/ert/analysis/analysis_table.h
+++ b/devel/libanalysis/include/ert/analysis/analysis_table.h
@@ -1,5 +1,5 @@
-#ifndef __ANALYSIS_TABLE_H__
-#define __ANALYSIS_TABLE_H__
+#ifndef ERT_ANALYSIS_TABLE_H
+#define ERT_ANALYSIS_TABLE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libanalysis/include/ert/analysis/enkf_linalg.h
+++ b/devel/libanalysis/include/ert/analysis/enkf_linalg.h
@@ -1,5 +1,5 @@
-#ifndef __ENKF_LINALG_H__
-#define __ENKF_LINALG_H__
+#ifndef ERT_ENKF_LINALG_H
+#define ERT_ENKF_LINALG_H
 
 #include <ert/util/matrix_lapack.h>
 #include <ert/util/matrix.h>

--- a/devel/libanalysis/include/ert/analysis/std_enkf.h
+++ b/devel/libanalysis/include/ert/analysis/std_enkf.h
@@ -1,5 +1,5 @@
-#ifndef __STD_ENKF_H__
-#define __STD_ENKF_H__
+#ifndef ERT_STD_ENKF_H
+#define ERT_STD_ENKF_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libanalysis/modules/rml_enkf_common.h
+++ b/devel/libanalysis/modules/rml_enkf_common.h
@@ -1,5 +1,5 @@
-#ifndef __RML_ENKF_COMMON_H__
-#define __RML_ENKF_COMMON_H__
+#ifndef ERT_RML_ENKF_COMMON_H
+#define ERT_RML_ENKF_COMMON_H
 
 #include <stdbool.h>
 

--- a/devel/libconfig/include/ert/config/conf.h
+++ b/devel/libconfig/include/ert/config/conf.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONF_H__
-#define __CONF_H__
+#ifndef ERT_CONF_H
+#define ERT_CONF_H
 
 /* libconfig: lightweight configuration parser
  *

--- a/devel/libconfig/include/ert/config/conf_data.h
+++ b/devel/libconfig/include/ert/config/conf_data.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONF_DATA_H__
-#define __CONF_DATA_H__
+#ifndef ERT_CONF_DATA_H
+#define ERT_CONF_DATA_H
 #include <stdbool.h>
 #include <time.h>
 

--- a/devel/libconfig/include/ert/config/conf_util.h
+++ b/devel/libconfig/include/ert/config/conf_util.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONF_UTIL_H__
-#define __CONF_UTIL_H__
+#ifndef ERT_CONF_UTIL_H
+#define ERT_CONF_UTIL_H
 
 char * conf_util_fscanf_alloc_token_buffer(  const char * file_name );
 

--- a/devel/libconfig/include/ert/config/config_content.h
+++ b/devel/libconfig/include/ert/config/config_content.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __CONFIG_CONTENT_H__
-#define __CONFIG_CONTENT_H__
+#ifndef ERT_CONFIG_CONTENT_H
+#define ERT_CONFIG_CONTENT_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libconfig/include/ert/config/config_content_item.h
+++ b/devel/libconfig/include/ert/config/config_content_item.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __CONFIG_CONTENT_ITEM_H__
-#define __CONFIG_CONTENT_ITEM_H__
+#ifndef ERT_CONFIG_CONTENT_ITEM_H
+#define ERT_CONFIG_CONTENT_ITEM_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libconfig/include/ert/config/config_content_node.h
+++ b/devel/libconfig/include/ert/config/config_content_node.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __CONFIG_CONTENT_NODE_H__
-#define __CONFIG_CONTENT_NODE_H__
+#ifndef ERT_CONFIG_CONTENT_NODE_H
+#define ERT_CONFIG_CONTENT_NODE_H
 
 #ifdef __cplusplus
 define extern "C" {

--- a/devel/libconfig/include/ert/config/config_error.h
+++ b/devel/libconfig/include/ert/config/config_error.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONFIG_ERROR_H__
-#define __CONFIG_ERROR_H__
+#ifndef ERT_CONFIG_ERROR_H
+#define ERT_CONFIG_ERROR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libconfig/include/ert/config/config_parser.h
+++ b/devel/libconfig/include/ert/config/config_parser.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONFIG_H__
-#define __CONFIG_H__
+#ifndef ERT_CONFIG_H
+#define ERT_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libconfig/include/ert/config/config_path_elm.h
+++ b/devel/libconfig/include/ert/config/config_path_elm.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONFIG_PATH_ELM_H__
-#define __CONFIG_PATH_ELM_H__
+#ifndef ERT_CONFIG_PATH_ELM_H
+#define ERT_CONFIG_PATH_ELM_H
 
 #ifdef __cplusplus
 extern "C" 

--- a/devel/libconfig/include/ert/config/config_root_path.h
+++ b/devel/libconfig/include/ert/config/config_root_path.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONFIG_ROOT_PATH_H__
-#define __CONFIG_ROOT_PATH_H__
+#ifndef ERT_CONFIG_ROOT_PATH_H
+#define ERT_CONFIG_ROOT_PATH_H
 
 #ifdef __cplusplus
 extern "C" 

--- a/devel/libconfig/include/ert/config/config_schema_item.h
+++ b/devel/libconfig/include/ert/config/config_schema_item.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __CONFIG_SCHEMA_ITEM_H__
-#define __CONFIG_SCHEMA_ITEM_H__
+#ifndef ERT_CONFIG_SCHEMA_ITEM_H
+#define ERT_CONFIG_SCHEMA_ITEM_H
 
 #ifdef  __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_box.h
+++ b/devel/libecl/include/ert/ecl/ecl_box.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_BOX_H__
-#define __ECL_BOX_H__
+#ifndef ERT_ECL_BOX_H
+#define ERT_ECL_BOX_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_coarse_cell.h
+++ b/devel/libecl/include/ert/ecl/ecl_coarse_cell.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_COARSE_CELL_H__
-#define __ECL_COARSE_CELL_H__
+#ifndef ERT_ECL_COARSE_CELL_H
+#define ERT_ECL_COARSE_CELL_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl/include/ert/ecl/ecl_endian_flip.h
+++ b/devel/libecl/include/ert/ecl/ecl_endian_flip.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_ENDIAN_FLIP_H__
-#define __ECL_ENDIAN_FLIP_H__
+#ifndef ERT_ECL_ENDIAN_FLIP_H
+#define ERT_ECL_ENDIAN_FLIP_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_file.h
+++ b/devel/libecl/include/ert/ecl/ecl_file.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_FILE_H__
-#define __ECL_FILE_H__
+#ifndef ERT_ECL_FILE_H
+#define ERT_ECL_FILE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_file_kw.h
+++ b/devel/libecl/include/ert/ecl/ecl_file_kw.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_FILE_KW_H__
-#define __ECL_FILE_KW_H__
+#ifndef ERT_ECL_FILE_KW_H
+#define ERT_ECL_FILE_KW_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_grav.h
+++ b/devel/libecl/include/ert/ecl/ecl_grav.h
@@ -17,8 +17,8 @@
    for more details. 
 */
 
-#ifndef __ECL_GRAV_H__
-#define __ECL_GRAV_H__
+#ifndef ERT_ECL_GRAV_H
+#define ERT_ECL_GRAV_H
 #ifdef __plusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_grav_calc.h
+++ b/devel/libecl/include/ert/ecl/ecl_grav_calc.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef  __ECL_GRAV_CALC_H__
-#define  __ECL_GRAV_CALC_H__
+#ifndef  ERT_ECL_GRAV_CALC_H
+#define  ERT_ECL_GRAV_CALC_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_grav_common.h
+++ b/devel/libecl/include/ert/ecl/ecl_grav_common.h
@@ -17,8 +17,8 @@
    for more details. 
 */
 
-#ifndef __ECL_GRAV_COMMON_H__
-#define __ECL_GRAV_COMMON_H__
+#ifndef ERT_ECL_GRAV_COMMON_H
+#define ERT_ECL_GRAV_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_grid.h
+++ b/devel/libecl/include/ert/ecl/ecl_grid.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_GRID_H__
-#define __ECL_GRID_H__
+#ifndef ERT_ECL_GRID_H
+#define ERT_ECL_GRID_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_grid_cache.h
+++ b/devel/libecl/include/ert/ecl/ecl_grid_cache.h
@@ -17,8 +17,8 @@
    for more details. 
 */
 
-#ifndef __ECL_GRID_CACHE_H__
-#define __ECL_GRID_CACHE_H__
+#ifndef ERT_ECL_GRID_CACHE_H
+#define ERT_ECL_GRID_CACHE_H
 
 #include <ert/ecl/ecl_grid.h>
 

--- a/devel/libecl/include/ert/ecl/ecl_grid_dims.h
+++ b/devel/libecl/include/ert/ecl/ecl_grid_dims.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_GRID_DIMS_H__
-#define __ECL_GRID_DIMS_H__
+#ifndef ERT_ECL_GRID_DIMS_H
+#define ERT_ECL_GRID_DIMS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_init_file.h
+++ b/devel/libecl/include/ert/ecl/ecl_init_file.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_INIT_FILE_H__
-#define __ECL_INIT_FILE_H__
+#ifndef ERT_ECL_INIT_FILE_H
+#define ERT_ECL_INIT_FILE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_io_config.h
+++ b/devel/libecl/include/ert/ecl/ecl_io_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_IO_CONFIG_H__
-#define __ECL_IO_CONFIG_H__
+#ifndef ERT_ECL_IO_CONFIG_H
+#define ERT_ECL_IO_CONFIG_H
 
 
 typedef struct ecl_io_config_struct ecl_io_config_type;

--- a/devel/libecl/include/ert/ecl/ecl_kw.h
+++ b/devel/libecl/include/ert/ecl/ecl_kw.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_KW_H__
-#define __ECL_KW_H__
+#ifndef ERT_ECL_KW_H
+#define ERT_ECL_KW_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_kw_grdecl.h
+++ b/devel/libecl/include/ert/ecl/ecl_kw_grdecl.h
@@ -22,8 +22,8 @@
  header explicitly.
 */
 
-#ifndef __ECL_KW_GRDECL_H__
-#define __ECL_KW_GRDECL_H__
+#ifndef ERT_ECL_KW_GRDECL_H
+#define ERT_ECL_KW_GRDECL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_kw_magic.h
+++ b/devel/libecl/include/ert/ecl/ecl_kw_magic.h
@@ -1,5 +1,5 @@
-#ifndef __ECL_KW_MAGIC_H__
-#define __ECL_KW_MAGIC_H__
+#ifndef ERT_ECL_KW_MAGIC_H
+#define ERT_ECL_KW_MAGIC_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_nnc_export.h
+++ b/devel/libecl/include/ert/ecl/ecl_nnc_export.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ECL_NNC_EXPORT__
-#define __ECL_NNC_EXPORT__
+#ifndef ERT_ECL_NNC_EXPORT
+#define ERT_ECL_NNC_EXPORT
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_region.h
+++ b/devel/libecl/include/ert/ecl/ecl_region.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_REGION_H__
-#define __ECL_REGION_H__
+#ifndef ERT_ECL_REGION_H
+#define ERT_ECL_REGION_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_rft_cell.h
+++ b/devel/libecl/include/ert/ecl/ecl_rft_cell.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_RFT_CELL_H__
-#define __ECL_RFT_CELL_H__
+#ifndef ERT_ECL_RFT_CELL_H
+#define ERT_ECL_RFT_CELL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_rft_file.h
+++ b/devel/libecl/include/ert/ecl/ecl_rft_file.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_RFT_FILE_H__
-#define __ECL_RFT_FILE_H__
+#ifndef ERT_ECL_RFT_FILE_H
+#define ERT_ECL_RFT_FILE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_rft_node.h
+++ b/devel/libecl/include/ert/ecl/ecl_rft_node.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_RFT_NODE_H__
-#define __ECL_RFT_NODE_H__
+#ifndef ERT_ECL_RFT_NODE_H
+#define ERT_ECL_RFT_NODE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_rst_file.h
+++ b/devel/libecl/include/ert/ecl/ecl_rst_file.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ECL_RST_FILE_H__
-#define __ECL_RST_FILE_H__
+#ifndef ERT_ECL_RST_FILE_H
+#define ERT_ECL_RST_FILE_H
 
 #include <ert/ecl/ecl_rsthead.h>
 

--- a/devel/libecl/include/ert/ecl/ecl_rsthead.h
+++ b/devel/libecl/include/ert/ecl/ecl_rsthead.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_RSTHEAD_H__
-#define __ECL_RSTHEAD_H__
+#ifndef ERT_ECL_RSTHEAD_H
+#define ERT_ECL_RSTHEAD_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_smspec.h
+++ b/devel/libecl/include/ert/ecl/ecl_smspec.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_SMSPEC__
-#define __ECL_SMSPEC__
+#ifndef ERT_ECL_SMSPEC
+#define ERT_ECL_SMSPEC
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_subsidence.h
+++ b/devel/libecl/include/ert/ecl/ecl_subsidence.h
@@ -17,8 +17,8 @@
    for more details.
 */
 
-#ifndef __ECL_SUBSIDENCE_H__
-#define __ECL_SUBSICENCE_H__
+#ifndef ERT_ECL_SUBSIDENCE_H
+#define ERT_ECL_SUBSICENCE_H
 #ifdef __plusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/ecl_sum.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_SUM_H__
-#define __ECL_SUM_H__
+#ifndef ERT_ECL_SUM_H
+#define ERT_ECL_SUM_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_sum_data.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_data.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_SUM_DATA_H__
-#define __ECL_SUM_DATA_H__
+#ifndef ERT_ECL_SUM_DATA_H
+#define ERT_ECL_SUM_DATA_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl/include/ert/ecl/ecl_sum_index.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_index.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ECL_SUM_INDEX_H__
-#define __ECL_SUM_INDEX_H__
+#ifndef ERT_ECL_SUM_INDEX_H
+#define ERT_ECL_SUM_INDEX_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_SUM_TSTEP_H__
-#define __ECL_SUM_TSTEP_H__
+#ifndef ERT_ECL_SUM_TSTEP_H
+#define ERT_ECL_SUM_TSTEP_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_sum_vector.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_vector.h
@@ -16,8 +16,8 @@
   for more details.
 */
 
-#ifndef __ECL_SUM_VECTOR_H__
-#define __ECL_SUM_VECTOR_H__
+#ifndef ERT_ECL_SUM_VECTOR_H
+#define ERT_ECL_SUM_VECTOR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/ecl_util.h
+++ b/devel/libecl/include/ert/ecl/ecl_util.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_UTIL_H__
-#define __ECL_UTIL_H__
+#ifndef ERT_ECL_UTIL_H
+#define ERT_ECL_UTIL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/fault_block.h
+++ b/devel/libecl/include/ert/ecl/fault_block.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FAULT_BLOCK_H__
-#define __FAULT_BLOCK_H__
+#ifndef ERT_FAULT_BLOCK_H
+#define ERT_FAULT_BLOCK_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/fault_block_layer.h
+++ b/devel/libecl/include/ert/ecl/fault_block_layer.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FAULT_BLOCK_LAYER_H__
-#define __FAULT_BLOCK_LAYER_H__
+#ifndef ERT_FAULT_BLOCK_LAYER_H
+#define ERT_FAULT_BLOCK_LAYER_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/fortio.h
+++ b/devel/libecl/include/ert/ecl/fortio.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FORTIO_H__
-#define __FORTIO_H__
+#ifndef ERT_FORTIO_H
+#define ERT_FORTIO_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/grid_dims.h
+++ b/devel/libecl/include/ert/ecl/grid_dims.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GRID_DIMS_H__
-#define __GRID_DIMS_H__
+#ifndef ERT_GRID_DIMS_H
+#define ERT_GRID_DIMS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/layer.h
+++ b/devel/libecl/include/ert/ecl/layer.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __LAYER_H__
-#define __LAYER_H__
+#ifndef ERT_LAYER_H
+#define ERT_LAYER_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl/include/ert/ecl/nnc_info.h
+++ b/devel/libecl/include/ert/ecl/nnc_info.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __NNC_INFO_H__
-#define __NNC_INFO_H__
+#ifndef ERT_NNC_INFO_H
+#define ERT_NNC_INFO_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/nnc_vector.h
+++ b/devel/libecl/include/ert/ecl/nnc_vector.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __NNC_VECTOR_H__
-#define __NNC_VECTOR_H__
+#ifndef ERT_NNC_VECTOR_H
+#define ERT_NNC_VECTOR_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/point.h
+++ b/devel/libecl/include/ert/ecl/point.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __POINT_H__
-#define __POINT_H__
+#ifndef ERT_POINT_H
+#define ERT_POINT_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libecl/include/ert/ecl/smspec_node.h
+++ b/devel/libecl/include/ert/ecl/smspec_node.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __SMSPEC_NODE_H__
-#define __SMSPEC_NODE_H__
+#ifndef ERT_SMSPEC_NODE_H
+#define ERT_SMSPEC_NODE_H
 
 #include <stdbool.h>
 

--- a/devel/libecl/include/ert/ecl/tetrahedron.h
+++ b/devel/libecl/include/ert/ecl/tetrahedron.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __TETRAHEDRON_H__
-#define __TETRAHEDRON_H__
+#ifndef ERT_TETRAHEDRON_H
+#define ERT_TETRAHEDRON_H
 
 
 typedef struct tetrahedron_struct tetrahedron_type;

--- a/devel/libecl_well/include/ert/ecl_well/well_branch_collection.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_branch_collection.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_BRANCH_COLLECTION_H__
-#define __WELL_BRANCH_COLLECTION_H__
+#ifndef ERT_WELL_BRANCH_COLLECTION_H
+#define ERT_WELL_BRANCH_COLLECTION_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl_well/include/ert/ecl_well/well_conn.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_conn.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_CONN_H__
-#define __WELL_CONN_H__
+#ifndef ERT_WELL_CONN_H
+#define ERT_WELL_CONN_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl_well/include/ert/ecl_well/well_conn_collection.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_conn_collection.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_CONN_COLLECTION_H__
-#define __WELL_CONN_COLLECTION_H__
+#ifndef ERT_WELL_CONN_COLLECTION_H
+#define ERT_WELL_CONN_COLLECTION_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl_well/include/ert/ecl_well/well_const.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_const.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_CONST_H__
-#define __WELL_CONST_H__
+#ifndef ERT_WELL_CONST_H
+#define ERT_WELL_CONST_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl_well/include/ert/ecl_well/well_info.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_info.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __WELL_INFO_H__
-#define __WELL_INFO_H__
+#ifndef ERT_WELL_INFO_H
+#define ERT_WELL_INFO_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl_well/include/ert/ecl_well/well_rseg_loader.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_rseg_loader.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __WELL_RSEG_LOADER_H__
-#define __WELL_RSEG_LOADER_H__
+#ifndef ERT_WELL_RSEG_LOADER_H
+#define ERT_WELL_RSEG_LOADER_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl_well/include/ert/ecl_well/well_segment.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_segment.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_SEGMENT_H__
-#define __WELL_SEGMENT_H__
+#ifndef ERT_WELL_SEGMENT_H
+#define ERT_WELL_SEGMENT_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl_well/include/ert/ecl_well/well_segment_collection.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_segment_collection.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_SEGMENT_COLLECTION_H__
-#define __WELL_SEGMENT_COLLECTION_H__
+#ifndef ERT_WELL_SEGMENT_COLLECTION_H
+#define ERT_WELL_SEGMENT_COLLECTION_H
 
 
 #ifdef __cplusplus

--- a/devel/libecl_well/include/ert/ecl_well/well_state.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_state.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_STATE_H__
-#define __WELL_STATE_H__
+#ifndef ERT_WELL_STATE_H
+#define ERT_WELL_STATE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libecl_well/include/ert/ecl_well/well_ts.h
+++ b/devel/libecl_well/include/ert/ecl_well/well_ts.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __WELL_TS_H__
-#define __WELL_TS_H__
+#ifndef ERT_WELL_TS_H
+#define ERT_WELL_TS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/applications/ert_tui/enkf_tui_QC.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_QC.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_QC_H__
-#define __ENKF_TUI_QC_H__
+#ifndef ERT_ENKF_TUI_QC_H
+#define ERT_ENKF_TUI_QC_H
 
 
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_analysis.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_analysis.h
@@ -17,8 +17,8 @@
    for more details. 
 */
 
-#ifndef  __ENKF_TUI_ANALYSIS_H__
-#define  __ENKF_TUI_ANALYSIS_H__
+#ifndef  ERT_ENKF_TUI_ANALYSIS_H
+#define  ERT_ENKF_TUI_ANALYSIS_H
 
 void enkf_tui_analysis_menu(void *);
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_export.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_export.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_EXPORT_H__
-#define __ENKF_TUI_EXPORT_H__
+#ifndef ERT_ENKF_TUI_EXPORT_H
+#define ERT_ENKF_TUI_EXPORT_H
 
 void enkf_tui_export_menu(void *);
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_fs.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_fs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_FS_H__
-#define __ENKF_TUI_FS_H__
+#ifndef ERT_ENKF_TUI_FS_H
+#define ERT_ENKF_TUI_FS_H
 
 void enkf_tui_fs_menu(void * );
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_help.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_help.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_HELP_H__
-#define __ENKF_TUI_HELP_H__
+#ifndef ERT_ENKF_TUI_HELP_H
+#define ERT_ENKF_TUI_HELP_H
 
 
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_init.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_init.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_INIT_H__
-#define __ENKF_TUI_INIT_H__
+#ifndef ERT_ENKF_TUI_INIT_H
+#define ERT_ENKF_TUI_INIT_H
 
 
 void enkf_tui_init_menu(void * );

--- a/devel/libenkf/applications/ert_tui/enkf_tui_main.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_main.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_INTER_MAIN_H__
-#define __ENKF_INTER_MAIN_H__
+#ifndef ERT_ENKF_INTER_MAIN_H
+#define ERT_ENKF_INTER_MAIN_H
 #include <ert/enkf/enkf_main.h>
 
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_misc.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_misc.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_MISC_H__
-#define __ENKF_TUI_MISC_H__
+#ifndef ERT_ENKF_TUI_MISC_H
+#define ERT_ENKF_TUI_MISC_H
 
 
 void enkf_tui_misc_menu( void * arg);

--- a/devel/libenkf/applications/ert_tui/enkf_tui_ranking.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_ranking.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_RANKING_H__
-#define __ENKF_TUI_RANKING_H__
+#ifndef ERT_ENKF_TUI_RANKING_H
+#define ERT_ENKF_TUI_RANKING_H
 
 
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_run.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_run.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef  __ENKF_TUI_RUN_H__
-#define  __ENKF_TUI_RUN_H__
+#ifndef  ERT_ENKF_TUI_RUN_H
+#define  ERT_ENKF_TUI_RUN_H
 
 void enkf_tui_run_menu(void *);
 void enkf_tui_run_exp(void *);

--- a/devel/libenkf/applications/ert_tui/enkf_tui_simple.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_simple.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_SIMPLE_H__
-#define __ENKF_TUI_SIMPLE_H__
+#ifndef ERT_ENKF_TUI_SIMPLE_H
+#define ERT_ENKF_TUI_SIMPLE_H
 
 
 void enkf_tui_simple_menu(void * );

--- a/devel/libenkf/applications/ert_tui/enkf_tui_table.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_table.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_TABLE__
-#define __ENKF_TUI_TABLE__
+#ifndef ERT_ENKF_TUI_TABLE
+#define ERT_ENKF_TUI_TABLE
 
 void enkf_tui_table_menu(void * );
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_util.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_util.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_TUI_UTIL_H__
-#define __ENKF_TUI_UTIL_H__
+#ifndef ERT_ENKF_TUI_UTIL_H
+#define ERT_ENKF_TUI_UTIL_H
 
 #include <ert/util/bool_vector.h>
 

--- a/devel/libenkf/applications/ert_tui/enkf_tui_workflow.h
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_workflow.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef  __ENKF_TUI_WORKFLOW_H__
-#define  __ENKF_TUI_WORKFLOW_H__
+#ifndef  ERT_ENKF_TUI_WORKFLOW_H
+#define  ERT_ENKF_TUI_WORKFLOW_H
 
 void enkf_tui_workflow_menu(void *);
 

--- a/devel/libenkf/applications/ert_tui/ert_tui_const.h
+++ b/devel/libenkf/applications/ert_tui/ert_tui_const.h
@@ -16,7 +16,7 @@
    for more details. 
 */
 
-#ifndef __ERT_TUI_CONST__
+#ifndef ERT_TUI_CONST
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/active_config.h
+++ b/devel/libenkf/include/ert/enkf/active_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ACTIVE_CONFIG_H__
-#define __ACTIVE_CONFIG_H__
+#ifndef ERT_ACTIVE_CONFIG_H
+#define ERT_ACTIVE_CONFIG_H
 
 
 #endif

--- a/devel/libenkf/include/ert/enkf/active_list.h
+++ b/devel/libenkf/include/ert/enkf/active_list.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ACTIVE_LIST_H__
-#define __ACTIVE_LIST_H__
+#ifndef ERT_ACTIVE_LIST_H
+#define ERT_ACTIVE_LIST_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/active_node.h
+++ b/devel/libenkf/include/ert/enkf/active_node.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ACTIVE_NODE_H__
-#define __ACTIVE_NODE_H__
+#ifndef ERT_ACTIVE_NODE_H
+#define ERT_ACTIVE_NODE_H
 
 
 typedef struct active_var_struct active_var_type;

--- a/devel/libenkf/include/ert/enkf/analysis_config.h
+++ b/devel/libenkf/include/ert/enkf/analysis_config.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ANALYSIS_CONFIG_H__
-#define __ANALYSIS_CONFIG_H__
+#ifndef ERT_ANALYSIS_CONFIG_H
+#define ERT_ANALYSIS_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/analysis_iter_config.h
+++ b/devel/libenkf/include/ert/enkf/analysis_iter_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ANALYSIS_ITER_CONFIG_H__
-#define __ANALYSIS_ITER_CONFIG_H__
+#ifndef ERT_ANALYSIS_ITER_CONFIG_H
+#define ERT_ANALYSIS_ITER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/block_fs_driver.h
+++ b/devel/libenkf/include/ert/enkf/block_fs_driver.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __BLOCK_FS_DRIVER_H__
-#define __BLOCK_FS_DRIVER_H__
+#ifndef ERT_BLOCK_FS_DRIVER_H
+#define ERT_BLOCK_FS_DRIVER_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/block_obs.h
+++ b/devel/libenkf/include/ert/enkf/block_obs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __BLOCK_OBS_H__
-#define __BLOCK_OBS_H__
+#ifndef ERT_BLOCK_OBS_H
+#define ERT_BLOCK_OBS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/cases_config.h
+++ b/devel/libenkf/include/ert/enkf/cases_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CASES_CONFIG_H__
-#define __CASES_CONFIG_H__
+#ifndef ERT_CASES_CONFIG_H
+#define ERT_CASES_CONFIG_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/config_keys.h
+++ b/devel/libenkf/include/ert/enkf/config_keys.h
@@ -17,8 +17,8 @@
  */
 
 
-#ifndef  __CONFIG_KEYS_H__
-#define  __CONFIG_KEYS_H__
+#ifndef  ERT_CONFIG_KEYS_H
+#define  ERT_CONFIG_KEYS_H
 #ifdef   __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/config_parser.h
+++ b/devel/libenkf/include/ert/enkf/config_parser.h
@@ -16,7 +16,7 @@
    for more details. 
 */
 
-#ifndef __CONFIG_PARSER_H__
-#define __CONFIG_PARSER_H__
+#ifndef ERT_CONFIG_PARSER_H
+#define ERT_CONFIG_PARSER_H
 
 #endif

--- a/devel/libenkf/include/ert/enkf/container.h
+++ b/devel/libenkf/include/ert/enkf/container.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONTAINER_H__
-#define __CONTAINER_H__
+#ifndef ERT_CONTAINER_H
+#define ERT_CONTAINER_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/container_config.h
+++ b/devel/libenkf/include/ert/enkf/container_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __CONTAINER_CONFIG_H__
-#define __CONTAINER_CONFIG_H__
+#ifndef ERT_CONTAINER_CONFIG_H
+#define ERT_CONTAINER_CONFIG_H
 
 
 #ifdef __cplusplus

--- a/devel/libenkf/include/ert/enkf/custom_kw.h
+++ b/devel/libenkf/include/ert/enkf/custom_kw.h
@@ -1,5 +1,5 @@
-#ifndef __CUSTOM_KW_H__
-#define __CUSTOM_KW_H__
+#ifndef ERT_CUSTOM_KW_H
+#define ERT_CUSTOM_KW_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/custom_kw_config.h
+++ b/devel/libenkf/include/ert/enkf/custom_kw_config.h
@@ -1,5 +1,5 @@
-#ifndef __CUSTOM_KW_CONFIG_H__
-#define __CUSTOM_KW_CONFIG_H__
+#ifndef ERT_CUSTOM_KW_CONFIG_H
+#define ERT_CUSTOM_KW_CONFIG_H
 #ifdef __cplusplus 
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/custom_kw_config_set.h
+++ b/devel/libenkf/include/ert/enkf/custom_kw_config_set.h
@@ -1,5 +1,5 @@
-#ifndef __CUSTOM_KW_CONFIG_SET_H__
-#define __CUSTOM_KW_CONFIG_SET_H__
+#ifndef ERT_CUSTOM_KW_CONFIG_SET_H
+#define ERT_CUSTOM_KW_CONFIG_SET_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/data_ranking.h
+++ b/devel/libenkf/include/ert/enkf/data_ranking.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __DATA_RANKING_H__
-#define __DATA_RANKING_H__
+#ifndef ERT_DATA_RANKING_H
+#define ERT_DATA_RANKING_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/ecl_config.h
+++ b/devel/libenkf/include/ert/enkf/ecl_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ECL_CONFIG_H__
-#define __ECL_CONFIG_H__
+#ifndef ERT_ECL_CONFIG_H
+#define ERT_ECL_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/ecl_refcase_list.h
+++ b/devel/libenkf/include/ert/enkf/ecl_refcase_list.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ECL_REFCASE_LIST_H__
-#define __ECL_REFCASE_LIST_H__
+#ifndef ERT_ECL_REFCASE_LIST_H
+#define ERT_ECL_REFCASE_LIST_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_analysis.h
+++ b/devel/libenkf/include/ert/enkf/enkf_analysis.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ENKF_ANALYSIS_H__
-#define __ENKF_ANALYSIS_H__
+#ifndef ERT_ENKF_ANALYSIS_H
+#define ERT_ENKF_ANALYSIS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_config_node.h
+++ b/devel/libenkf/include/ert/enkf/enkf_config_node.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_CONFIG_NODE_H__
-#define __ENKF_CONFIG_NODE_H__
+#ifndef ERT_ENKF_CONFIG_NODE_H
+#define ERT_ENKF_CONFIG_NODE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/enkf_defaults.h
+++ b/devel/libenkf/include/ert/enkf/enkf_defaults.h
@@ -8,8 +8,8 @@
     
 */
 
-#ifndef __ENKF_DEFAULT__
-#define __ENKF_DEFAULT__
+#ifndef ERT_ENKF_DEFAULT
+#define ERT_ENKF_DEFAULT
 #include <stdbool.h>
 
 #define DEFAULT_RUNPATH_KEY  "DEFAULT_RUNPATH"
@@ -179,7 +179,7 @@
 
 
 /* The magic string used to signal that *ALL* static keywords should be included. */
-#define DEFAULT_ALL_STATIC_KW "__ALL__"
+#define DEFAULT_ALL_STATIC_KW "ERT_ALL"
 #define NUM_STATIC_KW          56
 
 /* 

--- a/devel/libenkf/include/ert/enkf/enkf_fs.h
+++ b/devel/libenkf/include/ert/enkf/enkf_fs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_FS_H__
-#define __ENKF_FS_H__
+#ifndef ERT_ENKF_FS_H
+#define ERT_ENKF_FS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/enkf_fs_type.h
+++ b/devel/libenkf/include/ert/enkf/enkf_fs_type.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_FS_TYPES_H__
-#define __ENKF_FS_TYPES_H__
+#ifndef ERT_ENKF_FS_TYPES_H
+#define ERT_ENKF_FS_TYPES_H
 typedef struct enkf_fs_struct enkf_fs_type;
 #endif
 

--- a/devel/libenkf/include/ert/enkf/enkf_macros.h
+++ b/devel/libenkf/include/ert/enkf/enkf_macros.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_MACROS_H__
-#define __ENKF_MACROS_H__
+#ifndef ERT_ENKF_MACROS_H
+#define ERT_ENKF_MACROS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/enkf_main.h
+++ b/devel/libenkf/include/ert/enkf/enkf_main.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_MAIN_H__
-#define __ENKF_MAIN_H__
+#ifndef ERT_ENKF_MAIN_H
+#define ERT_ENKF_MAIN_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/enkf_main_update.h
+++ b/devel/libenkf/include/ert/enkf/enkf_main_update.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_MAIN_UPDATE__
-#define __ENKF_MAIN_UPDATE__
+#ifndef ERT_ENKF_MAIN_UPDATE
+#define ERT_ENKF_MAIN_UPDATE
 
 #include <enkf_main.h>
 

--- a/devel/libenkf/include/ert/enkf/enkf_node.h
+++ b/devel/libenkf/include/ert/enkf/enkf_node.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_NODE_H__
-#define __ENKF_NODE_H__
+#ifndef ERT_ENKF_NODE_H
+#define ERT_ENKF_NODE_H
 #include <stdlib.h>
 #include <stdbool.h>
 

--- a/devel/libenkf/include/ert/enkf/enkf_obs.h
+++ b/devel/libenkf/include/ert/enkf/enkf_obs.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_OBS_H__
-#define __ENKF_OBS_H__
+#ifndef ERT_ENKF_OBS_H
+#define ERT_ENKF_OBS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/enkf_plot_data.h
+++ b/devel/libenkf/include/ert/enkf/enkf_plot_data.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ENKF_PLOT_DATA_H__
-#define __ENKF_PLOT_DATA_H__
+#ifndef ERT_ENKF_PLOT_DATA_H
+#define ERT_ENKF_PLOT_DATA_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_plot_gen_kw.h
+++ b/devel/libenkf/include/ert/enkf/enkf_plot_gen_kw.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ENKF_PLOT_GEN_KW_H__
-#define __ENKF_PLOT_GEN_KW_H__
+#ifndef ERT_ENKF_PLOT_GEN_KW_H
+#define ERT_ENKF_PLOT_GEN_KW_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_plot_gen_kw_vector.h
+++ b/devel/libenkf/include/ert/enkf/enkf_plot_gen_kw_vector.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ENKF_PLOT_GEN_KW_VECTOR_H__
-#define __ENKF_PLOT_GEN_KW_VECTOR_H__
+#ifndef ERT_ENKF_PLOT_GEN_KW_VECTOR_H
+#define ERT_ENKF_PLOT_GEN_KW_VECTOR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_plot_gendata.h
+++ b/devel/libenkf/include/ert/enkf/enkf_plot_gendata.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_PLOT_GENDATA_H__
-#define __ENKF_PLOT_GENDATA_H__
+#ifndef ERT_ENKF_PLOT_GENDATA_H
+#define ERT_ENKF_PLOT_GENDATA_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_plot_genvector.h
+++ b/devel/libenkf/include/ert/enkf/enkf_plot_genvector.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_PLOT_GENVECTOR_H__
-#define __ENKF_PLOT_GENVECTOR_H__
+#ifndef ERT_ENKF_PLOT_GENVECTOR_H
+#define ERT_ENKF_PLOT_GENVECTOR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_plot_tvector.h
+++ b/devel/libenkf/include/ert/enkf/enkf_plot_tvector.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __ENKF_PLOT_TVECTOR_H__
-#define __ENKF_PLOT_TVECTOR_H__
+#ifndef ERT_ENKF_PLOT_TVECTOR_H
+#define ERT_ENKF_PLOT_TVECTOR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/enkf_serialize.h
+++ b/devel/libenkf/include/ert/enkf/enkf_serialize.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_SERIALIZE_H__
-#define __ENKF_SERIALIZE_H__
+#ifndef ERT_ENKF_SERIALIZE_H
+#define ERT_ENKF_SERIALIZE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/enkf_state.h
+++ b/devel/libenkf/include/ert/enkf/enkf_state.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_STATE_H__
-#define __ENKF_STATE_H__
+#ifndef ERT_ENKF_STATE_H
+#define ERT_ENKF_STATE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/enkf_types.h
+++ b/devel/libenkf/include/ert/enkf/enkf_types.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENKF_TYPES_H__
-#define __ENKF_TYPES_H__
+#ifndef ERT_ENKF_TYPES_H
+#define ERT_ENKF_TYPES_H
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -85,7 +85,7 @@ keep_runpath_type;
    parameter.
 
    These correspond to implementation types. The numbers are on disk,
-   and should **NOT BE UPDATED**. The __MIN_TYPE and __MAX_TYPE
+   and should **NOT BE UPDATED**. The ERT_MIN_TYPE and MAX_TYPE
    identifiers are needed for the block_fs_driver.
 */
 

--- a/devel/libenkf/include/ert/enkf/enkf_util.h
+++ b/devel/libenkf/include/ert/enkf/enkf_util.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ENKF_UTIL_H__
-#define __ENKF_UTIL_H__
+#ifndef ERT_ENKF_UTIL_H
+#define ERT_ENKF_UTIL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/ensemble_config.h
+++ b/devel/libenkf/include/ert/enkf/ensemble_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ENSEMBLE_CONFIG_H__
-#define __ENSEMBLE_CONFIG_H__
+#ifndef ERT_ENSEMBLE_CONFIG_H
+#define ERT_ENSEMBLE_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/ert_run_context.h
+++ b/devel/libenkf/include/ert/enkf/ert_run_context.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __ERT_RUN_CONTEXT_H__
-#define __ERT_RUN_CONTEXT_H__
+#ifndef ERT_RUN_CONTEXT_H
+#define ERT_RUN_CONTEXT_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/ert_template.h
+++ b/devel/libenkf/include/ert/enkf/ert_template.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ERT_TEMPLATE_H__
-#define __ERT_TEMPLATE_H__
+#ifndef ERT_TEMPLATE_H
+#define ERT_TEMPLATE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/ert_workflow_list.h
+++ b/devel/libenkf/include/ert/enkf/ert_workflow_list.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ERT_WORKFLOW_LIST_H__
-#define __ERT_WORKFLOW_LIST_H__
+#ifndef ERT_WORKFLOW_LIST_H
+#define ERT_WORKFLOW_LIST_H
 
 
 #ifdef __cplusplus

--- a/devel/libenkf/include/ert/enkf/field.h
+++ b/devel/libenkf/include/ert/enkf/field.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FIELD_H__
-#define __FIELD_H__
+#ifndef ERT_FIELD_H
+#define ERT_FIELD_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/field_common.h
+++ b/devel/libenkf/include/ert/enkf/field_common.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FIELD_COMMON_H__
-#define __FIELD_COMMON_H__
+#ifndef ERT_FIELD_COMMON_H
+#define ERT_FIELD_COMMON_H
 
 /*
   Contains some headers which both field.c and field_config.c need -

--- a/devel/libenkf/include/ert/enkf/field_config.h
+++ b/devel/libenkf/include/ert/enkf/field_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FIELD_CONFIG_H__
-#define __FIELD_CONFIG_H__
+#ifndef ERT_FIELD_CONFIG_H
+#define ERT_FIELD_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/field_trans.h
+++ b/devel/libenkf/include/ert/enkf/field_trans.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FIELD_TRANS_H__
-#define __FIELD_TRANS_H__
+#ifndef ERT_FIELD_TRANS_H
+#define ERT_FIELD_TRANS_H
 #ifdef __cplusplus 
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/forward_load_context.h
+++ b/devel/libenkf/include/ert/enkf/forward_load_context.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __FORWARD_LOAD_CONTEXT_H__
-#define __FORWARD_LOAD_CONTEXT_H__
+#ifndef ERT_FORWARD_LOAD_CONTEXT_H
+#define ERT_FORWARD_LOAD_CONTEXT_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/fs_driver.h
+++ b/devel/libenkf/include/ert/enkf/fs_driver.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FS_DRIVER_H__
-#define __FS_DRIVER_H__ 
+#ifndef ERT_FS_DRIVER_H
+#define ERT_FS_DRIVER_H 
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/fs_types.h
+++ b/devel/libenkf/include/ert/enkf/fs_types.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FS_TYPES_H__
-#define __FS_TYPES_H__
+#ifndef ERT_FS_TYPES_H
+#define ERT_FS_TYPES_H
 
 
 

--- a/devel/libenkf/include/ert/enkf/gen_common.h
+++ b/devel/libenkf/include/ert/enkf/gen_common.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GEN_COMMON_H__
-#define __GEN_COMMON_H__
+#ifndef ERT_GEN_COMMON_H
+#define ERT_GEN_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/gen_data.h
+++ b/devel/libenkf/include/ert/enkf/gen_data.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __GEN_DATA_H__
-#define __GEN_DATA_H__
+#ifndef ERT_GEN_DATA_H
+#define ERT_GEN_DATA_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/gen_data_common.h
+++ b/devel/libenkf/include/ert/enkf/gen_data_common.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GEN_DATA_COMMON_H__
-#define __GEN_DATA_COMMON_H__
+#ifndef ERT_GEN_DATA_COMMON_H
+#define ERT_GEN_DATA_COMMON_H
 
 /*
   Contains some headers which both gen_data.c and gen_data_config.c need -

--- a/devel/libenkf/include/ert/enkf/gen_data_config.h
+++ b/devel/libenkf/include/ert/enkf/gen_data_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __GEN_DATA_CONFIG_H__
-#define __GEN_DATA_CONFIG_H__
+#ifndef ERT_GEN_DATA_CONFIG_H
+#define ERT_GEN_DATA_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/gen_kw.h
+++ b/devel/libenkf/include/ert/enkf/gen_kw.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GEN_KW_H__
-#define __GEN_KW_H__
+#ifndef ERT_GEN_KW_H
+#define ERT_GEN_KW_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/gen_kw_common.h
+++ b/devel/libenkf/include/ert/enkf/gen_kw_common.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GEN_KW_COMMON_H__
-#define __GEN_KW_COMMON_H__
+#ifndef ERT_GEN_KW_COMMON_H
+#define ERT_GEN_KW_COMMON_H
 
 /*
   Contains some headers which both gen_kw.c and gen_kw_config.c need -

--- a/devel/libenkf/include/ert/enkf/gen_kw_config.h
+++ b/devel/libenkf/include/ert/enkf/gen_kw_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GEN_KW_CONFIG_H__
-#define __GEN_KW_CONFIG_H__
+#ifndef ERT_GEN_KW_CONFIG_H
+#define ERT_GEN_KW_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/gen_obs.h
+++ b/devel/libenkf/include/ert/enkf/gen_obs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GEN_OBS_H__
-#define __GEN_OBS_H__
+#ifndef ERT_GEN_OBS_H
+#define ERT_GEN_OBS_H
 
 #include <ert/enkf/gen_data_config.h>
 #include <ert/enkf/enkf_macros.h>

--- a/devel/libenkf/include/ert/enkf/hook_manager.h
+++ b/devel/libenkf/include/ert/enkf/hook_manager.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
-#ifndef __HOOK_MANAGER_H__
-#define __HOOK_MANAGER_H__
+#ifndef ERT_HOOK_MANAGER_H
+#define ERT_HOOK_MANAGER_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/hook_workflow.h
+++ b/devel/libenkf/include/ert/enkf/hook_workflow.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
-#ifndef __HOOK_WORKFLOW_H__
-#define __HOOK_WORKFLOW_H__
+#ifndef ERT_HOOK_WORKFLOW_H
+#define ERT_HOOK_WORKFLOW_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/local_config.h
+++ b/devel/libenkf/include/ert/enkf/local_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __LOCAL_CONFIG_H__
-#define __LOCAL_CONFIG_H__
+#ifndef ERT_LOCAL_CONFIG_H
+#define ERT_LOCAL_CONFIG_H
 
 #include <ert/util/stringlist.h>
 

--- a/devel/libenkf/include/ert/enkf/local_context.h
+++ b/devel/libenkf/include/ert/enkf/local_context.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __LOCAL_CONTEXT_H__
-#define __LOCAL_CONTEXT_H__
+#ifndef ERT_LOCAL_CONTEXT_H
+#define ERT_LOCAL_CONTEXT_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/local_dataset.h
+++ b/devel/libenkf/include/ert/enkf/local_dataset.h
@@ -17,8 +17,8 @@
    for more details.
 */
 
-#ifndef __LOCAL_DATASET_H__
-#define __LOCAL_DATASET_H__
+#ifndef ERT_LOCAL_DATASET_H
+#define ERT_LOCAL_DATASET_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/local_ministep.h
+++ b/devel/libenkf/include/ert/enkf/local_ministep.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __LOCAL_MINISTEP_H__
-#define __LOCAL_MINISTEP_H__
+#ifndef ERT_LOCAL_MINISTEP_H
+#define ERT_LOCAL_MINISTEP_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/local_obsdata.h
+++ b/devel/libenkf/include/ert/enkf/local_obsdata.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
-#ifndef __LOCAL_OBSDATA_H__
-#define __LOCAL_OBSDATA_H__
+#ifndef ERT_LOCAL_OBSDATA_H
+#define ERT_LOCAL_OBSDATA_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/local_obsdata_node.h
+++ b/devel/libenkf/include/ert/enkf/local_obsdata_node.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
-#ifndef __LOCAL_OBSDATA_NODE_H__
-#define __LOCAL_OBSDATA_NODE_H__
+#ifndef ERT_LOCAL_OBSDATA_NODE_H
+#define ERT_LOCAL_OBSDATA_NODE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/local_updatestep.h
+++ b/devel/libenkf/include/ert/enkf/local_updatestep.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __LOCAL_UPDATESTEP_H__
-#define __LOCAL_UPDATESTEP_H__
+#ifndef ERT_LOCAL_UPDATESTEP_H
+#define ERT_LOCAL_UPDATESTEP_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/meas_data.h
+++ b/devel/libenkf/include/ert/enkf/meas_data.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __MEAS_DATA_H__
-#define __MEAS_DATA_H__
+#ifndef ERT_MEAS_DATA_H
+#define ERT_MEAS_DATA_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/member_config.h
+++ b/devel/libenkf/include/ert/enkf/member_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __MEMBER_CONFIG_H__
-#define __MEMBER_CONFIG_H__
+#ifndef ERT_MEMBER_CONFIG_H
+#define ERT_MEMBER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/misfit_ensemble.h
+++ b/devel/libenkf/include/ert/enkf/misfit_ensemble.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __MISFIT_ENSEMBLE_H__
-#define __MISFIT_ENSEMBLE_H__
+#ifndef ERT_MISFIT_ENSEMBLE_H
+#define ERT_MISFIT_ENSEMBLE_H
 
 #include <stdbool.h>
 

--- a/devel/libenkf/include/ert/enkf/misfit_ensemble_typedef.h
+++ b/devel/libenkf/include/ert/enkf/misfit_ensemble_typedef.h
@@ -1,5 +1,5 @@
-#ifndef __MISFIT_ENSEMBLE_TYPEDEF_H__
-#define __MISFIT_ENSEMBLE_TYPEDEF_H__
+#ifndef ERT_MISFIT_ENSEMBLE_TYPEDEF_H
+#define ERT_MISFIT_ENSEMBLE_TYPEDEF_H
 
 typedef struct misfit_ensemble_struct misfit_ensemble_type;
 

--- a/devel/libenkf/include/ert/enkf/misfit_member.h
+++ b/devel/libenkf/include/ert/enkf/misfit_member.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __MISFIT_MEMBER_H__
-#define __MISFIT_MEMBER_H__
+#ifndef ERT_MISFIT_MEMBER_H
+#define ERT_MISFIT_MEMBER_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/misfit_ranking.h
+++ b/devel/libenkf/include/ert/enkf/misfit_ranking.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __MISFIT_RANKING_H__
-#define __MISFIT_RANKING_H__
+#ifndef ERT_MISFIT_RANKING_H
+#define ERT_MISFIT_RANKING_H
 
 #include <ert/util/type_macros.h>
 #include <ert/util/int_vector.h>

--- a/devel/libenkf/include/ert/enkf/misfit_ts.h
+++ b/devel/libenkf/include/ert/enkf/misfit_ts.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __MISFIT_TS_H__
-#define __MISFIT_TS_H__
+#ifndef ERT_MISFIT_TS_H
+#define ERT_MISFIT_TS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/model_config.h
+++ b/devel/libenkf/include/ert/enkf/model_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __MODEL_CONFIG_H__
-#define __MODEL_CONFIG_H__
+#ifndef ERT_MODEL_CONFIG_H
+#define ERT_MODEL_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/obs_data.h
+++ b/devel/libenkf/include/ert/enkf/obs_data.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __OBS_DATA_H__
-#define __OBS_DATA_H__
+#ifndef ERT_OBS_DATA_H
+#define ERT_OBS_DATA_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/obs_vector.h
+++ b/devel/libenkf/include/ert/enkf/obs_vector.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __OBS_VECTOR_H__
-#define __OBS_VECTOR_H__
+#ifndef ERT_OBS_VECTOR_H
+#define ERT_OBS_VECTOR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/pca_plot_data.h
+++ b/devel/libenkf/include/ert/enkf/pca_plot_data.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
    for more details. 
 */
-#ifndef __PCA_PLOT_DATA_H__
-#define __PCA_PLOT_DATA_H__
+#ifndef ERT_PCA_PLOT_DATA_H
+#define ERT_PCA_PLOT_DATA_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/pca_plot_vector.h
+++ b/devel/libenkf/include/ert/enkf/pca_plot_vector.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
    for more details. 
 */
-#ifndef __PCA_PLOT_VECTOR_H__
-#define __PCA_PLOT_VECTOR_H__
+#ifndef ERT_PCA_PLOT_VECTOR_H
+#define ERT_PCA_PLOT_VECTOR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/plain_driver.h
+++ b/devel/libenkf/include/ert/enkf/plain_driver.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __PLAIN_DRIVER_H__
-#define __PLAIN_DRIVER_H__
+#ifndef ERT_PLAIN_DRIVER_H
+#define ERT_PLAIN_DRIVER_H
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/devel/libenkf/include/ert/enkf/plain_driver_obs.h
+++ b/devel/libenkf/include/ert/enkf/plain_driver_obs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __PLAIN_DRIVER_OBS_H__
-#define __PLAIN_DRIVER_OBS_H__
+#ifndef ERT_PLAIN_DRIVER_OBS_H
+#define ERT_PLAIN_DRIVER_OBS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/plot_config.h
+++ b/devel/libenkf/include/ert/enkf/plot_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __PLOT_CONFIG_H__
-#define __PLOT_CONFIG_H__
+#ifndef ERT_PLOT_CONFIG_H
+#define ERT_PLOT_CONFIG_H
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_content.h>

--- a/devel/libenkf/include/ert/enkf/ranking_common.h
+++ b/devel/libenkf/include/ert/enkf/ranking_common.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RANKING_COMMON_H__
-#define __RANKING_COMMON_H__
+#ifndef ERT_RANKING_COMMON_H
+#define ERT_RANKING_COMMON_H
 #include <math.h>
 
 #define INVALID_RANKING_VALUE  INFINITY

--- a/devel/libenkf/include/ert/enkf/ranking_table.h
+++ b/devel/libenkf/include/ert/enkf/ranking_table.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __RANKING_TABLE_H__
-#define __RANKING_TABLE_H__
+#ifndef ERT_RANKING_TABLE_H
+#define ERT_RANKING_TABLE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/rng_config.h
+++ b/devel/libenkf/include/ert/enkf/rng_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __RNG_CONFIG_H__
-#define __RNG_CONFIG_H__
+#ifndef ERT_RNG_CONFIG_H
+#define ERT_RNG_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/run_arg.h
+++ b/devel/libenkf/include/ert/enkf/run_arg.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __RUN_ARG_H__
-#define __RUN_ARG_H__
+#ifndef ERT_RUN_ARG_H
+#define ERT_RUN_ARG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/run_arg_type.h
+++ b/devel/libenkf/include/ert/enkf/run_arg_type.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __RUN_ARG_TYPE_H__
-#define __RUN_ARG_TYPE_H__
+#ifndef ERT_RUN_ARG_TYPE_H
+#define ERT_RUN_ARG_TYPE_H
 
 typedef struct run_arg_struct run_arg_type;
 

--- a/devel/libenkf/include/ert/enkf/runpath_list.h
+++ b/devel/libenkf/include/ert/enkf/runpath_list.h
@@ -15,8 +15,8 @@
    for more details. 
 */
 
-#ifndef __RUNPATH_LIST_H__
-#define __RUNPATH_LIST_H__
+#ifndef ERT_RUNPATH_LIST_H
+#define ERT_RUNPATH_LIST_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/scalar_config.h
+++ b/devel/libenkf/include/ert/enkf/scalar_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCALAR_CONFIG_H__
-#define __SCALAR_CONFIG_H__
+#ifndef ERT_SCALAR_CONFIG_H
+#define ERT_SCALAR_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/site_config.h
+++ b/devel/libenkf/include/ert/enkf/site_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __SITE_CONFIG_H__
-#define __SITE_CONFIG_H__
+#ifndef ERT_SITE_CONFIG_H
+#define ERT_SITE_CONFIG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libenkf/include/ert/enkf/state_map.h
+++ b/devel/libenkf/include/ert/enkf/state_map.h
@@ -15,8 +15,8 @@
    for more details. 
 */
 
-#ifndef __STATE_MAP_H__
-#define __STATE_MAP_H__
+#ifndef ERT_STATE_MAP_H
+#define ERT_STATE_MAP_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/summary.h
+++ b/devel/libenkf/include/ert/enkf/summary.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SUMMARY_H__
-#define __SUMMARY_H__
+#ifndef ERT_SUMMARY_H
+#define ERT_SUMMARY_H
 #include <ert/util/double_vector.h>
 
 #include <ert/ecl/ecl_sum.h>

--- a/devel/libenkf/include/ert/enkf/summary_config.h
+++ b/devel/libenkf/include/ert/enkf/summary_config.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __SUMMARY_CONFIG_H__
-#define __SUMMARY_CONFIG_H__
+#ifndef ERT_SUMMARY_CONFIG_H
+#define ERT_SUMMARY_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/summary_key_matcher.h
+++ b/devel/libenkf/include/ert/enkf/summary_key_matcher.h
@@ -1,5 +1,5 @@
-#ifndef __SUMMARY_KEY_MATCHER_H__
-#define __SUMMARY_KEY_MATCHER_H__
+#ifndef ERT_SUMMARY_KEY_MATCHER_H
+#define ERT_SUMMARY_KEY_MATCHER_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/summary_key_set.h
+++ b/devel/libenkf/include/ert/enkf/summary_key_set.h
@@ -1,5 +1,5 @@
-#ifndef __SUMMARY_KEY_SET_H__
-#define __SUMMARY_KEY_SET_H__
+#ifndef ERT_SUMMARY_KEY_SET_H
+#define ERT_SUMMARY_KEY_SET_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/summary_obs.h
+++ b/devel/libenkf/include/ert/enkf/summary_obs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SUMMARY_OBS_H__
-#define __SUMMARY_OBS_H__
+#ifndef ERT_SUMMARY_OBS_H
+#define ERT_SUMMARY_OBS_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/surface.h
+++ b/devel/libenkf/include/ert/enkf/surface.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SURFACE_H__
-#define __SURFACE_H__
+#ifndef ERT_SURFACE_H
+#define ERT_SURFACE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/surface_config.h
+++ b/devel/libenkf/include/ert/enkf/surface_config.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SURFACE_CONFIG_H__
-#define __SURFACE_CONFIG_H__
+#ifndef ERT_SURFACE_CONFIG_H
+#define ERT_SURFACE_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/time_map.h
+++ b/devel/libenkf/include/ert/enkf/time_map.h
@@ -14,8 +14,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
-#ifndef __TIME_MAP_H__
-#define __TIME_MAP_H__
+#ifndef ERT_TIME_MAP_H
+#define ERT_TIME_MAP_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libenkf/include/ert/enkf/trans_func.h
+++ b/devel/libenkf/include/ert/enkf/trans_func.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __TRANS_FUNC_H__
-#define __TRANS_FUNC_H__
+#ifndef ERT_TRANS_FUNC_H
+#define ERT_TRANS_FUNC_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/arg_pack.h
+++ b/devel/libert_util/include/ert/util/arg_pack.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __ARG_PACK_H__
-#define __ARG_PACK_H__
+#ifndef ERT_ARG_PACK_H
+#define ERT_ARG_PACK_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/block_fs.h
+++ b/devel/libert_util/include/ert/util/block_fs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __BLOCK_FS__
-#define __BLOCK_FS__
+#ifndef ERT_BLOCK_FS
+#define ERT_BLOCK_FS
 #include <ert/util/buffer.h>
 #include <ert/util/vector.h>
 #include <ert/util/type_macros.h>

--- a/devel/libert_util/include/ert/util/buffer.h
+++ b/devel/libert_util/include/ert/util/buffer.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __BUFFER_H__
-#define __BUFFER_H__
+#ifndef ERT_BUFFER_H
+#define ERT_BUFFER_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/hash.h
+++ b/devel/libert_util/include/ert/util/hash.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __HASH_H__
-#define __HASH_H__
+#ifndef ERT_HASH_H
+#define ERT_HASH_H
 #ifdef __cplusplus
 extern"C" {
 #endif

--- a/devel/libert_util/include/ert/util/hash_node.h
+++ b/devel/libert_util/include/ert/util/hash_node.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __HASH_NODE_H__
-#define __HASH_NODE_H__
+#ifndef ERT_HASH_NODE_H
+#define ERT_HASH_NODE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/hash_sll.h
+++ b/devel/libert_util/include/ert/util/hash_sll.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __HASH_SLL_H__
-#define __HASH_SLL_H__
+#ifndef ERT_HASH_SLL_H
+#define ERT_HASH_SLL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/lars.h
+++ b/devel/libert_util/include/ert/util/lars.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __LARS_H__
-#define __LARS_H__
+#ifndef ERT_LARS_H
+#define ERT_LARS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/log.h
+++ b/devel/libert_util/include/ert/util/log.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __LOG_H__
-#define __LOG_H__
+#ifndef ERT_LOG_H
+#define ERT_LOG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/lookup_table.h
+++ b/devel/libert_util/include/ert/util/lookup_table.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __LOOKUP_TABLE_H__
-#define __LOOKUP_TABLE_H__
+#ifndef ERT_LOOKUP_TABLE_H
+#define ERT_LOOKUP_TABLE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/matrix.h
+++ b/devel/libert_util/include/ert/util/matrix.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __MATRIX_H__
-#define __MATRIX_H__
+#ifndef ERT_MATRIX_H
+#define ERT_MATRIX_H
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/devel/libert_util/include/ert/util/matrix_blas.h
+++ b/devel/libert_util/include/ert/util/matrix_blas.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __MATRIX_BLAS__
-#define __MATRIX_BLAS__
+#ifndef ERT_MATRIX_BLAS
+#define ERT_MATRIX_BLAS
 #include <stdbool.h>
 
 #include <ert/util/matrix.h>

--- a/devel/libert_util/include/ert/util/matrix_lapack.h
+++ b/devel/libert_util/include/ert/util/matrix_lapack.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
-#ifndef __MATRIX_LAPACK_H__
-#define __MATRIX_LAPACK_H__
+#ifndef ERT_MATRIX_LAPACK_H
+#define ERT_MATRIX_LAPACK_H
 
 #include <ert/util/matrix.h>
 

--- a/devel/libert_util/include/ert/util/matrix_stat.h
+++ b/devel/libert_util/include/ert/util/matrix_stat.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __MATRIX_STAT_H__
-#define __MATRIX_STAT_H__
+#ifndef ERT_MATRIX_STAT_H
+#define ERT_MATRIX_STAT_H
 
 #include <ert/util/matrix.h>
 

--- a/devel/libert_util/include/ert/util/menu.h
+++ b/devel/libert_util/include/ert/util/menu.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __MENU_H__
-#define __MENU_H__
+#ifndef ERT_MENU_H
+#define ERT_MENU_H
 
 typedef struct menu_struct menu_type;
 typedef struct menu_item_struct menu_item_type;

--- a/devel/libert_util/include/ert/util/msg.h
+++ b/devel/libert_util/include/ert/util/msg.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __MSG_H__
-#define __MSG_H__
+#ifndef ERT_MSG_H
+#define ERT_MSG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/mzran.h
+++ b/devel/libert_util/include/ert/util/mzran.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __MZRAN_H__
-#define __MZRAN_H__
+#ifndef ERT_MZRAN_H
+#define ERT_MZRAN_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/node_ctype.h
+++ b/devel/libert_util/include/ert/util/node_ctype.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __NODE_CTYPE_H__
-#define __NODE_CTYPE_H__
+#ifndef ERT_NODE_CTYPE_H
+#define ERT_NODE_CTYPE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/node_data.h
+++ b/devel/libert_util/include/ert/util/node_data.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __NODE_DATA_H__
-#define __NODE_DATA_H__
+#ifndef ERT_NODE_DATA_H
+#define ERT_NODE_DATA_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/parser.h
+++ b/devel/libert_util/include/ert/util/parser.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __PARSER_H__
-#define __PARSER_H__
+#ifndef ERT_PARSER_H
+#define ERT_PARSER_H
 #include <ert/util/stringlist.h>
 
 typedef struct basic_parser_struct basic_parser_type;

--- a/devel/libert_util/include/ert/util/path_fmt.h
+++ b/devel/libert_util/include/ert/util/path_fmt.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __PATH_FMT_H__
-#define __PATH_FMT_H__
+#ifndef ERT_PATH_FMT_H
+#define ERT_PATH_FMT_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/path_stack.h
+++ b/devel/libert_util/include/ert/util/path_stack.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __PATH_STACK_H__
-#define __PATH_STACK_H__
+#ifndef ERT_PATH_STACK_H
+#define ERT_PATH_STACK_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/regression.h
+++ b/devel/libert_util/include/ert/util/regression.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __REGRESSION_H__
-#define __REGRESSION_H__
+#ifndef ERT_REGRESSION_H
+#define ERT_REGRESSION_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libert_util/include/ert/util/rng.h
+++ b/devel/libert_util/include/ert/util/rng.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RNG_H__
-#define __RNG_H__
+#ifndef ERT_RNG_H
+#define ERT_RNG_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/set.h
+++ b/devel/libert_util/include/ert/util/set.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SET_H__
-#define __SET_H__
+#ifndef ERT_SET_H
+#define ERT_SET_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/ssize_t.h
+++ b/devel/libert_util/include/ert/util/ssize_t.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SSIZE_T_H__
-#define __SSIZE_T_H__
+#ifndef ERT_SSIZE_T_H
+#define ERT_SSIZE_T_H
 
 #ifdef _MSC_VER
 /* maximum number of bytes addressable */

--- a/devel/libert_util/include/ert/util/statistics.h
+++ b/devel/libert_util/include/ert/util/statistics.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __STATISTICS_H__
-#define __STATISTICS_H__
+#ifndef ERT_STATISTICS_H
+#define ERT_STATISTICS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/stepwise.h
+++ b/devel/libert_util/include/ert/util/stepwise.h
@@ -1,5 +1,5 @@
-#ifndef __STEPWISE_H__
-#define __STEPWISE_H__
+#ifndef ERT_STEPWISE_H
+#define ERT_STEPWISE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/string_util.h
+++ b/devel/libert_util/include/ert/util/string_util.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
    for more details. 
 */
-#ifndef __STRING_UTIL_H__
-#define __STRING_UTIL_H__
+#ifndef ERT_STRING_UTIL_H
+#define ERT_STRING_UTIL_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libert_util/include/ert/util/stringlist.h
+++ b/devel/libert_util/include/ert/util/stringlist.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __STRINGLIST_H__
-#define __STRINGLIST_H__
+#ifndef ERT_STRINGLIST_H
+#define ERT_STRINGLIST_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/struct_vector.h
+++ b/devel/libert_util/include/ert/util/struct_vector.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __STRUCT_VECTOR_H__
-#define __STRUCT_VECTOR_H__
+#ifndef ERT_STRUCT_VECTOR_H
+#define ERT_STRUCT_VECTOR_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libert_util/include/ert/util/subst_func.h
+++ b/devel/libert_util/include/ert/util/subst_func.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SUBST_FUNC_H__
-#define __SUBST_FUNC_H__
+#ifndef ERT_SUBST_FUNC_H
+#define ERT_SUBST_FUNC_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/subst_list.h
+++ b/devel/libert_util/include/ert/util/subst_list.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __SUBST_H__
-#define __SUBST_H__
+#ifndef ERT_SUBST_H
+#define ERT_SUBST_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/template.h
+++ b/devel/libert_util/include/ert/util/template.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __TEMPLATE_H__
-#define __TEMPLATE_H__
+#ifndef ERT_TEMPLATE_H
+#define ERT_TEMPLATE_H
 #ifdef __cplusplus 
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/test_util.h
+++ b/devel/libert_util/include/ert/util/test_util.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __TEST_UTIL_H__
-#define __TEST_UTIL_H__
+#ifndef ERT_TEST_UTIL_H
+#define ERT_TEST_UTIL_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/test_util_abort.h
+++ b/devel/libert_util/include/ert/util/test_util_abort.h
@@ -20,8 +20,8 @@
   This header is purely a convenience header - it is not installed.
 */
 
-#ifndef __TEST_UTIL_ABORT__
-#define __TEST_UTIL_ABORT__
+#ifndef ERT_TEST_UTIL_ABORT
+#define ERT_TEST_UTIL_ABORT
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/test_work_area.h
+++ b/devel/libert_util/include/ert/util/test_work_area.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __TEST_WORK_AREA_H__
-#define __TEST_WORK_AREA_H__
+#ifndef ERT_TEST_WORK_AREA_H
+#define ERT_TEST_WORK_AREA_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/thread_pool.h
+++ b/devel/libert_util/include/ert/util/thread_pool.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
    for more details. 
 */
-#ifndef __THREAD_POOL_H__
-#define __THREAD_POOL_H__
+#ifndef ERT_THREAD_POOL_H
+#define ERT_THREAD_POOL_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/thread_pool1.h
+++ b/devel/libert_util/include/ert/util/thread_pool1.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __THREAD_POOL_H__
-#define __THREAD_POOL_H__
+#ifndef ERT_THREAD_POOL_H
+#define ERT_THREAD_POOL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/time_interval.h
+++ b/devel/libert_util/include/ert/util/time_interval.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __TIME_INTERVAL_H__
-#define __TIME_INTERVAL_H__
+#ifndef ERT_TIME_INTERVAL_H
+#define ERT_TIME_INTERVAL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libert_util/include/ert/util/timer.h
+++ b/devel/libert_util/include/ert/util/timer.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __TIMER_H__
-#define __TIMER_H__
+#ifndef ERT_TIMER_H
+#define ERT_TIMER_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/type_macros.h
+++ b/devel/libert_util/include/ert/util/type_macros.h
@@ -1,5 +1,5 @@
-#ifndef __TYPE_MACROS_H__
-#define __TYPE_MACROS_H__
+#ifndef ERT_TYPE_MACROS_H
+#define ERT_TYPE_MACROS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/type_vector_functions.h
+++ b/devel/libert_util/include/ert/util/type_vector_functions.h
@@ -15,8 +15,8 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
-#ifndef __TYPE_VECTOR_FUNCTIONS_H__
-#define __TYPE_VECTOR_FUNCTIONS_H__
+#ifndef ERT_TYPE_VECTOR_FUNCTIONS_H
+#define ERT_TYPE_VECTOR_FUNCTIONS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/ui_return.h
+++ b/devel/libert_util/include/ert/util/ui_return.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __UI_RETURN_H__
-#define __UI_RETURN_H__
+#ifndef ERT_UI_RETURN_H
+#define ERT_UI_RETURN_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/util.h
+++ b/devel/libert_util/include/ert/util/util.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __UTIL_H__
-#define __UTIL_H__
+#ifndef ERT_UTIL_H
+#define ERT_UTIL_H
 
 #include <stdbool.h>
 #include <stdio.h>

--- a/devel/libert_util/include/ert/util/util_endian.h
+++ b/devel/libert_util/include/ert/util/util_endian.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __UTIL_ENDIAN_H__
-#define __UTIL_ENDIAN_H__
+#ifndef ERT_UTIL_ENDIAN_H
+#define ERT_UTIL_ENDIAN_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/util_env.h
+++ b/devel/libert_util/include/ert/util/util_env.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __UTIL_ENV_H__
-#define __UTIL_ENV_H__
+#ifndef ERT_UTIL_ENV_H
+#define ERT_UTIL_ENV_H
 
 
 

--- a/devel/libert_util/include/ert/util/vector.h
+++ b/devel/libert_util/include/ert/util/vector.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __VECTOR_H__
-#define __VECTOR_H__
+#ifndef ERT_VECTOR_H
+#define ERT_VECTOR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libert_util/include/ert/util/vector_template.h
+++ b/devel/libert_util/include/ert/util/vector_template.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __@TYPE@_VECTOR_H__
-#define __@TYPE@_VECTOR_H__
+#ifndef ERT_@TYPE@_VECTOR_H
+#define ERT_@TYPE@_VECTOR_H
 #ifdef __cplusplus 
 extern "C" {
 #endif

--- a/devel/libgeometry/include/ert/geometry/geo_pointset.h
+++ b/devel/libgeometry/include/ert/geometry/geo_pointset.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __GEO_POINTSET_H__
-#define __GEO_POINTSET_H__
+#ifndef ERT_GEO_POINTSET_H
+#define ERT_GEO_POINTSET_H
 
 
 #ifdef __cplusplus

--- a/devel/libgeometry/include/ert/geometry/geo_polygon.h
+++ b/devel/libgeometry/include/ert/geometry/geo_polygon.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __GEO_POLYGON_H__
-#define __GEO_POLYGON_H__
+#ifndef ERT_GEO_POLYGON_H
+#define ERT_GEO_POLYGON_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libgeometry/include/ert/geometry/geo_polygon_collection.h
+++ b/devel/libgeometry/include/ert/geometry/geo_polygon_collection.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GEO_POLYGON_COLLECTION_H__
-#define __GEO_POLYGON_COLLECTION_H__
+#ifndef ERT_GEO_POLYGON_COLLECTION_H
+#define ERT_GEO_POLYGON_COLLECTION_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libgeometry/include/ert/geometry/geo_region.h
+++ b/devel/libgeometry/include/ert/geometry/geo_region.h
@@ -26,8 +26,8 @@
 #include <ert/geometry/geo_pointset.h>
 #include <ert/geometry/geo_polygon.h>
 
-#ifndef __GEO_REGION_H__
-#define __GEO_REGION_H__
+#ifndef ERT_GEO_REGION_H
+#define ERT_GEO_REGION_H
 
 
 #ifdef __cplusplus

--- a/devel/libgeometry/include/ert/geometry/geo_surface.h
+++ b/devel/libgeometry/include/ert/geometry/geo_surface.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __GEO_SURFACE_H__
-#define __GEO_SURFACE_H__
+#ifndef ERT_GEO_SURFACE_H
+#define ERT_GEO_SURFACE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libgeometry/include/ert/geometry/geo_util.h
+++ b/devel/libgeometry/include/ert/geometry/geo_util.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __GEO_UTIL_H__
-#define __GEO_UTIL_H__
+#ifndef ERT_GEO_UTIL_H
+#define ERT_GEO_UTIL_H
 
 
 #ifdef __cplusplus

--- a/devel/libjob_queue/include/ert/job_queue/ext_job.h
+++ b/devel/libjob_queue/include/ert/job_queue/ext_job.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __EXT_JOB_H__
-#define __EXT_JOB_H__
+#ifndef ERT_EXT_JOB_H
+#define ERT_EXT_JOB_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/ext_joblist.h
+++ b/devel/libjob_queue/include/ert/job_queue/ext_joblist.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __EXT_JOBLIST_H__
-#define __EXT_JOBLIST_H__
+#ifndef ERT_EXT_JOBLIST_H
+#define ERT_EXT_JOBLIST_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/forward_model.h
+++ b/devel/libjob_queue/include/ert/job_queue/forward_model.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __FORWARD_MODEL_H__
-#define __FORWARD_MODEL_H__
+#ifndef ERT_FORWARD_MODEL_H
+#define ERT_FORWARD_MODEL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/job_list.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_list.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __JOB_LIST_H__
-#define __JOB_LIST_H__
+#ifndef ERT_JOB_LIST_H
+#define ERT_JOB_LIST_H
 
 
 #ifdef __cplusplus

--- a/devel/libjob_queue/include/ert/job_queue/job_node.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_node.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __JOB_NODE_H__
-#define __JOB_NODE_H__
+#ifndef ERT_JOB_NODE_H
+#define ERT_JOB_NODE_H
 
 
 #ifdef __cplusplus

--- a/devel/libjob_queue/include/ert/job_queue/job_queue.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __JOB_QUEUE_H__
-#define __JOB_QUEUE_H__
+#ifndef ERT_JOB_QUEUE_H
+#define ERT_JOB_QUEUE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/job_queue_manager.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue_manager.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __JOB_QUEUE_MANAGER_H__
-#define __JOB_QUEUE_MANAGER_H__
+#ifndef ERT_JOB_QUEUE_MANAGER_H
+#define ERT_JOB_QUEUE_MANAGER_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/job_queue_status.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue_status.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __JOB_QUEUE_STATUS_H__
-#define __JOB_QUEUE_STATUS_H__
+#ifndef ERT_JOB_QUEUE_STATUS_H
+#define ERT_JOB_QUEUE_STATUS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libjob_queue/include/ert/job_queue/local_driver.h
+++ b/devel/libjob_queue/include/ert/job_queue/local_driver.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __LOCAL_DRIVER_H__
-#define __LOCAL_DRIVER_H__
+#ifndef ERT_LOCAL_DRIVER_H
+#define ERT_LOCAL_DRIVER_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/lsb.h
+++ b/devel/libjob_queue/include/ert/job_queue/lsb.h
@@ -17,8 +17,8 @@
 */
 
 
-#ifndef __LSB_H__
-#define __LSB_H__
+#ifndef ERT_LSB_H
+#define ERT_LSB_H
 
 
 #ifdef __cplusplus

--- a/devel/libjob_queue/include/ert/job_queue/lsf_driver.h
+++ b/devel/libjob_queue/include/ert/job_queue/lsf_driver.h
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#ifndef __LSF_DRIVER_H__
-#define __LSF_DRIVER_H__
+#ifndef ERT_LSF_DRIVER_H
+#define ERT_LSF_DRIVER_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/queue_driver.h
+++ b/devel/libjob_queue/include/ert/job_queue/queue_driver.h
@@ -16,8 +16,8 @@
    for more details.
  */
 
-#ifndef __QUEUE_DRIVER_H__
-#define __QUEUE_DRIVER_H__
+#ifndef ERT_QUEUE_DRIVER_H
+#define ERT_QUEUE_DRIVER_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/rsh_driver.h
+++ b/devel/libjob_queue/include/ert/job_queue/rsh_driver.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RSH_DRIVER_H__
-#define __RSH_DRIVER_H__
+#ifndef ERT_RSH_DRIVER_H
+#define ERT_RSH_DRIVER_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libjob_queue/include/ert/job_queue/workflow.h
+++ b/devel/libjob_queue/include/ert/job_queue/workflow.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __WORKFLOW_H__
-#define __WORKFLOW_H__
+#ifndef ERT_WORKFLOW_H
+#define ERT_WORKFLOW_H
 
 
 #ifdef __cplusplus

--- a/devel/libjob_queue/include/ert/job_queue/workflow_job.h
+++ b/devel/libjob_queue/include/ert/job_queue/workflow_job.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __WORKFLOW_JOB_H__
-#define __WORKFLOW_JOB_H__
+#ifndef ERT_WORKFLOW_JOB_H
+#define ERT_WORKFLOW_JOB_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libjob_queue/include/ert/job_queue/workflow_joblist.h
+++ b/devel/libjob_queue/include/ert/job_queue/workflow_joblist.h
@@ -19,8 +19,8 @@
 
 
 
-#ifndef __WORKFLOW_JOBLIST_H__
-#define __WORKFLOW_JOBLIST_H__
+#ifndef ERT_WORKFLOW_JOBLIST_H
+#define ERT_WORKFLOW_JOBLIST_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/librms/include/ert/rms/rms_export.h
+++ b/devel/librms/include/ert/rms/rms_export.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RMS_EXPORT_H__
-#define __RMS_EXPORT_H__
+#ifndef ERT_RMS_EXPORT_H
+#define ERT_RMS_EXPORT_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/librms/include/ert/rms/rms_file.h
+++ b/devel/librms/include/ert/rms/rms_file.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RMS_FILE_H__
-#define __RMS_FILE_H__
+#ifndef ERT_RMS_FILE_H
+#define ERT_RMS_FILE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/librms/include/ert/rms/rms_stats.h
+++ b/devel/librms/include/ert/rms/rms_stats.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RMS_STATS_H__
-#define __RMS_STATS_H__
+#ifndef ERT_RMS_STATS_H
+#define ERT_RMS_STATS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/librms/include/ert/rms/rms_tag.h
+++ b/devel/librms/include/ert/rms/rms_tag.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RMS_TAG_H__
-#define __RMS_TAG_H__
+#ifndef ERT_RMS_TAG_H
+#define ERT_RMS_TAG_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/librms/include/ert/rms/rms_tagkey.h
+++ b/devel/librms/include/ert/rms/rms_tagkey.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RMS_TAGKEY_H__
-#define __RMS_TAGKEY_H__
+#ifndef ERT_RMS_TAGKEY_H
+#define ERT_RMS_TAGKEY_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/librms/include/ert/rms/rms_type.h
+++ b/devel/librms/include/ert/rms/rms_type.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RMS_TYPE_H__
-#define __RMS_TYPE_H__
+#ifndef ERT_RMS_TYPE_H
+#define ERT_RMS_TYPE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/librms/include/ert/rms/rms_util.h
+++ b/devel/librms/include/ert/rms/rms_util.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __RMS_UTIL_H__
-#define __RMS_UTIL_H__
+#ifndef ERT_RMS_UTIL_H
+#define ERT_RMS_UTIL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/applications/perturb_history/group_rate.h
+++ b/devel/libsched/applications/perturb_history/group_rate.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GROUP_RATE_H__
-#define __GROUP_RATE_H__
+#ifndef ERT_GROUP_RATE_H
+#define ERT_GROUP_RATE_H
 
 #include <time_t_vector.h>
 #include <well_rate.h>

--- a/devel/libsched/applications/perturb_history/pert_util.h
+++ b/devel/libsched/applications/perturb_history/pert_util.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __PERT_UTIL_H__
-#define __PERT_UTIL_H__
+#ifndef ERT_PERT_UTIL_H
+#define ERT_PERT_UTIL_H
 #include <double_vector.h>
 #include <bool_vector.h>
 #include <time_t_vector.h>

--- a/devel/libsched/applications/perturb_history/well_rate.h
+++ b/devel/libsched/applications/perturb_history/well_rate.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __WELL_RATE_H__
-#define __WELL_RATE_H__
+#ifndef ERT_WELL_RATE_H
+#define ERT_WELL_RATE_H
 
 #include <time_t_vector.h>
 #include <sched_file.h>

--- a/devel/libsched/include/ert/sched/group_history.h
+++ b/devel/libsched/include/ert/sched/group_history.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GROUP_HISTORY_H__
-#define __GROUP_HISTORY_H__
+#ifndef ERT_GROUP_HISTORY_H
+#define ERT_GROUP_HISTORY_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libsched/include/ert/sched/group_index.h
+++ b/devel/libsched/include/ert/sched/group_index.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GROUP_INDEX_H__
-#define __GROUP_INDEX_H__
+#ifndef ERT_GROUP_INDEX_H
+#define ERT_GROUP_INDEX_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libsched/include/ert/sched/gruptree.h
+++ b/devel/libsched/include/ert/sched/gruptree.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __GRUPTREE_H__
-#define __GRUPTREE_H__
+#ifndef ERT_GRUPTREE_H
+#define ERT_GRUPTREE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/history.h
+++ b/devel/libsched/include/ert/sched/history.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __HISTORY_H__
-#define __HISTORY_H__
+#ifndef ERT_HISTORY_H
+#define ERT_HISTORY_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_blob.h
+++ b/devel/libsched/include/ert/sched/sched_blob.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_BLOB_H__
-#define __SCHED_BLOB_H__
+#ifndef ERT_SCHED_BLOB_H
+#define ERT_SCHED_BLOB_H
 #ifdef __cplusplus 
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_file.h
+++ b/devel/libsched/include/ert/sched/sched_file.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_FILE_H__
-#define __SCHED_FILE_H__
+#ifndef ERT_SCHED_FILE_H
+#define ERT_SCHED_FILE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_history.h
+++ b/devel/libsched/include/ert/sched/sched_history.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_HISTORY_H__
-#define __SCHED_HISTORY_H__
+#ifndef ERT_SCHED_HISTORY_H
+#define ERT_SCHED_HISTORY_H
 
 #ifdef __cplusplus 
 extern "C" {

--- a/devel/libsched/include/ert/sched/sched_kw.h
+++ b/devel/libsched/include/ert/sched/sched_kw.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_H__
-#define __SCHED_KW_H__
+#ifndef ERT_SCHED_KW_H
+#define ERT_SCHED_KW_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_kw_compdat.h
+++ b/devel/libsched/include/ert/sched/sched_kw_compdat.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_COMPDAT_H__
-#define __SCHED_KW_COMPDAT_H__
+#ifndef ERT_SCHED_KW_COMPDAT_H
+#define ERT_SCHED_KW_COMPDAT_H
 #include <stdio.h>
 
 #include <ert/util/set.h>

--- a/devel/libsched/include/ert/sched/sched_kw_dates.h
+++ b/devel/libsched/include/ert/sched/sched_kw_dates.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_DATES__
-#define __SCHED_KW_DATES__
+#ifndef ERT_SCHED_KW_DATES
+#define ERT_SCHED_KW_DATES
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_kw_gruptree.h
+++ b/devel/libsched/include/ert/sched/sched_kw_gruptree.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_GRUPTREE_H__
-#define __SCHED_KW_GRUPTREE_H__
+#ifndef ERT_SCHED_KW_GRUPTREE_H
+#define ERT_SCHED_KW_GRUPTREE_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_kw_include.h
+++ b/devel/libsched/include/ert/sched/sched_kw_include.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_INCLUDE_H__
-#define __SCHED_KW_INCLDUE_H__
+#ifndef ERT_SCHED_KW_INCLUDE_H
+#define ERT_SCHED_KW_INCLDUE_H
 
 #include <ert/util/stringlist.h>
 

--- a/devel/libsched/include/ert/sched/sched_kw_tstep.h
+++ b/devel/libsched/include/ert/sched/sched_kw_tstep.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_TSTEP__
-#define __SCHED_KW_TSTEP__
+#ifndef ERT_SCHED_KW_TSTEP
+#define ERT_SCHED_KW_TSTEP
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_kw_untyped.h
+++ b/devel/libsched/include/ert/sched/sched_kw_untyped.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_UNTYPED_H__
-#define __SCHED_KW_UNTYPED_H__
+#ifndef ERT_SCHED_KW_UNTYPED_H
+#define ERT_SCHED_KW_UNTYPED_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_kw_wconhist.h
+++ b/devel/libsched/include/ert/sched/sched_kw_wconhist.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_WCONHIST_H__
-#define __SCHED_KW_WCONHIST_H__
+#ifndef ERT_SCHED_KW_WCONHIST_H
+#define ERT_SCHED_KW_WCONHIST_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_kw_wconinj.h
+++ b/devel/libsched/include/ert/sched/sched_kw_wconinj.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_WCONINJ_H__
-#define __SCHED_KW_WCONINJ_H__
+#ifndef ERT_SCHED_KW_WCONINJ_H
+#define ERT_SCHED_KW_WCONINJ_H
 
 
 #ifdef __cplusplus

--- a/devel/libsched/include/ert/sched/sched_kw_wconinje.h
+++ b/devel/libsched/include/ert/sched/sched_kw_wconinje.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_WCONINJE_H__
-#define __SCHED_KW_WCONINJE_H__
+#ifndef ERT_SCHED_KW_WCONINJE_H
+#define ERT_SCHED_KW_WCONINJE_H
 
 
 #ifdef __cplusplus

--- a/devel/libsched/include/ert/sched/sched_kw_wconinjh.h
+++ b/devel/libsched/include/ert/sched/sched_kw_wconinjh.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_WCONINJH_H__
-#define __SCHED_KW_WCONINJH_H__
+#ifndef ERT_SCHED_KW_WCONINJH_H
+#define ERT_SCHED_KW_WCONINJH_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_kw_wconprod.h
+++ b/devel/libsched/include/ert/sched/sched_kw_wconprod.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_WCONPROD_H__
-#define __SCHED_KW_WCONPROD_H__
+#ifndef ERT_SCHED_KW_WCONPROD_H
+#define ERT_SCHED_KW_WCONPROD_H
 
 
 #ifdef __cplusplus

--- a/devel/libsched/include/ert/sched/sched_kw_welspecs.h
+++ b/devel/libsched/include/ert/sched/sched_kw_welspecs.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_KW_WELSPECS_H__
-#define __SCHED_KW_WELSPECS_H__
+#ifndef ERT_SCHED_KW_WELSPECS_H
+#define ERT_SCHED_KW_WELSPECS_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_macros.h
+++ b/devel/libsched/include/ert/sched/sched_macros.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_MACROS_H___
-#define __SCHED_MACROS_H___
+#ifndef ERT_SCHED_MACROS_H_
+#define ERT_SCHED_MACROS_H_
 
 
 

--- a/devel/libsched/include/ert/sched/sched_time.h
+++ b/devel/libsched/include/ert/sched/sched_time.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_TIME_H__
-#define __SCHED_TIME_H__
+#ifndef ERT_SCHED_TIME_H
+#define ERT_SCHED_TIME_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_types.h
+++ b/devel/libsched/include/ert/sched/sched_types.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_TYPES_H__
-#define __SCHED_TYPES_H__
+#ifndef ERT_SCHED_TYPES_H
+#define ERT_SCHED_TYPES_H
 #ifdef __cplusplus 
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/sched_util.h
+++ b/devel/libsched/include/ert/sched/sched_util.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __SCHED_UTIL_H__
-#define __SCHED_UTIL_H__
+#ifndef ERT_SCHED_UTIL_H
+#define ERT_SCHED_UTIL_H
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/devel/libsched/include/ert/sched/well_history.h
+++ b/devel/libsched/include/ert/sched/well_history.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __WELL_HISTORY__
-#define __WELL_HISTORY__
+#ifndef ERT_WELL_HISTORY
+#define ERT_WELL_HISTORY
 
 #ifdef __cplusplus
 extern "C" {

--- a/devel/libsched/include/ert/sched/well_index.h
+++ b/devel/libsched/include/ert/sched/well_index.h
@@ -16,8 +16,8 @@
    for more details. 
 */
 
-#ifndef __WELL_INDEX_H__
-#define __WELL_INDEX_H__
+#ifndef ERT_WELL_INDEX_H
+#define ERT_WELL_INDEX_H
 
 #ifdef __cplusplus 
 extern "C" {


### PR DESCRIPTION
it seems like the C specification reserves macros that begin and end
with two underscores for internal purposes: when compiling with
`clang++ -Weverything foo.cc` and if foo.cc includes e.g. the 'util.h'
ERT header, one gets

```
include/ert/util/util.h:20:9: warning: macro name is a reserved identifier [-Wreserved-id-macro]
```

(this was compiled using clang 3.6.)

since IMO the compiler is right about that complaint, let's just use a
different naming scheme for the guard macros of ert: this patch
replaces `__$FOO_H__` by `ERT_$FOO_H`.