### PR TITLE
Smspec C++ bindings - num + types

### DIFF
--- a/devel/libeclxx/include/ert/ecl/Smspec.hpp
+++ b/devel/libeclxx/include/ert/ecl/Smspec.hpp
@@ -34,6 +34,7 @@ namespace ERT {
                     int dims[ 3 ],
                     int region );
 
+            int type() const;
             const char* wgname() const;
             const char* keyword() const;
 

--- a/devel/libeclxx/include/ert/ecl/Smspec.hpp
+++ b/devel/libeclxx/include/ert/ecl/Smspec.hpp
@@ -37,6 +37,7 @@ namespace ERT {
             int type() const;
             const char* wgname() const;
             const char* keyword() const;
+            int num() const;
 
         private:
             smspec_node(

--- a/devel/libeclxx/src/Smspec.cpp
+++ b/devel/libeclxx/src/Smspec.cpp
@@ -67,6 +67,10 @@ namespace ERT {
                     join, grid_dims, num, index, default_value ) )
     {}
 
+    int smspec_node::type() const {
+        return smspec_node_get_var_type( this->node.get() );
+    }
+
     const char* smspec_node::wgname() const {
         return smspec_node_get_wgname( this->node.get() );
     }

--- a/devel/libeclxx/src/Smspec.cpp
+++ b/devel/libeclxx/src/Smspec.cpp
@@ -78,4 +78,8 @@ namespace ERT {
     const char* smspec_node::keyword() const {
         return smspec_node_get_keyword( this->node.get() );
     }
+
+    int smspec_node::num() const {
+        return smspec_node_get_num( this->node.get() );
+    }
 }

--- a/devel/libeclxx/tests/eclxx_smspec.cpp
+++ b/devel/libeclxx/tests/eclxx_smspec.cpp
@@ -61,6 +61,7 @@ void test_smspec_block() {
 
     test_assert_true( block.keyword() == kw );
     test_assert_true( block.type() == ECL_SMSPEC_BLOCK_VAR );
+    test_assert_true( block.num() == 556 );
 }
 
 void test_smspec_region() {
@@ -70,6 +71,7 @@ void test_smspec_region() {
 
     test_assert_true( region.keyword() == kw );
     test_assert_true( region.type() == ECL_SMSPEC_REGION_VAR );
+    test_assert_true( region.num() == 0 );
 }
 
 void test_smspec_completion() {
@@ -81,6 +83,7 @@ void test_smspec_completion() {
 
     test_assert_true( completion.keyword() == kw );
     test_assert_true( completion.type() == ECL_SMSPEC_COMPLETION_VAR );
+    test_assert_true( completion.num() == 112 );
 }
 
 int main (int argc, char **argv) {

--- a/devel/libeclxx/tests/eclxx_smspec.cpp
+++ b/devel/libeclxx/tests/eclxx_smspec.cpp
@@ -38,7 +38,10 @@ void test_smspec_wg() {
     ERT::smspec_node group( ECL_SMSPEC_GROUP_VAR, gr, kw );
 
     test_assert_true(well.wgname() == wg);
+    test_assert_true(well.type() == ECL_SMSPEC_WELL_VAR );
+
     test_assert_true(group.wgname() == gr);
+    test_assert_true(group.type() == ECL_SMSPEC_GROUP_VAR );
 }
 
 void test_smspec_field() {
@@ -46,6 +49,7 @@ void test_smspec_field() {
     ERT::smspec_node field( kw );
 
     test_assert_true( field.keyword() == kw );
+    test_assert_true( field.type() == ECL_SMSPEC_FIELD_VAR );
 }
 
 void test_smspec_block() {
@@ -56,6 +60,7 @@ void test_smspec_block() {
     ERT::smspec_node block( kw, dims, ijk );
 
     test_assert_true( block.keyword() == kw );
+    test_assert_true( block.type() == ECL_SMSPEC_BLOCK_VAR );
 }
 
 void test_smspec_region() {
@@ -64,6 +69,7 @@ void test_smspec_region() {
     ERT::smspec_node region( kw, dims, 0 );
 
     test_assert_true( region.keyword() == kw );
+    test_assert_true( region.type() == ECL_SMSPEC_REGION_VAR );
 }
 
 void test_smspec_completion() {
@@ -74,6 +80,7 @@ void test_smspec_completion() {
     ERT::smspec_node completion( kw, wg, dims, ijk );
 
     test_assert_true( completion.keyword() == kw );
+    test_assert_true( completion.type() == ECL_SMSPEC_COMPLETION_VAR );
 }
 
 int main (int argc, char **argv) {


### PR DESCRIPTION
Adds a `type()` and `num()` methods on the `Smspec` class.