### PR TITLE
pass ignore to to_numeric instead of coerce

### DIFF
--- a/devel/python/python/ert_gui/plottery/plots/histogram.py
+++ b/devel/python/python/ert_gui/plottery/plots/histogram.py
@@ -38,7 +38,7 @@ def plotHistogram(plot_context):
 
         if data[case].dtype == "object":
             try:
-                data[case] = pd.to_numeric(data[case], errors='coerce')
+                data[case] = pd.to_numeric(data[case], errors='ignore')
             except AttributeError:
                 data[case] = data[case].convert_objects(convert_numeric=True)
 


### PR DESCRIPTION
Using `errors=ignore` instead of `errors=coerce` fixes histogram plotting of text.

This means that any data set containing text will be plotted as classes instead of ranges.

`s = pd.Series(['apple', '1.0', '2', -3])` with `pd.to_numeric(s, errors='coerce')` will yield `[NaN, 1, 2, -3]` whereas `pd.to_numeric(s, errors='ignore')` yields `s`.