### PR TITLE
Fwd step enkf

### DIFF
--- a/devel/libanalysis/src/fwd_step_enkf.c
+++ b/devel/libanalysis/src/fwd_step_enkf.c
@@ -1,26 +1,26 @@
 /*
-   copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'fwd_step_enkf.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'fwd_step_enkf.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <stdio.h>
-  
+
 #include <ert/util/type_macros.h>
 #include <ert/util/util.h>
 #include <ert/util/rng.h>
@@ -43,7 +43,7 @@
 
 struct fwd_step_enkf_data_struct {
   UTIL_TYPE_ID_DECLARATION;
-  stepwise_type        * stepwise_data; 
+  stepwise_type        * stepwise_data;
   rng_type             * rng;
   int                    nfolds;
   long                   option_flags;
@@ -67,7 +67,7 @@ void fwd_step_enkf_set_r2_limit( fwd_step_enkf_data_type * data , double limit )
 void * fwd_step_enkf_data_alloc( rng_type * rng ) {
   fwd_step_enkf_data_type * data = util_malloc( sizeof * data );
   UTIL_TYPE_ID_INIT( data , FWD_STEP_ENKF_TYPE_ID );
-  
+
   data->stepwise_data = NULL;
   data->rng          = rng;
   data->nfolds       = DEFAULT_NFOLDS;
@@ -80,38 +80,38 @@ void * fwd_step_enkf_data_alloc( rng_type * rng ) {
 
 
 /*Main function: */
