### PR TITLE
Adding innovations to forecast ensemble

### DIFF
--- a/devel/libanalysis/src/fwd_step_enkf.c
+++ b/devel/libanalysis/src/fwd_step_enkf.c
@@ -163,7 +163,7 @@ void fwd_step_enkf_updateA(void * module_data ,
             matrix_iset(di , 0 , k , matrix_iget( D , k , j ) );
           }
 
-          xHat = stepwise_eval(stepwise_data , di );
+          xHat = matrix_iget( A , i , j ) + stepwise_eval(stepwise_data , di );
           matrix_iset(A , i , j , xHat);
         }
 

--- a/devel/libert_util/include/ert/util/regression.h
+++ b/devel/libert_util/include/ert/util/regression.h
@@ -28,7 +28,7 @@ extern "C" {
 
 double  regression_scale( matrix_type * X ,  matrix_type * Y , matrix_type * X_mean , matrix_type * X_norm);
 double  regression_unscale(const matrix_type * beta , const matrix_type * X_norm , const matrix_type * X_mean , double Y_mean , matrix_type * beta0);
-void    regression_OLS(const matrix_type * X , const matrix_type * Y , const matrix_type *E, matrix_type * beta);
+void    regression_augmented_OLS(const matrix_type * X , const matrix_type * Y , const matrix_type *E, matrix_type * beta);
 
 #ifdef __cplusplus
 }

--- a/devel/libert_util/include/ert/util/regression.h
+++ b/devel/libert_util/include/ert/util/regression.h
@@ -1,25 +1,25 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'regression.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'regression.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_REGRESSION_H
 #define ERT_REGRESSION_H
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -28,9 +28,9 @@ extern "C" {
 
 double  regression_scale( matrix_type * X ,  matrix_type * Y , matrix_type * X_mean , matrix_type * X_norm);
 double  regression_unscale(const matrix_type * beta , const matrix_type * X_norm , const matrix_type * X_mean , double Y_mean , matrix_type * beta0);
-void    regression_OLS(const matrix_type * X , const matrix_type * Y , matrix_type * beta);
+void    regression_OLS(const matrix_type * X , const matrix_type * Y , const matrix_type *E, matrix_type * beta);
 
 #ifdef __cplusplus
 }
 #endif
-#endif 
+#endif

