### PR TITLE
Fixed test that checked write access on wrong file

### DIFF
--- a/devel/libecl/tests/ecl_file.c
+++ b/devel/libecl/tests/ecl_file.c
@@ -111,6 +111,7 @@ void test_writable(const char * src_file ) {
 
   test_work_area_copy_file( work_area , src_file );
   {
+    test_flags( fname );
     ecl_file_type * ecl_file = ecl_file_open( fname , ECL_FILE_WRITABLE);
     ecl_kw_type * swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 0 );
     ecl_kw_type * swat0 = ecl_kw_alloc_copy( swat );
@@ -163,8 +164,7 @@ int main( int argc , char ** argv) {
   {
     test_work_area_type * work_area = test_work_area_alloc("ecl_file");
 
-    test_work_area_install_file( work_area , src_file );
-    test_flags( src_file );
+    test_work_area_copy_file( work_area , src_file );
     test_loadall(src_file , target_file );
 
     test_close_stream1( src_file , target_file);


### PR DESCRIPTION
Now we check write access on newly created file.