### PR TITLE
Adding PRE_SIMULATION hook support cont

### DIFF
--- a/devel/docs/user/keywords/index.rst
+++ b/devel/docs/user/keywords/index.rst
@@ -1952,7 +1952,6 @@ run. Observe that the workflows being 'hooked in' with the
 :code:`HOOK_WORKFLOW` must be loaded with the :code:`LOAD_WORKFLOW`
 keyword.
 
-NB: Currently the :code:`PRE_SIMULATION` workflow is never called.
 
 Manipulating the Unix environment
 ---------------------------------

--- a/devel/libenkf/applications/ert_tui/enkf_tui_run.c
+++ b/devel/libenkf/applications/ert_tui/enkf_tui_run.c
@@ -92,7 +92,7 @@ void enkf_tui_run_exp(void * enkf_main) {
     free( prompt );
   }
   if (bool_vector_count_equal(iactive , true))
-    enkf_main_run_exp(enkf_main , iactive , true );
+    enkf_main_run_exp(enkf_main , iactive );
 
   bool_vector_free(iactive);
 }
@@ -115,7 +115,7 @@ void enkf_tui_run_create_runpath__(void * __enkf_main) {
     util_safe_free( select_string );
     free( prompt );
   }
-  enkf_main_run_exp(enkf_main , iactive , false );
+  enkf_main_create_run_path(enkf_main , iactive , 0 );
   bool_vector_free(iactive);
 }
 

--- a/devel/libenkf/include/ert/enkf/enkf_main.h
+++ b/devel/libenkf/include/ert/enkf/enkf_main.h
@@ -61,6 +61,7 @@ extern "C" {
 #include <ert/enkf/pca_plot_data.h>
 #include <ert/enkf/field_config.h>
 #include <ert/enkf/ert_run_context.h>
+#include <ert/enkf/ert_init_context.h>
 
   /*****************************************************************/
 
@@ -106,12 +107,11 @@ extern "C" {
 
   bool                          enkf_main_UPDATE(enkf_main_type * enkf_main , const int_vector_type * step_list, enkf_fs_type * source_fs, enkf_fs_type * target_fs , int target_step , run_mode_type run_mode);
   bool                          enkf_main_smoother_update(enkf_main_type * enkf_main , enkf_fs_type * source_fs, enkf_fs_type * target_fs);
-
+  void                          enkf_main_create_run_path(enkf_main_type * enkf_main , bool_vector_type * iactive , int iter);
   bool                          enkf_main_run_simple_step(enkf_main_type * enkf_main , bool_vector_type * iactive , init_mode_type init_mode, int iter);
 
   void                          enkf_main_run_exp(enkf_main_type * enkf_main ,
-                                                  bool_vector_type * iactive ,
-                                                  bool             simulate);
+                                                  bool_vector_type * iactive);
 
 
   void                          enkf_main_run_smoother(enkf_main_type * enkf_main , enkf_fs_type * source_fs, const char * target_fs_name , bool_vector_type * iactive , int iter , bool rerun);
@@ -264,14 +264,14 @@ extern "C" {
   void              enkf_main_set_case_table( enkf_main_type * enkf_main , const char * case_table_file );
 
   void              enkf_main_initialize_from_scratch(enkf_main_type * enkf_main ,
-						      enkf_fs_type * init_fs, 
+						      enkf_fs_type * init_fs,
                                                       const stringlist_type * param_list ,
                                                       int iens1 ,
                                                       int iens2,
                                                       init_mode_type init_mode);
 
   void              enkf_main_initialize_from_scratch_with_bool_vector(enkf_main_type * enkf_main ,
-								       enkf_fs_type * init_fs, 
+								       enkf_fs_type * init_fs,
 								       const stringlist_type * param_list ,
 								       const bool_vector_type * iens_mask ,
 								       init_mode_type init_mode);
@@ -324,7 +324,7 @@ extern "C" {
 
   runpath_list_type    * enkf_main_get_runpath_list( const enkf_main_type * enkf_main );
   ert_run_context_type * enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT(const enkf_main_type * enkf_main , enkf_fs_type * fs , const bool_vector_type * iactive , init_mode_type init_mode , int iter);
-  ert_run_context_type * enkf_main_alloc_ert_run_context_INIT_ONLY(const enkf_main_type * enkf_main , enkf_fs_type * fs , const bool_vector_type * iactive , init_mode_type init_mode , int iter);
+  ert_init_context_type * enkf_main_alloc_ert_init_context(const enkf_main_type * enkf_main , enkf_fs_type * fs, const bool_vector_type * iactive , init_mode_type init_mode , int iter);
 
 
 UTIL_SAFE_CAST_HEADER(enkf_main);

--- a/devel/libenkf/include/ert/enkf/ert_init_context.h
+++ b/devel/libenkf/include/ert/enkf/ert_init_context.h
@@ -1,0 +1,62 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'ert_init_context.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef ERT_INIT_CONTEXT_H
+#define ERT_INIT_CONTEXT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <ert/util/type_macros.h>
+#include <ert/util/bool_vector.h>
+#include <ert/util/path_fmt.h>
+#include <ert/util/subst_list.h>
+
+#include <ert/enkf/enkf_types.h>
+#include <ert/enkf/run_arg.h>
+#include <ert/enkf/enkf_fs.h>
+
+typedef struct ert_init_context_struct ert_init_context_type;
+
+  stringlist_type      * ert_init_context_alloc_runpath_list(const bool_vector_type * iactive , path_fmt_type * runpath_fmt , subst_list_type * subst_list , int iter);
+  char                 * ert_init_context_alloc_runpath( int iens , path_fmt_type * runpath_fmt , subst_list_type * subst_list , int iter);
+
+  ert_init_context_type * ert_init_context_alloc(enkf_fs_type * init_fs , const bool_vector_type * iactive ,
+                                                 path_fmt_type * runpath_fmt ,
+                                                 subst_list_type * subst_list ,
+                                                 init_mode_type init_mode ,
+                                                 int iter);
+
+  void                     ert_init_context_free( ert_init_context_type * );
+  int                      ert_init_context_get_size( const ert_init_context_type * context );
+  init_mode_type           ert_init_context_get_init_mode( const ert_init_context_type * context );
+  bool_vector_type       * ert_init_context_get_iactive( const ert_init_context_type * context );
+  int                      ert_init_context_get_iter( const ert_init_context_type * context );
+  run_arg_type           * ert_init_context_iget_arg( const ert_init_context_type * context , int index);
+  run_arg_type           * ert_init_context_iens_get_arg( const ert_init_context_type * context , int iens);
+
+
+  UTIL_IS_INSTANCE_HEADER( ert_init_context );
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+

--- a/devel/libenkf/include/ert/enkf/ert_run_context.h
+++ b/devel/libenkf/include/ert/enkf/ert_run_context.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
-   The file 'run_info.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2014  Statoil ASA, Norway.
+
+   The file 'ert_run_context.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_RUN_CONTEXT_H
@@ -35,26 +35,19 @@ typedef struct ert_run_context_struct ert_run_context_type;
 
   stringlist_type      * ert_run_context_alloc_runpath_list(const bool_vector_type * iactive , path_fmt_type * runpath_fmt , subst_list_type * subst_list , int iter);
   char                 * ert_run_context_alloc_runpath( int iens , path_fmt_type * runpath_fmt , subst_list_type * subst_list , int iter);
-  ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * fs , 
-                                                                   const bool_vector_type * iactive , 
-                                                                   path_fmt_type * runpath_fmt , 
+  ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * fs ,
+                                                                   const bool_vector_type * iactive ,
+                                                                   path_fmt_type * runpath_fmt ,
                                                                    subst_list_type * subst_list ,
-                                                                   init_mode_type init_mode , 
+                                                                   init_mode_type init_mode ,
                                                                    int iter);
 
 
-  ert_run_context_type * ert_run_context_alloc_INIT_ONLY(enkf_fs_type * init_fs , const bool_vector_type * iactive , 
-                                                         path_fmt_type * runpath_fmt , 
-                                                         subst_list_type * subst_list ,
-                                                         init_mode_type init_mode , 
-                                                         int iter);
-
-
-  ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * simulate_fs , enkf_fs_type * target_update_fs , 
-                                                            const bool_vector_type * iactive , 
-                                                            path_fmt_type * runpath_fmt , 
+  ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * simulate_fs , enkf_fs_type * target_update_fs ,
+                                                            const bool_vector_type * iactive ,
+                                                            path_fmt_type * runpath_fmt ,
                                                             subst_list_type * subst_list ,
-                                                            init_mode_type init_mode , 
+                                                            init_mode_type init_mode ,
                                                             int iter);
   void                     ert_run_context_set_init_fs(ert_run_context_type * context,  enkf_fs_type * init_fs);
   void                     ert_run_context_set_result_fs(ert_run_context_type * context, enkf_fs_type * result_fs);
@@ -71,13 +64,13 @@ typedef struct ert_run_context_struct ert_run_context_type;
   int                      ert_run_context_get_load_start( const ert_run_context_type * context );
   run_arg_type           * ert_run_context_iget_arg( const ert_run_context_type * context , int index);
   run_arg_type           * ert_run_context_iens_get_arg( const ert_run_context_type * context , int iens);
-  
+
   enkf_fs_type * ert_run_context_get_init_fs(const ert_run_context_type * run_context);
   enkf_fs_type * ert_run_context_get_result_fs(const ert_run_context_type * run_context);
   enkf_fs_type * ert_run_context_get_update_target_fs(const ert_run_context_type * run_context);
 
   UTIL_IS_INSTANCE_HEADER( ert_run_context );
-  
+
 
 #ifdef __cplusplus
 }

