### PR TITLE
axes.errorbar takes yerr array, not 2xn matrix.

### DIFF
--- a/devel/python/python/ert_gui/plottery/plots/observations.py
+++ b/devel/python/python/ert_gui/plottery/plots/observations.py
@@ -24,5 +24,6 @@ def _plotObservations(axes, plot_config, data, value_column):
 
     style = plot_config.observationsStyle()
 
-    errorbars = axes.errorbar(x=data.index.values, y=data[value_column], yerr=data["STD_%s" % value_column],
-                 fmt=' ', ecolor=style.color, alpha=style.alpha)
+    errorbars = axes.errorbar(x=data.index.values, y=data[value_column].values,
+                              yerr=data["STD_%s" % value_column].values,
+                              fmt=' ', ecolor=style.color, alpha=style.alpha)


### PR DESCRIPTION
* Added `.values` to both y and yerr arguments to errorbar
* Previously, we sent 2xn matrices, now we send lists of values

This fixes a (keyerror) crash while plotting errorbars in `XXX_WPR_DIFF@199`.