--- a/devel/libert_util/include/ert/util/stepwise.h
+++ b/devel/libert_util/include/ert/util/stepwise.h
@@ -11,13 +11,13 @@ extern "C" {
   typedef struct stepwise_struct stepwise_type;
 
 
-  stepwise_type * stepwise_alloc2( matrix_type * X , matrix_type * Y , bool internal_copy , rng_type * rng);
   stepwise_type * stepwise_alloc1(int nsample, int nvar, rng_type * rng);
   stepwise_type * stepwise_alloc0(rng_type * rng);
   void            stepwise_free( stepwise_type * stepwise);
 
   void            stepwise_set_Y0( stepwise_type * stepwise ,  matrix_type * Y);
   void            stepwise_set_X0( stepwise_type * stepwise ,  matrix_type * X);
+  void            stepwise_set_E0( stepwise_type * stepwise ,  matrix_type * E);
   void            stepwise_set_beta( stepwise_type * stepwise ,  matrix_type * b);
   void            stepwise_set_R2( stepwise_type * stepwise ,  const double R2);
   void            stepwise_set_active_set( stepwise_type * stepwise ,  bool_vector_type * a);

--- a/devel/libert_util/src/regression.c
+++ b/devel/libert_util/src/regression.c
@@ -98,7 +98,7 @@ double regression_unscale(const matrix_type * beta , const matrix_type * X_norm 
 */
 
 void regression_OLS( const matrix_type * X , const matrix_type * Y , const matrix_type* E, matrix_type * beta) {
-  int nvar = matrix_get_columns( E );
+  int nvar = matrix_get_columns( X );
   matrix_type * Xt   = matrix_alloc_transpose( X );
   matrix_type * Xinv = matrix_alloc( nvar ,  nvar);
 

--- a/devel/libert_util/src/regression.c
+++ b/devel/libert_util/src/regression.c
@@ -67,7 +67,7 @@ double regression_scale(matrix_type * X , matrix_type * Y , matrix_type * X_mean
       }
 
       for (col=0; col < nvar; col++) {
-        double norm = sqrt( (1.0 / (nsample - 1)) * matrix_get_column_sum2( X , col ));
+        double norm = 1.0/sqrt( (1.0 / (nsample - 1)) * matrix_get_column_sum2( X , col ));
         matrix_iset( X_norm , 0 , col , norm );
       }
     }

--- a/devel/libert_util/src/stepwise.c
+++ b/devel/libert_util/src/stepwise.c
@@ -100,7 +100,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
 
     matrix_type * beta     = matrix_alloc( nvar , 1);           /* This is the beta vector as estimated from the OLS estimator. */
 
-    regression_OLS( X , Y , E, beta );
+    regression_augmented_OLS( X , Y , E, beta );
 
 
     /*

--- a/devel/libert_util/src/stepwise.c
+++ b/devel/libert_util/src/stepwise.c
@@ -16,6 +16,7 @@ struct stepwise_struct {
   UTIL_TYPE_ID_DECLARATION;
 
   matrix_type      * X0;             // Externally supplied data.
+  matrix_type      * E0;             // Externally supplied data.
   matrix_type      * Y0;
   bool               data_owner;     // Does the stepwise estimator own the data matrices X0 and Y0?
 
@@ -32,6 +33,7 @@ struct stepwise_struct {
 
 static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type * active_rows) {
   matrix_type * X;
+  matrix_type * E;
   matrix_type * Y;
 
   double y_mean    = 0;
@@ -54,6 +56,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
   */
   if ((nsample < matrix_get_rows( stepwise->X0 )) || (nvar < matrix_get_columns( stepwise->X0 ))) {
     X = matrix_alloc( nsample , nvar );
+    E = matrix_alloc( nsample , nvar );
     Y = matrix_alloc( nsample , 1);
 
     {
@@ -66,6 +69,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
           for (icol = 0; icol < matrix_get_columns( stepwise->X0 ); icol++) {
             if (bool_vector_iget( stepwise->active_set , icol )) {
               matrix_iset( X , arow , acol , matrix_iget( stepwise->X0 , irow , icol ));
+              matrix_iset( E , arow , acol , matrix_iget( stepwise->E0 , irow , icol ));
               acol++;
             }
           }
@@ -77,6 +81,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
     }
   } else {
     X = matrix_alloc_copy( stepwise->X0 );
+    E = matrix_alloc_copy( stepwise->E0 );
     Y = matrix_alloc_copy( stepwise->Y0 );
   }
 
@@ -94,12 +99,8 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
     stepwise->X_norm = matrix_alloc( 1 , nvar );
 
     matrix_type * beta     = matrix_alloc( nvar , 1);           /* This is the beta vector as estimated from the OLS estimator. */
-    matrix_type * tmp_beta = matrix_alloc_copy( beta );         /* This is the beta vector shifted and scaled back to original variables. */
 
-    stepwise->Y_mean = regression_scale( X , Y , stepwise->X_mean , stepwise->X_norm );
-
-    regression_OLS( X , Y , beta );
-    y_mean = regression_unscale( beta , stepwise->X_norm , stepwise->X_mean , stepwise->Y_mean , tmp_beta );
+    regression_OLS( X , Y , E, beta );
 
 
     /*
@@ -112,7 +113,7 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
       avar = 0;
       for (ivar = 0; ivar < matrix_get_columns( stepwise->X0 ); ivar++) {
         if (bool_vector_iget( stepwise->active_set , ivar )) {
-          matrix_iset( stepwise->beta , ivar , 0 , matrix_iget( tmp_beta , avar , 0));
+          matrix_iset( stepwise->beta , ivar , 0 , matrix_iget( beta , avar , 0));
           avar++;
         }
       }
@@ -120,10 +121,10 @@ static double stepwise_estimate__( stepwise_type * stepwise , bool_vector_type *
 
 
     matrix_free( beta );
-    matrix_free( tmp_beta );
   }
 
   matrix_free( X );
+  matrix_free( E );
   matrix_free( Y );
   return y_mean;
 }
@@ -322,6 +323,7 @@ static stepwise_type * stepwise_alloc__( int nsample , int nvar , rng_type * rng
   stepwise->Y_mean      = 0.0;
   stepwise->rng         = rng;
   stepwise->X0          = NULL;
+  stepwise->E0          = NULL;
   stepwise->Y0          = NULL;
   stepwise->active_set  = bool_vector_alloc( nvar , true );
   stepwise->beta        = matrix_alloc( nvar , 1 );
@@ -335,6 +337,7 @@ stepwise_type * stepwise_alloc0( rng_type * rng) {
 
   stepwise->rng         = rng;
   stepwise->X0          = NULL;
+  stepwise->E0          = NULL;
   stepwise->Y0          = NULL;
   stepwise->beta        = NULL;
   stepwise->active_set  = NULL;
@@ -354,24 +357,10 @@ stepwise_type * stepwise_alloc1( int nsample , int nvar, rng_type * rng) {
 
   stepwise->rng         = rng;
   stepwise->X0          = matrix_alloc( nsample , nvar );
+  stepwise->E0          = matrix_alloc( nsample , nvar );
   stepwise->Y0          = matrix_alloc( nsample , 1 );
   stepwise->data_owner  = true;
 
-  return stepwise;
-}
-
-
-stepwise_type * stepwise_alloc2( matrix_type * X , matrix_type * Y , bool internal_copy , rng_type * rng) {
-  stepwise_type * stepwise = stepwise_alloc__( matrix_get_rows( X ) , matrix_get_columns( X ) , rng);
-  if (internal_copy) {
-    stepwise->X0 = matrix_alloc_copy( X );
-    stepwise->Y0 = matrix_alloc_copy( Y );
-    stepwise->data_owner = true;
-  } else {
-    stepwise->X0 = X;
-    stepwise->Y0 = Y;
-    stepwise->data_owner = false;
-  }
   return stepwise;
 }
 
@@ -390,6 +379,14 @@ void stepwise_set_X0( stepwise_type * stepwise ,  matrix_type * X) {
 
 
   stepwise->X0 = X;
+}
+
+void stepwise_set_E0( stepwise_type * stepwise ,  matrix_type * E) {
+  if (stepwise->E0 != NULL)
+    matrix_free( stepwise->E0 );
+
+
+  stepwise->E0 = E;
 }
 
 
@@ -458,6 +455,7 @@ void stepwise_free( stepwise_type * stepwise ) {
 
   if (stepwise->data_owner) {
     matrix_free( stepwise->X0 );
+    matrix_free( stepwise->E0 );
     matrix_free( stepwise->Y0 );
   }
   free( stepwise );

--- a/devel/python/python/ert_gui/models/connectors/run/analysis_module_variables_model.py
+++ b/devel/python/python/ert_gui/models/connectors/run/analysis_module_variables_model.py
@@ -15,7 +15,7 @@
 #  for more details.
 from ert.analysis.analysis_module import AnalysisModule
 from ert_gui.models import ErtConnector
-
+from ert_gui.models.connectors import EnsembleSizeModel
 
 class AnalysisModuleVariablesModel(ErtConnector):
 
@@ -32,7 +32,7 @@ class AnalysisModuleVariablesModel(ErtConnector):
             "LAMBDA_RECALCULATE": {"type": bool, "labelname":"Recalculate Lambda after each Iteration", "pos":7},
             "ENKF_TRUNCATION" :{"type": float, "min": 0, "max": 1, "step":0.1, "labelname":"Singular value truncation", "pos":9},
             "ENKF_NCOMP": {"type": int, "min": -1, "max": 10, "step":1.0, "labelname":"ENKF_NCOMP", "pos":10},
-            "CV_NFOLDS": {"type": int, "min": -1, "max": 10, "step":1.0, "labelname":"CV_NFOLDS", "pos":11},
+            "CV_NFOLDS": {"type": int, "min": 2, "max": EnsembleSizeModel().getValue() - 1, "step":1.0, "labelname":"CV_NFOLDS", "pos":11},
             "FWD_STEP_R2_LIMIT":{"type": float, "min": -1, "max": 100, "step":1.0, "labelname":"FWD_STEP_R2_LIMIT", "pos":12},
             "CV_PEN_PRESS": {"type": bool, "labelname":"CV_PEN_PRESS", "pos":13}
         }


### PR DESCRIPTION
This is another problem, apparent when testing fwd_enkf on parameters. The forecast ensemble was replaced by the innovations.

Need to merge for further testing. Still on testing phase, some of these WIP changes could be reverted.
