### PR TITLE
Set indeterminate=False on running simulations

### DIFF
--- a/devel/python/python/ert_gui/models/connectors/run/ensemble_experiment.py
+++ b/devel/python/python/ert_gui/models/connectors/run/ensemble_experiment.py
@@ -16,7 +16,7 @@ class EnsembleExperiment(BaseRunModel):
         self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
 
-        self.setPhaseName("Running ensemble experiment...", indeterminate=True)
+        self.setPhaseName("Running ensemble experiment...", indeterminate=False)
 
         success = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(active_realization_mask)
 

--- a/devel/python/python/ert_gui/models/connectors/run/ensemble_smoother.py
+++ b/devel/python/python/ert_gui/models/connectors/run/ensemble_smoother.py
@@ -26,7 +26,7 @@ class EnsembleSmoother(BaseRunModel):
         self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, 0)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
 
-        self.setPhaseName("Running forecast...", indeterminate=True)
+        self.setPhaseName("Running forecast...", indeterminate=False)
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_CONDITIONAL , 0)
 
         if not success:

--- a/devel/python/python/ert_gui/models/connectors/run/iterated_ensemble_smoother.py
+++ b/devel/python/python/ert_gui/models/connectors/run/iterated_ensemble_smoother.py
@@ -26,7 +26,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.ert().getEnkfSimulationRunner().createRunPath(active_realization_mask, phase)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
 
-        self.setPhaseName("Running forecast...", indeterminate=True)
+        self.setPhaseName("Running forecast...", indeterminate=False)
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, mode, phase)
 
         if not success:


### PR DESCRIPTION
In 2951e31 `setPhaseName(name, indeterminate=True)` was added for the three simulators
* ensemble_experiment
* ensemble_smoother
* iterated_ensemble_smoother.

This led the progressbar to not display the progress correctly due to the simulations being indeterminate.

This patch sets `indeterminate=False`.