--- a/devel/libenkf/src/CMakeLists.txt
+++ b/devel/libenkf/src/CMakeLists.txt
@@ -83,6 +83,7 @@ set( source_files
      ert_log.c
      run_arg.c
      ert_run_context.c
+     ert_init_context.c
      custom_kw.c
      custom_kw_config.c
      custom_kw_config_set.c
@@ -182,6 +183,7 @@ set( header_files
      run_arg.h
      run_arg_type.h
      ert_run_context.h
+     ert_init_context.h
      custom_kw.h
      custom_kw_config.h
      custom_kw_config_set.h

--- a/devel/libenkf/src/enkf_main_jobs.c
+++ b/devel/libenkf/src/enkf_main_jobs.c
@@ -77,7 +77,7 @@ void * enkf_main_ensemble_run_JOB( void * self , const stringlist_type * args ) 
   bool_vector_type * iactive = alloc_iactive_vector_from_range(args, 0, stringlist_get_size(args), ens_size);
 
   bool_vector_iset( iactive , ens_size - 1 , true );
-  enkf_main_run_exp( enkf_main , iactive , true );
+  enkf_main_run_exp( enkf_main , iactive);
   bool_vector_free(iactive);
   return NULL;
 }
@@ -92,7 +92,7 @@ static void * enkf_main_smoother_JOB__( void * self , int iter , const stringlis
   enkf_fs_type * source_fs     = enkf_main_job_get_fs( enkf_main );
   //Argument 2: Rerun. Default false.
   bool rerun = (stringlist_get_size(args) >= 2) ? stringlist_iget_as_bool(args, 1, &valid) : false;
-  
+
   if (!valid) {
       fprintf(stderr, "** Warning: Function %s : Second argument must be a bool value. Exiting job\n", __func__);
       return NULL;

--- a/devel/libenkf/src/ert_init_context.c
+++ b/devel/libenkf/src/ert_init_context.c
@@ -1,0 +1,154 @@
+/*
+   Copyright (C) 2014  Statoil ASA, Norway.
+
+   The file 'ert_init_context.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <ert/util/type_macros.h>
+#include <ert/util/vector.h>
+#include <ert/util/path_fmt.h>
+#include <ert/util/subst_list.h>
+#include <ert/util/int_vector.h>
+#include <ert/util/stringlist.h>
+#include <ert/util/type_vector_functions.h>
+
+#include <ert/enkf/enkf_types.h>
+#include <ert/enkf/run_arg.h>
+#include <ert/enkf/ert_init_context.h>
+
+
+#define ERT_INIT_CONTEXT_TYPE_ID 555341328
+
+
+struct ert_init_context_struct {
+  UTIL_TYPE_ID_DECLARATION;
+  vector_type      * run_args;
+  bool_vector_type * iactive;   // This can be updated ....
+  init_mode_type     init_mode;
+  int                iter;
+  int_vector_type  * iens_map;
+
+};
+
+
+
+
+char * ert_init_context_alloc_runpath( int iens , path_fmt_type * runpath_fmt , subst_list_type * subst_list , int iter) {
+  char * runpath;
+  {
+    char * first_pass = path_fmt_alloc_path(runpath_fmt , false , iens, iter);    /* 1: Replace first %d with iens, if a second %d replace with iter */
+
+    if (subst_list)
+      runpath = subst_list_alloc_filtered_string( subst_list , first_pass );         /* 2: Filter out various magic strings like <CASE> and <CWD>. */
+    else
+      runpath = util_alloc_string_copy( first_pass );
+
+    free( first_pass );
+  }
+  return runpath;
+}
+
+
+stringlist_type * ert_init_context_alloc_runpath_list(const bool_vector_type * iactive , path_fmt_type * runpath_fmt , subst_list_type * subst_list , int iter) {
+  stringlist_type * runpath_list = stringlist_alloc_new();
+  for (int iens = 0; iens < bool_vector_size( iactive ); iens++) {
+
+    if (bool_vector_iget( iactive , iens ))
+      stringlist_append_owned_ref( runpath_list , ert_init_context_alloc_runpath(iens , runpath_fmt , subst_list , iter));
+    else
+      stringlist_append_ref( runpath_list , NULL );
+
+  }
+  return runpath_list;
+}
+
+
+static ert_init_context_type * ert_init_context_alloc1(const bool_vector_type * iactive , init_mode_type init_mode, int iter) {
+  ert_init_context_type * context = util_malloc( sizeof * context );
+  UTIL_TYPE_ID_INIT( context , ERT_INIT_CONTEXT_TYPE_ID );
+
+  context->iactive = bool_vector_alloc_copy( iactive );
+  context->iens_map = bool_vector_alloc_active_index_list( iactive , -1 );
+  context->run_args = vector_alloc_new();
+  context->init_mode = init_mode;
+  context->iter = iter;
+
+  return context;
+}
+
+ert_init_context_type * ert_init_context_alloc(enkf_fs_type * init_fs , const bool_vector_type * iactive ,
+                                               path_fmt_type * runpath_fmt ,
+                                               subst_list_type * subst_list ,
+                                               init_mode_type init_mode ,
+                                               int iter) {
+
+  ert_init_context_type * context = ert_init_context_alloc1( iactive , init_mode , iter );
+  {
+    stringlist_type * runpath_list = ert_init_context_alloc_runpath_list( iactive , runpath_fmt , subst_list , iter );
+    for (int iens = 0; iens < bool_vector_size( iactive ); iens++) {
+      if (bool_vector_iget( iactive , iens )) {
+        run_arg_type * arg = run_arg_alloc_INIT_ONLY( init_fs , iens , iter , stringlist_iget( runpath_list , iens));
+        vector_append_owned_ref( context->run_args , arg , run_arg_free__);
+      }
+    }
+    stringlist_free( runpath_list );
+  }
+  return context;
+}
+
+
+
+
+UTIL_IS_INSTANCE_FUNCTION( ert_init_context , ERT_INIT_CONTEXT_TYPE_ID );
+
+
+
+void ert_init_context_free( ert_init_context_type * context ) {
+
+  vector_free( context->run_args );
+  bool_vector_free( context->iactive );
+  int_vector_free( context->iens_map );
+  free( context );
+}
+
+
+int ert_init_context_get_size( const ert_init_context_type * context ) {
+  return vector_get_size( context->run_args );
+}
+
+
+
+init_mode_type ert_init_context_get_init_mode( const ert_init_context_type * context ) {
+  return context->init_mode;
+}
+
+
+bool_vector_type * ert_init_context_get_iactive( const ert_init_context_type * context ) {
+  return context->iactive;
+}
+
+
+run_arg_type * ert_init_context_iget_arg( const ert_init_context_type * context , int index) {
+  return vector_iget( context->run_args , index );
+}
+
+
+run_arg_type * ert_init_context_iens_get_arg( const ert_init_context_type * context , int iens) {
+  int index = int_vector_iget( context->iens_map , iens );
+  if (index >= 0)
+    return vector_iget( context->run_args , index );
+  else
+    return NULL;
+}

--- a/devel/libenkf/src/ert_run_context.c
+++ b/devel/libenkf/src/ert_run_context.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
-   The file 'ert_run_context.c' is part of ERT - Ensemble based Reservoir Tool. 
-   
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2014  Statoil ASA, Norway.
+
+   The file 'ert_run_context.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <ert/util/type_macros.h>
@@ -35,7 +35,7 @@
 struct ert_run_context_struct {
   UTIL_TYPE_ID_DECLARATION;
   vector_type      * run_args;
-  bool_vector_type * iactive;   // This can be updated .... 
+  bool_vector_type * iactive;   // This can be updated ....
   run_mode_type      run_mode;
   init_mode_type     init_mode;
   int                iter;
@@ -95,40 +95,17 @@ static ert_run_context_type * ert_run_context_alloc(const bool_vector_type * iac
   ert_run_context_set_init_fs(context, init_fs);
   ert_run_context_set_result_fs(context, result_fs);
   ert_run_context_set_update_target_fs(context, update_target_fs);
-  
+
   context->step1 = 0;
   context->step2 = 0;
   return context;
 }
 
 
-ert_run_context_type * ert_run_context_alloc_INIT_ONLY(enkf_fs_type * init_fs , const bool_vector_type * iactive , 
-                                                       path_fmt_type * runpath_fmt , 
-                                                       subst_list_type * subst_list ,
-                                                       init_mode_type init_mode , 
-                                                       int iter) {
-
-  ert_run_context_type * context = ert_run_context_alloc( iactive , INIT_ONLY , init_fs , NULL , NULL , init_mode , iter );
-  {
-    stringlist_type * runpath_list = ert_run_context_alloc_runpath_list( iactive , runpath_fmt , subst_list , iter );
-    for (int iens = 0; iens < bool_vector_size( iactive ); iens++) {
-      if (bool_vector_iget( iactive , iens )) {
-        run_arg_type * arg = run_arg_alloc_INIT_ONLY( init_fs , iens , iter , stringlist_iget( runpath_list , iens));
-        vector_append_owned_ref( context->run_args , arg , run_arg_free__);
-      }
-    }
-    stringlist_free( runpath_list );
-  }
-  return context;
-}
-
-
-
-
-ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * fs , const bool_vector_type * iactive , 
-                                                                 path_fmt_type * runpath_fmt , 
+ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * fs , const bool_vector_type * iactive ,
+                                                                 path_fmt_type * runpath_fmt ,
                                                                  subst_list_type * subst_list ,
-                                                                 init_mode_type init_mode , 
+                                                                 init_mode_type init_mode ,
                                                                  int iter) {
 
   ert_run_context_type * context = ert_run_context_alloc( iactive , ENSEMBLE_EXPERIMENT , fs , fs , NULL , init_mode , iter);
@@ -147,11 +124,11 @@ ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * 
 
 
 
-ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * simulate_fs , enkf_fs_type * target_update_fs , 
-                                                          const bool_vector_type * iactive , 
-                                                          path_fmt_type * runpath_fmt , 
+ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * simulate_fs , enkf_fs_type * target_update_fs ,
+                                                          const bool_vector_type * iactive ,
+                                                          path_fmt_type * runpath_fmt ,
                                                           subst_list_type * subst_list ,
-                                                          init_mode_type init_mode , 
+                                                          init_mode_type init_mode ,
                                                           int iter) {
 
   ert_run_context_type * context = ert_run_context_alloc( iactive , SMOOTHER_UPDATE , simulate_fs , simulate_fs , target_update_fs , init_mode , iter);

--- a/devel/libenkf/tests/enkf_ert_run_context.c
+++ b/devel/libenkf/tests/enkf_ert_run_context.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
-   The file 'ert_run_context.c' is part of ERT - Ensemble based Reservoir Tool. 
-   
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2014  Statoil ASA, Norway.
+
+   The file 'ert_run_context.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 
@@ -22,6 +22,7 @@
 #include <ert/util/subst_list.h>
 
 #include <ert/enkf/ert_run_context.h>
+#include <ert/enkf/ert_init_context.h>
 #include <ert/enkf/run_arg.h>
 
 void test_create() {
@@ -32,20 +33,20 @@ void test_create() {
     enkf_fs_type * init_fs = NULL;
     subst_list_type * subst_list = subst_list_alloc( NULL );
     path_fmt_type * runpath_fmt = path_fmt_alloc_directory_fmt("/tmp/path/%04d");
-    ert_run_context_type * context = ert_run_context_alloc_INIT_ONLY( init_fs ,  iactive , runpath_fmt , subst_list , INIT_CONDITIONAL , 13 );
-    
-    test_assert_true( ert_run_context_is_instance( context ));
-    test_assert_int_equal( 8 , ert_run_context_get_size( context ));
+    ert_init_context_type * context = ert_init_context_alloc( init_fs ,  iactive , runpath_fmt , subst_list , INIT_CONDITIONAL , 13 );
+
+    test_assert_true( ert_init_context_is_instance( context ));
+    test_assert_int_equal( 8 , ert_init_context_get_size( context ));
 
     {
-      run_arg_type * run_arg0 = ert_run_context_iget_arg( context , 0 );
-      
+      run_arg_type * run_arg0 = ert_init_context_iget_arg( context , 0 );
+
       test_assert_int_equal( 13 , run_arg_get_iter( run_arg0 ));
       test_assert_string_equal( "/tmp/path/0000" , run_arg_get_runpath( run_arg0 ));
-      
+
       test_assert_true( run_arg_is_instance( run_arg0 ));
     }
-    ert_run_context_free( context );
+    ert_init_context_free( context );
     path_fmt_free( runpath_fmt );
   }
   bool_vector_free( iactive );
@@ -61,7 +62,7 @@ void test_create_ENSEMBLE_EXPERIMENT() {
     path_fmt_type * runpath_fmt = path_fmt_alloc_directory_fmt("/tmp/path/%04d/%d");
     enkf_fs_type * fs = NULL;
     ert_run_context_type * context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, iactive , runpath_fmt , subst_list , INIT_CONDITIONAL , 7 );
-    
+
     test_assert_true( ert_run_context_is_instance( context ));
     test_assert_int_equal( 8 , ert_run_context_get_size( context ));
 
@@ -69,7 +70,7 @@ void test_create_ENSEMBLE_EXPERIMENT() {
       run_arg_type * run_arg0 = ert_run_context_iens_get_arg( context , 0 );
       run_arg_type * run_arg2 = ert_run_context_iens_get_arg( context , 2 );
       run_arg_type * run_argi = ert_run_context_iget_arg( context , 1 );
-      
+
       test_assert_NULL( run_arg0 );
       test_assert_true( run_arg_is_instance( run_argi ));
       test_assert_ptr_equal( run_arg2 , run_argi);
@@ -80,7 +81,7 @@ void test_create_ENSEMBLE_EXPERIMENT() {
 
       test_assert_int_equal( 7 , run_arg_get_iter( run_arg1 ));
       test_assert_string_equal( "/tmp/path/0002/7" , run_arg_get_runpath( run_arg1 ));
-      
+
       test_assert_true( run_arg_is_instance( run_arg1 ));
     }
     ert_run_context_free( context );

--- a/devel/libenkf/tests/enkf_export_inactive_cells.c
+++ b/devel/libenkf/tests/enkf_export_inactive_cells.c
@@ -1,19 +1,19 @@
 /*
    Copyright (C) 2014  Statoil ASA, Norway.
-    
+
    The file 'enkf_export_inactive_cells.c' is part of ERT - Ensemble based Reservoir Tool.
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -124,7 +124,7 @@ void forward_initialize_node(enkf_main_type * enkf_main, const char * init_file,
     bool_vector_type * iactive = bool_vector_alloc(0, false);
     bool_vector_iset( iactive , ens_size - 1 , true );
 
-    enkf_main_run_exp(enkf_main , iactive , false);
+    enkf_main_create_run_path(enkf_main , iactive , 0);
     bool_vector_free(iactive);
   }
 

--- a/devel/libenkf/tests/enkf_forward_init_FIELD.c
+++ b/devel/libenkf/tests/enkf_forward_init_FIELD.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'enkf_forward_init_FIELD.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'enkf_forward_init_FIELD.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -29,12 +29,12 @@
 #include <ert/enkf/enkf_main.h>
 
 
-void create_runpath(enkf_main_type * enkf_main ) {
+void create_runpath(enkf_main_type * enkf_main, int iter) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(0,false);
 
   bool_vector_iset( iactive , ens_size - 1 , true );
-  enkf_main_run_exp(enkf_main , iactive , false );
+  enkf_main_create_run_path(enkf_main , iactive , iter);
   bool_vector_free(iactive);
 }
 
@@ -73,32 +73,32 @@ int main(int argc , char ** argv) {
         free( init_file1 );
         free( init_file2 );
       }
-  
+
       test_assert_bool_equal( enkf_node_use_forward_init( field_node ) , forward_init );
       if (forward_init)
         test_assert_bool_not_equal( enkf_node_initialize( field_node , 0 , enkf_state_get_rng( state )) , forward_init);
       // else hard_failure()
     }
     test_assert_bool_equal( forward_init, ensemble_config_have_forward_init( enkf_main_get_ensemble_config( enkf_main )));
-    
+
     if (forward_init) {
       enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
       enkf_node_type * field_node = enkf_state_get_node( state , "PORO" );
       run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( fs , 0 ,0 , "simulations/run0");
-      node_id_type node_id = {.report_step = 0 ,  
+      node_id_type node_id = {.report_step = 0 ,
                               .iens = 0 };
 
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
-      
+
       {
         int result;
         stringlist_type * msg_list = stringlist_alloc_new();
 
-        
+
         test_assert_false( enkf_node_has_data( field_node , fs, node_id ));
-        
+
         util_unlink_existing( "simulations/run0/petro.grdecl" );
 
         test_assert_false(enkf_node_forward_init(field_node, "simulations/run0", 0));
@@ -115,7 +115,7 @@ int main(int argc , char ** argv) {
         stringlist_free(msg_list);
         test_assert_true(LOAD_FAILURE & result);
       }
-      
+
 
       util_copy_file( init_file , "simulations/run0/petro.grdecl");
       {
@@ -132,18 +132,18 @@ int main(int argc , char ** argv) {
 
         {
           double value;
-          test_assert_true( enkf_node_user_get( field_node , fs , "5,5,5" , node_id , &value)); 
+          test_assert_true( enkf_node_user_get( field_node , fs , "5,5,5" , node_id , &value));
           test_assert_double_equal( 0.28485405445 , value);
         }
       }
       util_clear_directory( "simulations" , true , true );
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
       test_assert_true( util_is_file( "simulations/run0/PORO.grdecl" ));
       test_assert_true( enkf_node_fload( field_node , "simulations/run0/PORO.grdecl"));
       {
         double value;
-        test_assert_true( enkf_node_user_get( field_node , fs , "4,4,4" , node_id , &value)); 
+        test_assert_true( enkf_node_user_get( field_node , fs , "4,4,4" , node_id , &value));
         test_assert_double_equal( 0.130251303315 , value);
       }
       util_clear_directory( "simulations" , true , true );

--- a/devel/libenkf/tests/enkf_forward_init_GEN_KW.c
+++ b/devel/libenkf/tests/enkf_forward_init_GEN_KW.c
@@ -30,15 +30,14 @@
 #include <ert/enkf/run_arg.h>
 
 
-void create_runpath(enkf_main_type * enkf_main ) {
+void create_runpath(enkf_main_type * enkf_main, int iter ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(0,false);
 
   bool_vector_iset( iactive , ens_size - 1 , true );
-  enkf_main_run_exp(enkf_main , iactive , false );
+  enkf_main_create_run_path(enkf_main , iactive , iter);
   bool_vector_free(iactive);
 }
-
 
 
 int main(int argc , char ** argv) {
@@ -88,7 +87,7 @@ int main(int argc , char ** argv) {
       node_id_type node_id = {.report_step = 0 ,
                               .iens = 0 };
 
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
 
       {
@@ -145,7 +144,7 @@ int main(int argc , char ** argv) {
       test_assert_true( util_is_file ("simulations/run0/parameters.txt")); //Export of gen kw params
 
       util_clear_directory( "simulations" , true , true );
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
       test_assert_true( util_is_file( "simulations/run0/MULTFLT.INC" ));
       {

--- a/devel/libenkf/tests/enkf_forward_init_GEN_PARAM.c
+++ b/devel/libenkf/tests/enkf_forward_init_GEN_PARAM.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'enkf_forward_init_GEN_PARAM.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'enkf_forward_init_GEN_PARAM.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -30,12 +30,12 @@
 #include <ert/enkf/run_arg.h>
 
 
-void create_runpath(enkf_main_type * enkf_main ) {
+void create_runpath(enkf_main_type * enkf_main, int iter ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(0,false);
 
   bool_vector_iset( iactive , ens_size - 1 , true );
-  enkf_main_run_exp(enkf_main , iactive , false );
+  enkf_main_create_run_path(enkf_main , iactive , iter);
   bool_vector_free(iactive);
 }
 
@@ -52,7 +52,7 @@ int main(int argc , char ** argv) {
     bool forward_init;
     bool strict = true;
     enkf_main_type * enkf_main;
-    
+
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
@@ -72,25 +72,25 @@ int main(int argc , char ** argv) {
         free( init_file1 );
         free( init_file2 );
       }
-  
+
       test_assert_bool_equal( enkf_node_use_forward_init( gen_param_node ) , forward_init );
       if (forward_init)
         test_assert_bool_not_equal( enkf_node_initialize( gen_param_node , 0 , enkf_state_get_rng( state )) , forward_init);
       // else hard_failure()
     }
     test_assert_bool_equal( forward_init, ensemble_config_have_forward_init( enkf_main_get_ensemble_config( enkf_main )));
-    
+
     if (forward_init) {
       enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
       run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( fs , 0 , 0 , "simulations/run0");
       enkf_node_type * gen_param_node = enkf_state_get_node( state , "PARAM" );
-      node_id_type node_id = {.report_step = 0 ,  
+      node_id_type node_id = {.report_step = 0 ,
                               .iens = 0};
 
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
-      
+
       test_assert_false( enkf_node_has_data( gen_param_node , fs, node_id ));
       util_unlink_existing( "simulations/run0/PARAM_INIT" );
 
@@ -99,15 +99,15 @@ int main(int argc , char ** argv) {
         fprintf(stream , "0\n1\n2\n3\n" );
         fclose( stream );
       }
-      
+
       {
         int error;
         stringlist_type * msg_list = stringlist_alloc_new();
 
         test_assert_true( enkf_node_forward_init( gen_param_node , "simulations/run0" , 0 ));
-        
+
         error = enkf_state_forward_init( state , run_arg );
-        test_assert_int_equal(0, error); 
+        test_assert_int_equal(0, error);
         {
           enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
           state_map_type * state_map = enkf_fs_get_state_map(fs);
@@ -116,29 +116,29 @@ int main(int argc , char ** argv) {
         error = enkf_state_load_from_forward_model( state , run_arg , msg_list );
 
         stringlist_free( msg_list );
-        test_assert_int_equal(0, error); 
+        test_assert_int_equal(0, error);
 
         {
           double value;
-          test_assert_true( enkf_node_user_get( gen_param_node , fs , "0" , node_id , &value)); 
+          test_assert_true( enkf_node_user_get( gen_param_node , fs , "0" , node_id , &value));
           test_assert_double_equal( 0 , value);
 
-          test_assert_true( enkf_node_user_get( gen_param_node , fs , "1" , node_id , &value)); 
+          test_assert_true( enkf_node_user_get( gen_param_node , fs , "1" , node_id , &value));
           test_assert_double_equal( 1 , value);
 
-          test_assert_true( enkf_node_user_get( gen_param_node , fs , "2" , node_id , &value)); 
+          test_assert_true( enkf_node_user_get( gen_param_node , fs , "2" , node_id , &value));
           test_assert_double_equal( 2 , value);
         }
       }
       util_clear_directory( "simulations" , true , true );
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
       test_assert_true( util_is_file( "simulations/run0/PARAM.INC" ));
       {
         FILE * stream = util_fopen("simulations/run0/PARAM.INC" , "r");
         double v0,v1,v2,v3;
         fscanf(stream , "%lg %lg %lg %lg" , &v0,&v1,&v2,&v3);
-        fclose( stream );                
+        fclose( stream );
         test_assert_double_equal( 0 , v0);
         test_assert_double_equal( 1 , v1);
         test_assert_double_equal( 2 , v2);

--- a/devel/libenkf/tests/enkf_forward_init_SURFACE.c
+++ b/devel/libenkf/tests/enkf_forward_init_SURFACE.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'enkf_forward_init_SURFACE.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'enkf_forward_init_SURFACE.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -29,12 +29,12 @@
 #include <ert/enkf/enkf_main.h>
 #include <ert/enkf/run_arg.h>
 
-void create_runpath(enkf_main_type * enkf_main ) {
+void create_runpath(enkf_main_type * enkf_main, int iter  ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(0,false);
 
   bool_vector_iset( iactive , ens_size - 1 , true );
-  enkf_main_run_exp(enkf_main , iactive , false );
+  enkf_main_create_run_path(enkf_main , iactive , iter);
   bool_vector_free(iactive);
 }
 
@@ -75,34 +75,34 @@ int main(int argc , char ** argv) {
         free( init_file1 );
         free( init_file2 );
       }
-  
+
       test_assert_bool_equal( enkf_node_use_forward_init( surface_node ) , forward_init );
       if (forward_init)
         test_assert_bool_not_equal( enkf_node_initialize( surface_node , 0 , enkf_state_get_rng( state )) , forward_init);
       // else hard_failure()
     }
     test_assert_bool_equal( forward_init, ensemble_config_have_forward_init( enkf_main_get_ensemble_config( enkf_main )));
-    
+
     if (forward_init) {
       enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
       run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( fs , 0 ,0 , "simulations/run0");
       enkf_node_type * surface_node = enkf_state_get_node( state , "SURFACE" );
-      node_id_type node_id = {.report_step = 0 ,  
+      node_id_type node_id = {.report_step = 0 ,
                               .iens = 0 };
 
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
-      
+
       {
         int error;
         stringlist_type * msg_list = stringlist_alloc_new();
 
-                
+
         test_assert_false( enkf_node_has_data( surface_node , fs, node_id ));
-        
+
         util_unlink_existing( "simulations/run0/Surface.irap" );
-        
+
         test_assert_false( enkf_node_forward_init( surface_node , "simulations/run0" , 0 ));
         error = enkf_state_forward_init( state , run_arg );
         test_assert_true(LOAD_FAILURE & error);
@@ -116,41 +116,41 @@ int main(int argc , char ** argv) {
         stringlist_free( msg_list );
         test_assert_true(LOAD_FAILURE & error);
       }
-      
+
 
       util_copy_file( init_file , "simulations/run0/Surface.irap");
       {
         int error;
         stringlist_type * msg_list = stringlist_alloc_new();
 
-        
+
         test_assert_true( enkf_node_forward_init( surface_node , "simulations/run0" , 0 ));
         error = enkf_state_forward_init( state , run_arg );
-        test_assert_int_equal(0, error); 
+        test_assert_int_equal(0, error);
         error = enkf_state_load_from_forward_model( state , run_arg ,  msg_list );
         stringlist_free( msg_list );
-        test_assert_int_equal(0, error); 
+        test_assert_int_equal(0, error);
 
         {
           double value;
-          test_assert_true( enkf_node_user_get( surface_node , fs , "0" , node_id , &value)); 
+          test_assert_true( enkf_node_user_get( surface_node , fs , "0" , node_id , &value));
           test_assert_double_equal( 2735.7461 , value);
 
-          test_assert_true( enkf_node_user_get( surface_node , fs , "5" , node_id , &value)); 
+          test_assert_true( enkf_node_user_get( surface_node , fs , "5" , node_id , &value));
           test_assert_double_equal( 2737.0122 , value);
         }
       }
       util_clear_directory( "simulations" , true , true );
-      create_runpath( enkf_main );
+      create_runpath( enkf_main, 0 );
       test_assert_true( util_is_directory( "simulations/run0" ));
       test_assert_true( util_is_file( "simulations/run0/SURFACE.INC" ));
       test_assert_true( enkf_node_fload( surface_node , "simulations/run0/SURFACE.INC"));
       {
         double value;
-        test_assert_true( enkf_node_user_get( surface_node , fs , "0" , node_id , &value)); 
+        test_assert_true( enkf_node_user_get( surface_node , fs , "0" , node_id , &value));
         test_assert_double_equal( 2735.7461 , value);
-      
-        test_assert_true( enkf_node_user_get( surface_node , fs , "5" , node_id , &value)); 
+
+        test_assert_true( enkf_node_user_get( surface_node , fs , "5" , node_id , &value));
         test_assert_double_equal( 2737.0122 , value);
       }
       util_clear_directory( "simulations" , true , true );

--- a/devel/libenkf/tests/enkf_forward_init_transform.c
+++ b/devel/libenkf/tests/enkf_forward_init_transform.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'enkf_forward_init_transform.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'enkf_forward_init_transform.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -35,12 +35,12 @@
 
 
 
-void create_runpath(enkf_main_type * enkf_main ) {
+void create_runpath(enkf_main_type * enkf_main, int iter ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(0,false);
 
   bool_vector_iset( iactive , ens_size - 1 , true );
-  enkf_main_run_exp(enkf_main , iactive , false );
+  enkf_main_create_run_path(enkf_main , iactive , iter);
   bool_vector_free(iactive);
 }
 
@@ -49,18 +49,18 @@ bool check_original_exported_data_equal(const enkf_node_type * field_node) {
   FILE * original_stream = util_fopen( "petro.grdecl" , "r");
   ecl_kw_type * kw_original = ecl_kw_fscanf_alloc_grdecl_dynamic( original_stream , "PORO" , ECL_DOUBLE_TYPE );
 
-  enkf_node_ecl_write(field_node, "tmp", NULL, 0); 
+  enkf_node_ecl_write(field_node, "tmp", NULL, 0);
   FILE * exported_stream = util_fopen( "tmp/PORO.grdecl" , "r");
   ecl_kw_type * kw_exported = ecl_kw_fscanf_alloc_grdecl_dynamic( exported_stream , "PORO" , ECL_DOUBLE_TYPE );
 
   bool ret = ecl_kw_numeric_equal(kw_original, kw_exported, 1e-5 , 1e-5);
 
-  util_fclose(original_stream); 
-  util_fclose(exported_stream); 
-  ecl_kw_free(kw_original); 
-  ecl_kw_free(kw_exported); 
-  
-  return ret; 
+  util_fclose(original_stream);
+  util_fclose(exported_stream);
+  ecl_kw_free(kw_original);
+  ecl_kw_free(kw_exported);
+
+  return ret;
 }
 
 
@@ -70,27 +70,27 @@ int main(int argc , char ** argv) {
   const char * config_file = argv[2];
   const char * init_file   = argv[3];
   const char * forward_init_string = argv[4];
-  
+
   test_work_area_type * work_area = test_work_area_alloc(config_file );
   test_work_area_copy_directory_content( work_area , root_path );
   test_work_area_install_file( work_area , init_file );
-  test_work_area_set_store(work_area, true); 
-  
+  test_work_area_set_store(work_area, true);
+
   bool strict = true;
   enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , strict , true );
   enkf_fs_type * init_fs = enkf_main_get_fs(enkf_main);
   enkf_state_type * state = enkf_main_iget_state( enkf_main , 0 );
   run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( init_fs , 0 ,0 , "simulations/run0");
   enkf_node_type * field_node = enkf_state_get_node( state , "PORO" );
-  
+
   bool forward_init;
   test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
   test_assert_bool_equal( enkf_node_use_forward_init( field_node ) , forward_init );
   test_assert_bool_equal( forward_init, ensemble_config_have_forward_init( enkf_main_get_ensemble_config( enkf_main )));
-  
+
   util_clear_directory( "Storage" , true , true );
-  
-  create_runpath( enkf_main );
+
+  create_runpath( enkf_main, 0 );
   test_assert_true( util_is_directory( "simulations/run0" ));
 
   if (forward_init)
@@ -99,17 +99,17 @@ int main(int argc , char ** argv) {
   {
     bool_vector_type * iactive = bool_vector_alloc( enkf_main_get_ensemble_size(enkf_main) , true);
     int error;
-    stringlist_type * msg_list = stringlist_alloc_new();  
+    stringlist_type * msg_list = stringlist_alloc_new();
     error = enkf_state_load_from_forward_model( state , run_arg ,  msg_list );
     stringlist_free( msg_list );
     bool_vector_free( iactive );
-    test_assert_int_equal(error, 0); 
+    test_assert_int_equal(error, 0);
   }
 
   test_assert_true(check_original_exported_data_equal(field_node));
 
   run_arg_free( run_arg );
-  enkf_main_free(enkf_main);    
-  test_work_area_free(work_area); 
+  enkf_main_free(enkf_main);
+  test_work_area_free(work_area);
 }
 

--- a/devel/python/python/ert/enkf/enkf_main.py
+++ b/devel/python/python/ert/enkf/enkf_main.py
@@ -240,6 +240,8 @@ class EnKFMain(BaseCClass):
     def loadFromForwardModel(self, realization, iteration, fs):
         EnKFMain.cNamespace().load_from_forward_model(self, iteration, realization, fs)
 
+    def createRunPath(self , run_arg):
+        EnKFMain.cNamespace().create_run_path( self , run_arg)
 
     def submitSimulation(self , run_arg):
         EnKFMain.cNamespace().submit_simulation( self , run_arg)
@@ -254,7 +256,7 @@ class EnKFMain(BaseCClass):
 
     def addNode(self, enkf_config_node):
         EnKFMain.cNamespace().add_node(self, enkf_config_node)
-    
+
 
 ##################################################################
 
@@ -313,6 +315,7 @@ EnKFMain.cNamespace().export_field = cwrapper.prototype("bool enkf_main_export_f
 EnKFMain.cNamespace().export_field_with_fs = cwrapper.prototype("bool enkf_main_export_field_with_fs(enkf_main, char*, char*, bool_vector, enkf_field_file_format_enum, int, enkf_fs_manager)")
 EnKFMain.cNamespace().load_from_forward_model = cwrapper.prototype("void enkf_main_load_from_forward_model_from_gui(enkf_main, int, bool_vector, enkf_fs)")
 
+EnKFMain.cNamespace().create_run_path = cwrapper.prototype("void enkf_main_icreate_run_path(enkf_main , run_arg)")
 EnKFMain.cNamespace().submit_simulation = cwrapper.prototype("void enkf_main_isubmit_job(enkf_main , run_arg)")
 EnKFMain.cNamespace().alloc_run_context_ENSEMBLE_EXPERIMENT= cwrapper.prototype("ert_run_context_obj enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT( enkf_main , enkf_fs , bool_vector , enkf_init_mode_enum , int)")
 EnKFMain.cNamespace().alloc_field_init_file = cwrapper.prototype("cstring_obj enkf_main_alloc_abs_path_to_init_file(enkf_main, enkf_config_node)")

--- a/devel/python/python/ert/enkf/enkf_simulation_runner.py
+++ b/devel/python/python/ert/enkf/enkf_simulation_runner.py
@@ -18,6 +18,10 @@ class EnkfSimulationRunner(BaseCClass):
         assert isinstance(initialization_mode, EnkfInitModeEnum)
         return EnkfSimulationRunner.cNamespace().run_simple_step(self, active_realization_mask, initialization_mode , iter_nr)
 
+    def createRunPath(self, active_realization_mask, iter_nr):
+        """ @rtype: bool """
+        assert isinstance(active_realization_mask, BoolVector)
+        return EnkfSimulationRunner.cNamespace().create_run_path(self, active_realization_mask, iter_nr)
 
     def runEnsembleExperiment(self, active_realization_mask=None):
         """ @rtype: bool """
@@ -32,9 +36,9 @@ class EnkfSimulationRunner(BaseCClass):
     def runWorkflows(self , runtime):
         """:type ert.enkf.enum.HookRuntimeEnum"""
         hook_manager = self.ert.getHookManager()
-        hook_manager.runWorkflows( runtime  , self.ert ) 
-        
-    
+        hook_manager.runWorkflows( runtime  , self.ert )
+
+
 
     def smootherUpdate(self, source_fs , target_fs):
         """ @rtype: bool """
@@ -47,6 +51,6 @@ cwrapper = CWrapper(ENKF_LIB)
 cwrapper.registerType("enkf_simulation_runner", EnkfSimulationRunner)
 
 EnkfSimulationRunner.cNamespace().run_smoother      = cwrapper.prototype("void enkf_main_run_smoother(enkf_simulation_runner, char*, bool)")
-
+EnkfSimulationRunner.cNamespace().create_run_path   = cwrapper.prototype("bool enkf_main_create_run_path(enkf_simulation_runner, bool_vector, int)")
 EnkfSimulationRunner.cNamespace().run_simple_step   = cwrapper.prototype("bool enkf_main_run_simple_step(enkf_simulation_runner, bool_vector, enkf_init_mode_enum, int)")
 EnkfSimulationRunner.cNamespace().smoother_update   = cwrapper.prototype("bool enkf_main_smoother_update(enkf_simulation_runner, enkf_fs , enkf_fs)")

--- a/devel/python/python/ert/server/simulation_context.py
+++ b/devel/python/python/ert/server/simulation_context.py
@@ -31,6 +31,9 @@ class SimulationContext(object):
         member = self._ert.getRealisation(iens)
         runpath = ErtRunContext.createRunpath(iens , runpath_fmt, member.getDataKW( ))
         run_arg = RunArg.createEnsembleExperimentRunArg(target_fs, iens, runpath)
+
+        self._ert.createRunPath(run_arg)
+
         self._run_args[iens] = run_arg
         self._thread_pool.submitJob(ArgPack(self._ert, run_arg))
 

--- a/devel/python/python/ert_gui/models/connectors/run/ensemble_experiment.py
+++ b/devel/python/python/ert_gui/models/connectors/run/ensemble_experiment.py
@@ -11,7 +11,13 @@ class EnsembleExperiment(BaseRunModel):
     def runSimulations(self):
         self.setPhase(0, "Running simulations...", indeterminate=False)
         active_realization_mask = ActiveRealizationsModel().getActiveRealizationsMask()
-        
+
+        self.setPhaseName("Pre processing...", indeterminate=True)
+        self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
+        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
+
+        self.setPhaseName("Running ensemble experiment...", indeterminate=True)
+
         success = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(active_realization_mask)
 
         if not success:

--- a/devel/python/python/ert_gui/models/connectors/run/ensemble_smoother.py
+++ b/devel/python/python/ert_gui/models/connectors/run/ensemble_smoother.py
@@ -19,11 +19,14 @@ class EnsembleSmoother(BaseRunModel):
 
     def runSimulations(self):
         self.setPhase(0, "Running simulations...", indeterminate=False)
-
         self.setAnalysisModule()
-
         active_realization_mask = ActiveRealizationsModel().getActiveRealizationsMask()
 
+        self.setPhaseName("Pre processing...", indeterminate=True)
+        self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
+        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
+
+        self.setPhaseName("Running forecast...", indeterminate=True)
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_CONDITIONAL , 0)
 
         if not success:
@@ -37,10 +40,10 @@ class EnsembleSmoother(BaseRunModel):
             #else ignore and continue
 
 
-        
+
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
-        
+
         self.setPhaseName("Analyzing...", indeterminate=True)
 
         target_case_name = TargetCaseModel().getValue()
@@ -52,8 +55,14 @@ class EnsembleSmoother(BaseRunModel):
             raise ErtRunError("Analysis of simulation failed!")
 
         self.setPhase(1, "Running simulations...", indeterminate=False)
-
         self.ert().getEnkfFsManager().switchFileSystem(target_fs)
+        
+        self.setPhaseName("Pre processing...", indeterminate=True)
+        self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 1)
+        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
+
+        self.setPhaseName("Running forecast...", indeterminate=True)
+
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_NONE, 1)
 
         if not success:

--- a/devel/python/python/ert_gui/models/connectors/run/iterated_ensemble_smoother.py
+++ b/devel/python/python/ert_gui/models/connectors/run/iterated_ensemble_smoother.py
@@ -22,6 +22,11 @@ class IteratedEnsembleSmoother(BaseRunModel):
     def runAndPostProcess(self, active_realization_mask, phase, phase_count, mode):
         self.setPhase(phase, "Running iteration %d of %d simulation iterations..." % (phase, phase_count - 1), indeterminate=False)
 
+        self.setPhaseName("Pre processing...", indeterminate=True)
+        self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, phase)
+        self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
+
+        self.setPhaseName("Running forecast...", indeterminate=True)
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, mode, phase)
 
         if not success:
@@ -37,7 +42,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
 
-        
+
     def createTargetCaseFileSystem(self, phase):
         target_case_format = TargetCaseFormatModel().getValue()
         target_fs = self.ert().getEnkfFsManager().getFileSystem(target_case_format % phase)


### PR DESCRIPTION
I'd appreciate comments on this. This PR attempts to split as commented in:

#1053 

as some sort of replication of the way is done for tui when creating the run path. 

If this is OK, I'll add further support for PRE_SIMULATION to the tui functions. 