-void fwd_step_enkf_updateA(void * module_data , 
-                           matrix_type * A , 
-                           matrix_type * S , 
-                           matrix_type * R , 
-                           matrix_type * dObs , 
+void fwd_step_enkf_updateA(void * module_data ,
+                           matrix_type * A ,
+                           matrix_type * S ,
+                           matrix_type * R ,
+                           matrix_type * dObs ,
                            matrix_type * E ,
                            matrix_type * D ) {
-                           
 
-  
+
+
   fwd_step_enkf_data_type * fwd_step_data = fwd_step_enkf_data_safe_cast( module_data );
   printf("Running Forward Stepwise regression:\n");
   {
-        
+
     int ens_size = matrix_get_columns( S );
     int nx = matrix_get_rows( A );
     int nd = matrix_get_rows( S );
-    
+
     {
 
       stepwise_type * stepwise_data = stepwise_alloc1(ens_size, nd , fwd_step_data->rng);
 
       matrix_type * workS = matrix_alloc( ens_size , nd  );
 
-      
+
       /*workS = S' */
       for (int i = 0; i < nd; i++) {
         for (int j = 0; j < ens_size; j++) {
           matrix_iset( workS , j , i , matrix_iget( S , i , j ) );
         }
       }
-                                                      
+
       /*This might be illigal???? */
       stepwise_set_X0( stepwise_data , workS );
       double xHat;
@@ -123,46 +123,46 @@ void fwd_step_enkf_updateA(void * module_data ,
         /*Update values of y */
         /*Start of the actual update */
         matrix_type * y = matrix_alloc( ens_size , 1 );
-      
+
         for (int j = 0; j < ens_size; j++) {
           matrix_iset(y , j , 0 , matrix_iget( A, i , j ) );
         }
-        
+
         /*This might be illigal???? */
         stepwise_set_Y0( stepwise_data , y );
-        
+
         stepwise_estimate(stepwise_data , fwd_step_data->r2_limit , fwd_step_data->nfolds );
-        
+
         /*manipulate A directly*/
         for (int j = 0; j < ens_size; j++) {
           for (int k = 0; k < nd; k++) {
             matrix_iset(di , 0 , k , matrix_iget( D , k , j ) );
           }
-          
+
           xHat = stepwise_eval(stepwise_data , di );
           matrix_iset(A , i , j , xHat);
         }
-        
-        
-        
+
+
+
       }
-       
+
       printf("Done with stepwise regression enkf\n");
       stepwise_free( stepwise_data );
       matrix_free( di );
-      
+
       /*workS is freed in stepwise_free() */
       /*matrix_free( workS ); */
       /*matrix_free( y );*/
-      
-        
+
+
     }
-    
-    
-    
+
+
+
   }
-  
-  
+
+
 }
 
 
@@ -201,13 +201,13 @@ bool fwd_step_enkf_set_int( void * arg , const char * var_name , int value) {
   fwd_step_enkf_data_type * module_data = fwd_step_enkf_data_safe_cast( arg );
   {
     bool name_recognized = true;
-    
+
     /*Set number of CV folds */
     if (strcmp( var_name , NFOLDS_KEY) == 0)
       fwd_step_enkf_set_nfolds( module_data , value);
     else
       name_recognized = false;
-    
+
     return name_recognized;
    }
 }
@@ -263,12 +263,12 @@ int fwd_step_enkf_get_int( const void * arg, const char * var_name) {
 analysis_table_type SYMBOL_TABLE = {
   .alloc           = fwd_step_enkf_data_alloc,
   .freef           = fwd_step_enkf_data_free,
-  .set_int         = fwd_step_enkf_set_int , 
-  .set_double      = fwd_step_enkf_set_double , 
-  .set_bool        = NULL , 
-  .set_string      = NULL , 
-  .get_options     = fwd_step_enkf_get_options , 
-  .initX           = NULL , 
+  .set_int         = fwd_step_enkf_set_int ,
+  .set_double      = fwd_step_enkf_set_double ,
+  .set_bool        = NULL ,
+  .set_string      = NULL ,
+  .get_options     = fwd_step_enkf_get_options ,
+  .initX           = NULL ,
   .updateA         = fwd_step_enkf_updateA,
   .init_update     = NULL ,
   .complete_update = NULL ,

--- a/devel/libanalysis/src/fwd_step_enkf.c
+++ b/devel/libanalysis/src/fwd_step_enkf.c
@@ -97,6 +97,14 @@ void fwd_step_enkf_updateA(void * module_data ,
     int ens_size = matrix_get_columns( S );
     int nx = matrix_get_rows( A );
     int nd = matrix_get_rows( S );
+    int nfolds = fwd_step_data->nfolds;
+
+    /* Should this check be done in an internal module check? */
+    if ( ens_size <= nfolds){
+        fprintf(stderr, "**ERROR: The number of ensembles: %d must be larger than the CV fold %d\n", ens_size, nfolds);
+        fprintf(stderr, "**ERROR: Forward Stepwise regression failed...\n");
+        return;
+    }
 
     {
 

--- a/devel/libanalysis/src/fwd_step_enkf.c
+++ b/devel/libanalysis/src/fwd_step_enkf.c
@@ -99,12 +99,9 @@ void fwd_step_enkf_updateA(void * module_data ,
     int nd = matrix_get_rows( S );
     int nfolds = fwd_step_data->nfolds;
 
-    /* Should this check be done in an internal module check? */
-    if ( ens_size <= nfolds){
-        fprintf(stderr, "**ERROR: The number of ensembles: %d must be larger than the CV fold %d\n", ens_size, nfolds);
-        fprintf(stderr, "**ERROR: Forward Stepwise regression failed...\n");
-        return;
-    }
+    if ( ens_size <= nfolds)
+      util_abort("%s: The number of ensembles must be larger than the CV fold - aborting\n", __func__);
+
 
     {
 

--- a/devel/libert_util/src/regression.c
+++ b/devel/libert_util/src/regression.c
@@ -67,7 +67,7 @@ double regression_scale(matrix_type * X , matrix_type * Y , matrix_type * X_mean
       }
 
       for (col=0; col < nvar; col++) {
-        double norm = 1.0 / sqrt( (1.0 / (nsample - 1)) * matrix_get_column_sum2( X , col ));
+        double norm = sqrt( (1.0 / (nsample - 1)) * matrix_get_column_sum2( X , col ));
         matrix_iset( X_norm , 0 , col , norm );
       }
     }

--- a/devel/libert_util/src/regression.c
+++ b/devel/libert_util/src/regression.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'regression.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'regression.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
@@ -32,7 +32,7 @@
    Will normalize the the data in X and Y:
 
      1. Y -> Y - <Y>
-     2. For each column: X -> X - <X>  
+     2. For each column: X -> X - <X>
      3. For each column: ||X|| = 1
 
    The mean Y value is returned from the function, and the mean X and
@@ -47,7 +47,7 @@ double regression_scale(matrix_type * X , matrix_type * Y , matrix_type * X_mean
 
   if ( matrix_get_rows( Y ) != nsample)
     util_abort("%s: dimension mismatch X:[%d,%d]  Y:%d \n",__func__ , nsample , nvar , matrix_get_rows( Y ));
-  
+
   if ( matrix_get_columns( X_norm ) != nvar)
     util_abort("%s: dimension mismtach X_norm \n",__func__);
 
@@ -57,7 +57,7 @@ double regression_scale(matrix_type * X , matrix_type * Y , matrix_type * X_mean
   {
     double y_mean = matrix_get_column_sum( Y , 0 ) / nsample;
     matrix_shift_column( Y , 0 , -y_mean );
-    
+
     {
       int col;
       for (col = 0; col < nvar; col++) {
@@ -65,7 +65,7 @@ double regression_scale(matrix_type * X , matrix_type * Y , matrix_type * X_mean
         matrix_shift_column(X , col , -mean);
         matrix_iset( X_mean , 0 , col , mean );
       }
-      
+
       for (col=0; col < nvar; col++) {
         double norm = 1.0 / sqrt( (1.0 / (nsample - 1)) * matrix_get_column_sum2( X , col ));
         matrix_iset( X_norm , 0 , col , norm );
@@ -80,7 +80,7 @@ double regression_unscale(const matrix_type * beta , const matrix_type * X_norm 
   int    nvars = matrix_get_rows( beta0 );
   int    k;
   double yshift = 0;
-  
+
   for (k=0; k < nvars; k++) {
     double scaled_beta = matrix_iget( beta , k , 0 ) * matrix_iget( X_norm , 0 , k);
     matrix_iset( beta0 , k , 0 , scaled_beta);
@@ -93,7 +93,7 @@ double regression_unscale(const matrix_type * beta , const matrix_type * X_norm 
 /**
    Performs an ordinary least squares estimation of the parameter
    vector beta.
-      
+
    beta = inv(X'·X)·X'·y
 */
 
@@ -113,4 +113,4 @@ void regression_OLS( const matrix_type * X , const matrix_type * Y , matrix_type
   matrix_free( Xt );
   matrix_free( Xinv );
 }
-                                                                                          
+

--- a/devel/libert_util/src/stepwise.c
+++ b/devel/libert_util/src/stepwise.c
@@ -20,11 +20,11 @@ struct stepwise_struct {
   bool               data_owner;     // Does the stepwise estimator own the data matrices X0 and Y0?
 
   matrix_type      * beta;           // Quantities estimated by the stepwise algorithm
-  double             Y_mean; 
+  double             Y_mean;
   matrix_type      * X_mean;
   matrix_type      * X_norm;
   bool_vector_type * active_set;
-  rng_type         * rng;           // Needed in the cross-validation 
+  rng_type         * rng;           // Needed in the cross-validation
 };
 
 
@@ -45,7 +45,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
   nsample = bool_vector_count_equal( active_rows , true );
   nvar = bool_vector_count_equal( stepwise->active_set , true );
 
-  
+
   matrix_set( stepwise->beta , 0 ); // It is essential to make sure that old finite values in the beta0 vector do not hang around.
 
 
@@ -59,7 +59,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
   if ((nsample < matrix_get_rows( stepwise->X0 )) || (nvar < matrix_get_columns( stepwise->X0 ))) {
     X = matrix_alloc( nsample , nvar );
     Y = matrix_alloc( nsample , 1);
-    
+
     {
       int icol,irow;   // Running over all values.
       int arow,acol;   // Running over active values.
@@ -73,7 +73,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
               acol++;
             }
           }
-          
+
           matrix_iset( Y , arow , 0 , matrix_iget( stepwise->Y0 , irow , 0 ));
           arow++;
         }
@@ -83,55 +83,55 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
     X = matrix_alloc_copy( stepwise->X0 );
     Y = matrix_alloc_copy( stepwise->Y0 );
   }
-  
-  
+
+
   {
 
     if (stepwise->X_mean != NULL)
       matrix_free( stepwise->X_mean);
-    
+
     stepwise->X_mean = matrix_alloc( 1 , nvar );
 
     if (stepwise->X_norm != NULL)
       matrix_free( stepwise->X_norm);
-    
+
     stepwise->X_norm = matrix_alloc( 1 , nvar );
 
-    
-    
 
-    
+
+
+
 
     matrix_type * beta     = matrix_alloc( nvar , 1);           /* This is the beta vector as estimated from the OLS estimator. */
-    matrix_type * tmp_beta = matrix_alloc_copy( beta );         /* This is the beta vector shifted and scaled back to original variables. */ 
-    
+    matrix_type * tmp_beta = matrix_alloc_copy( beta );         /* This is the beta vector shifted and scaled back to original variables. */
+
 
 
     stepwise->Y_mean = regression_scale( X , Y , stepwise->X_mean , stepwise->X_norm );
-    
+
     regression_OLS( X , Y , beta );
     y_mean = regression_unscale( beta , stepwise->X_norm , stepwise->X_mean , stepwise->Y_mean , tmp_beta );
 
-    
+
     /*Compute the actual mean of y:
     double tmpMean = 0.0;
     for (int ii = 0; ii < nsample; ii++) {
       tmpMean += matrix_iget( Y , ii , 0 );
     }
-    
+
     tmpMean = tmpMean / nsample;
     printf("Average of y = %0.2f\n",tmpMean); */
-    
-    
-    
 
-    /* 
+
+
+
+    /*
        In this code block the beta/tmp_beta vector which is dense with
        fewer elements than the full model is scattered into the beta0
        vector which has full size and @nvar elements.
     */
     {
-      int ivar,avar;   
+      int ivar,avar;
       avar = 0;
       for (ivar = 0; ivar < matrix_get_columns( stepwise->X0 ); ivar++) {
         if (bool_vector_iget( stepwise->active_set , ivar )) {
@@ -140,12 +140,12 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
         }
       }
     }
-    
+
 
     matrix_free( beta );
     matrix_free( tmp_beta );
   }
-  
+
   matrix_free( X );
   matrix_free( Y );
   return y_mean;
@@ -154,7 +154,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
 
 
 
-static double stepwise_eval__( const stepwise_type * stepwise , const matrix_type * x ) { 
+static double stepwise_eval__( const stepwise_type * stepwise , const matrix_type * x ) {
   return matrix_row_column_dot_product( x , 0 , stepwise->beta , 0 );
 }
 
@@ -162,7 +162,7 @@ static double stepwise_eval__( const stepwise_type * stepwise , const matrix_typ
 
 static double stepwise_test_var( stepwise_type * stepwise , int test_var , int blocks) {
   double prediction_error = 0;
-  
+
   bool_vector_iset( stepwise->active_set , test_var , true );   // Temporarily activate this variable
   {
 
@@ -172,24 +172,24 @@ static double stepwise_test_var( stepwise_type * stepwise , int test_var , int b
     matrix_type * beta             = matrix_alloc( nvar , 1 );
     bool_vector_type * active_rows = bool_vector_alloc( nsample, true );
 
-    
 
-      
+
+
 
     /*True Cross-Validation: */
     int * randperms     = util_calloc( nsample , sizeof * randperms );
     for (int i=0; i < nsample; i++)
       randperms[i] = i;
-    
+
     /* Randomly perturb ensemble indices */
     rng_shuffle_int( stepwise->rng , randperms , nsample );
-    
+
 
     for (int iblock = 0; iblock < blocks; iblock++) {
 
       int validation_start = iblock * block_size;
       int validation_end   = validation_start + block_size - 1;
-      
+
       if (iblock == (blocks - 1))
         validation_end = nsample - 1;
 
@@ -201,20 +201,20 @@ static double stepwise_test_var( stepwise_type * stepwise , int test_var , int b
       {
         bool_vector_reset( active_rows );
 
-        bool_vector_iset( active_rows , nsample - 1 , true );   
-        /* 
+        bool_vector_iset( active_rows , nsample - 1 , true );
+        /*
            If blocks == 1 that means all datapoint are used in the
            regression, and then subsequently reused in the R2
-           calculation. 
+           calculation.
         */
-        if (blocks > 1) {                                      
+        if (blocks > 1) {
           for (int i = validation_start; i <= validation_end; i++) {
             bool_vector_iset( active_rows , randperms[i] , false );
           }
         }
       }
-      
-  
+
+
       /*
         Evaluate the prediction error on the validation part of the
         dataset.
@@ -226,26 +226,26 @@ static double stepwise_test_var( stepwise_type * stepwise , int test_var , int b
           matrix_type * x_vector = matrix_alloc( 1 , nvar );
           for (irow=validation_start; irow <= validation_end; irow++) {
             matrix_copy_row( x_vector , stepwise->X0 , 0 , irow);
-            
+
             {
               double true_value      = matrix_iget( stepwise->Y0 , irow , 0 );
               double estimated_value = stepwise_eval__( stepwise , x_vector );
               prediction_error += (true_value - estimated_value) * (true_value - estimated_value);
             }
-            
+
           }
           matrix_free( x_vector );
         }
       }
     }
-    
-    matrix_free( beta );  
+
+    matrix_free( beta );
     free( randperms );
     bool_vector_free( active_rows );
   }
-  
+
   /*inactivate the test_var-variable after completion*/
-  bool_vector_iset( stepwise->active_set , test_var , false );  
+  bool_vector_iset( stepwise->active_set , test_var , false );
   return prediction_error;
 }
 
@@ -265,8 +265,8 @@ void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV
   for (int i = 0; i < nvar; i++) {
     matrix_iset(stepwise->beta, i , 0 , 0.0);
   }
-  
-  
+
+
 
   bool_vector_set_default( stepwise->active_set , false );
   bool_vector_reset( stepwise->active_set );
@@ -274,12 +274,12 @@ void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV
 
   double MSE_min = 10000000;
   double Prev_MSE_min = MSE_min;
-  double minR2    = -1;  
+  double minR2    = -1;
 
   while (true) {
     int    best_var = 0;
     Prev_MSE_min = MSE_min;
-    
+
     /*
       Go through all the inactive variables, and calculate the
       resulting prediction error IF this particular variable is added;
@@ -296,7 +296,7 @@ void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV
     }
 
 
-    
+
     printf("Current best variable  = %d\n",best_var);
 
     /*
@@ -305,12 +305,12 @@ void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV
       active set, and we return to repeat the loop one more
       time. Otherwise we just exit.
     */
-    
+
     {
       MSE_min = minR2;
       printf("MSE_min = %f\n",MSE_min);
-      double deltaR2 = MSE_min / Prev_MSE_min; 
-      
+      double deltaR2 = MSE_min / Prev_MSE_min;
+
       printf("deltaR2 for variable %d = %0.2f\n",best_var,deltaR2);
 
       if (( currentR2 < 0) || deltaR2 < deltaR2_limit) {
@@ -324,8 +324,8 @@ void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV
         /* NB! Need one final compuation of beta (since the test_var function does not reset the last tested beta value !) */
         stepwise_estimate__( stepwise , active_rows );
         break;
-      } 
-      
+      }
+
       if (bool_vector_count_equal( stepwise->active_set , true) == matrix_get_columns( stepwise->X0 )) {
         printf("All variable are active -  done with the forward stepwise regression!\n");
         stepwise_estimate__( stepwise , active_rows );
@@ -341,7 +341,7 @@ void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV
   }
 
 
-  
+
   printf("\n");
 
 
@@ -351,7 +351,7 @@ void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV
 
 
 
-double stepwise_eval( const stepwise_type * stepwise , const matrix_type * x ) { 
+double stepwise_eval( const stepwise_type * stepwise , const matrix_type * x ) {
   double yHat = stepwise_eval__(stepwise, x );
   return yHat;
 }
@@ -360,7 +360,7 @@ double stepwise_eval( const stepwise_type * stepwise , const matrix_type * x ) {
 
 static stepwise_type * stepwise_alloc__( int nsample , int nvar , rng_type * rng) {
   stepwise_type * stepwise = util_malloc( sizeof * stepwise );
-  
+
   stepwise->X_mean      = NULL;
   stepwise->X_norm      = NULL;
   stepwise->Y_mean      = 0.0;
@@ -369,14 +369,14 @@ static stepwise_type * stepwise_alloc__( int nsample , int nvar , rng_type * rng
   stepwise->Y0          = NULL;
   stepwise->active_set  = bool_vector_alloc( nvar , true );
   stepwise->beta        = matrix_alloc( nvar , 1 );
-  
+
   return stepwise;
 }
 
 
 stepwise_type * stepwise_alloc0( rng_type * rng) {
   stepwise_type * stepwise = util_malloc( sizeof * stepwise );
-  
+
   stepwise->rng         = rng;
   stepwise->X0          = NULL;
   stepwise->Y0          = NULL;
@@ -386,9 +386,9 @@ stepwise_type * stepwise_alloc0( rng_type * rng) {
   stepwise->X_mean      = NULL;
   stepwise->X_norm      = NULL;
   stepwise->Y_mean      = 0.0;
-  
-  
-  
+
+
+
   return stepwise;
 }
 
@@ -401,7 +401,7 @@ stepwise_type * stepwise_alloc1( int nsample , int nvar, rng_type * rng) {
   stepwise->X0          = matrix_alloc( nsample , nvar );
   stepwise->Y0          = matrix_alloc( nsample , 1 );
   stepwise->data_owner  = true;
-  
+
   return stepwise;
 }
 
@@ -413,7 +413,7 @@ stepwise_type * stepwise_alloc2( matrix_type * X , matrix_type * Y , bool intern
     stepwise->Y0 = matrix_alloc_copy( Y );
     stepwise->data_owner = true;
   } else {
-    stepwise->X0 = X; 
+    stepwise->X0 = X;
     stepwise->Y0 = Y;
     stepwise->data_owner = false;
   }
@@ -425,14 +425,14 @@ void stepwise_set_Y0( stepwise_type * stepwise , matrix_type * Y) {
   if (stepwise->Y0 != NULL) {
     matrix_free( stepwise->Y0 );
   }
-  
+
   stepwise->Y0 = Y;
 }
 
 void stepwise_set_X0( stepwise_type * stepwise ,  matrix_type * X) {
   if (stepwise->X0 != NULL)
     matrix_free( stepwise->X0 );
-  
+
 
   stepwise->X0 = X;
 }
@@ -441,14 +441,14 @@ void stepwise_set_X0( stepwise_type * stepwise ,  matrix_type * X) {
 void stepwise_set_beta( stepwise_type * stepwise ,  matrix_type * b) {
 if (stepwise->beta != NULL)
     matrix_free( stepwise->beta );
-  
+
   stepwise->beta = b;
 }
 
 void stepwise_set_active_set( stepwise_type * stepwise ,  bool_vector_type * a) {
   if (stepwise->active_set != NULL)
     bool_vector_free( stepwise->active_set );
-  
+
   stepwise->active_set = a;
 }
 
@@ -478,20 +478,20 @@ void stepwise_free( stepwise_type * stepwise ) {
   if (stepwise->active_set != NULL) {
     bool_vector_free( stepwise->active_set );
   }
-  
+
 
   if (stepwise->beta != NULL)
     matrix_free( stepwise->beta );
 
 
 
-  if (stepwise->X_mean != NULL)  
+  if (stepwise->X_mean != NULL)
     matrix_free( stepwise->X_mean );
 
 
   if (stepwise->X_norm != NULL)
     matrix_free( stepwise->X_norm );
-  
+
 
 
   if (stepwise->data_owner) {
@@ -499,5 +499,5 @@ void stepwise_free( stepwise_type * stepwise ) {
     matrix_free( stepwise->Y0 );
   }
   free( stepwise );
-  
+
 }


### PR DESCRIPTION
Starting work on fwd_step_enkf.

1. Whitespace
2. A consistency check on number of folds with respect to number of ensembles.
3. A bug in function "regression_scale" in my opinion, since X_norm is set to be to the inverse of the standard deviation.

Let y = beta x + e be our original, unscaled regression problem. 

The scaled version y1 = beta1 x1 + e, where x1 = x/std(x) is not solved here since X is actually not being scaled even if the comment on the function says so. The solution beta1 to the scaled problem is std(x)*beta.

Instead, the original, unscaled regression is solved and the scaling is done on beta. To obtain the scaled version of beta, one multipies later on beta by the scaling std, in function "regression_unscale".

If I am correct, this bug is also affecting the method in lars.

After the proposed change on the scaling the updates now look reasonable. 