### PR TITLE
Confirmed running feature

### DIFF
--- a/devel/libenkf/src/site_config.c
+++ b/devel/libenkf/src/site_config.c
@@ -194,7 +194,7 @@ site_config_type * site_config_alloc_empty() {
   site_config->user_mode = false;
   site_config->driver_type = NULL_DRIVER;
 
-  site_config->job_queue = job_queue_alloc(DEFAULT_MAX_SUBMIT, "OK", "ERROR");
+  site_config->job_queue = job_queue_alloc(DEFAULT_MAX_SUBMIT, "OK", "STATUS", "ERROR");
   site_config->env_variables_user = hash_alloc();
   site_config->env_variables_site = hash_alloc();
 

--- a/devel/libjob_queue/include/ert/job_queue/job_node.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_node.h
@@ -51,6 +51,7 @@ typedef struct job_queue_node_struct job_queue_node_type;
 
 
   bool job_queue_node_status_transition( job_queue_node_type * node , job_queue_status_type * status , job_status_type new_status);
+  bool job_queue_node_status_confirmed_running(job_queue_node_type * node);
   submit_status_type job_queue_node_submit( job_queue_node_type * node , job_queue_status_type * status , queue_driver_type * driver);
   void job_queue_node_free_error_info( job_queue_node_type * node );
   void job_queue_node_fscanf_EXIT( job_queue_node_type * node );
@@ -96,8 +97,10 @@ typedef struct job_queue_node_struct job_queue_node_type;
   time_t job_queue_node_get_sim_start( const job_queue_node_type * node );
   time_t job_queue_node_get_sim_end( const job_queue_node_type * node );
   time_t job_queue_node_get_submit_time( const job_queue_node_type * node );
+  time_t job_queue_node_time_since_sim_start (const job_queue_node_type * node ) ;
 
   const char * job_queue_node_get_ok_file( const job_queue_node_type * node);
+  const char * job_queue_node_get_running_file( const job_queue_node_type * node);
   const char * job_queue_node_get_exit_file( const job_queue_node_type * node);
 
   bool job_queue_node_run_DONE_callback( job_queue_node_type * node );

--- a/devel/libjob_queue/include/ert/job_queue/job_node.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_node.h
@@ -65,6 +65,7 @@ typedef struct job_queue_node_struct job_queue_node_type;
                                               const char ** argv ,
                                               int num_cpu ,
                                               const char * ok_file,
+                                              const char * status_file,
                                               const char * exit_file,
                                               job_callback_ftype * done_callback,
                                               job_callback_ftype * retry_callback,
@@ -97,7 +98,8 @@ typedef struct job_queue_node_struct job_queue_node_type;
   time_t job_queue_node_get_sim_start( const job_queue_node_type * node );
   time_t job_queue_node_get_sim_end( const job_queue_node_type * node );
   time_t job_queue_node_get_submit_time( const job_queue_node_type * node );
-  time_t job_queue_node_time_since_sim_start (const job_queue_node_type * node ) ;
+  double job_queue_node_time_since_sim_start( const job_queue_node_type * node ) ;
+  void job_queue_node_set_max_confirmation_wait_time( job_queue_node_type * node, time_t time );
 
   const char * job_queue_node_get_ok_file( const job_queue_node_type * node);
   const char * job_queue_node_get_status_file( const job_queue_node_type * node);

--- a/devel/libjob_queue/include/ert/job_queue/job_node.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_node.h
@@ -100,7 +100,7 @@ typedef struct job_queue_node_struct job_queue_node_type;
   time_t job_queue_node_time_since_sim_start (const job_queue_node_type * node ) ;
 
   const char * job_queue_node_get_ok_file( const job_queue_node_type * node);
-  const char * job_queue_node_get_running_file( const job_queue_node_type * node);
+  const char * job_queue_node_get_status_file( const job_queue_node_type * node);
   const char * job_queue_node_get_exit_file( const job_queue_node_type * node);
 
   bool job_queue_node_run_DONE_callback( job_queue_node_type * node );

--- a/devel/libjob_queue/include/ert/job_queue/job_queue.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue.h
@@ -39,7 +39,7 @@ extern "C" {
   bool                job_queue_has_driver(const job_queue_type * queue );
   //void                job_queue_set_size( job_queue_type * job_queue , int size );
   void                job_queue_set_runpath_fmt(job_queue_type *  , const path_fmt_type * );
-  job_queue_type   *  job_queue_alloc( int  , const char * ok_file , const char * running_file, const char * exit_file);
+  job_queue_type   *  job_queue_alloc( int  , const char * ok_file , const char * status_file, const char * exit_file);
   void                job_queue_free(job_queue_type *);
 
   int                 job_queue_add_job(job_queue_type * ,

--- a/devel/libjob_queue/include/ert/job_queue/job_queue.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue.h
@@ -39,7 +39,7 @@ extern "C" {
   bool                job_queue_has_driver(const job_queue_type * queue );
   //void                job_queue_set_size( job_queue_type * job_queue , int size );
   void                job_queue_set_runpath_fmt(job_queue_type *  , const path_fmt_type * );
-  job_queue_type   *  job_queue_alloc( int  , const char * ok_file , const char * exit_file);
+  job_queue_type   *  job_queue_alloc( int  , const char * ok_file , const char * running_file, const char * exit_file);
   void                job_queue_free(job_queue_type *);
 
   int                 job_queue_add_job(job_queue_type * ,

--- a/devel/libjob_queue/include/ert/job_queue/job_queue.h
+++ b/devel/libjob_queue/include/ert/job_queue/job_queue.h
@@ -67,6 +67,7 @@ extern "C" {
   time_t              job_queue_iget_sim_start( job_queue_type * queue, int job_index);
   time_t              job_queue_iget_sim_end( job_queue_type * queue, int job_index);
   time_t              job_queue_iget_submit_time( job_queue_type * queue, int job_index);
+  void                job_queue_iset_max_confirm_wait_time( job_queue_type * queue, int job_index, time_t time );
 
   void                job_queue_set_max_job_duration(job_queue_type * queue, int max_duration_seconds);
   int                 job_queue_get_max_job_duration(const job_queue_type * queue);

--- a/devel/libjob_queue/include/ert/job_queue/queue_driver.h
+++ b/devel/libjob_queue/include/ert/job_queue/queue_driver.h
@@ -47,23 +47,24 @@ extern "C" {
 #define MAX_RUNNING          "MAX_RUNNING"
 
   typedef enum {
-    JOB_QUEUE_NOT_ACTIVE = 1, /* This value is used in external query routines - for jobs which are (currently) not active. */
-    //JOB_QUEUE_LOADING            =     2 ,   /* This value is used by external routines. Not used in the libjob_queue implementation. */
-    JOB_QUEUE_WAITING = 4, /* A node which is waiting in the internal queue. */
-    JOB_QUEUE_SUBMITTED = 8, /* Internal status: It has has been submitted - the next status update will (should) place it as pending or running. */
-    JOB_QUEUE_PENDING = 16, /* A node which is pending - a status returned by the external system. I.e LSF */
-    JOB_QUEUE_RUNNING = 32, /* The job is running */
-    JOB_QUEUE_DONE = 64, /* The job is done - but we have not yet checked if the target file is produced */
-    JOB_QUEUE_EXIT = 128, /* The job has exited - check attempts to determine if we retry or go to complete_fail   */
-    //JOB_QUEUE_RUN_OK             =   256 ,   /* The job has completed - and all checks performed by the queue layer indicate success. */
-    //JOB_QUEUE_RUN_FAIL           =   512 ,   /* The job has completed - but the queue system has detected that it has failed.         */
-    //JOB_QUEUE_ALL_OK             =  1024 ,   /* The job has loaded OK - observe that it is the calling scope which will set the status to this. */
-    //JOB_QUEUE_ALL_FAIL           =  2048 ,   /* The job has failed completely - the calling scope must set this status. */
-    JOB_QUEUE_USER_KILLED = 4096, /* The job has been killed by the user - can restart. */
-    JOB_QUEUE_USER_EXIT = 8192, /* The whole job_queue has been exited by the user - the job can NOT be restarted. */
-    JOB_QUEUE_SUCCESS = 16384,
+    JOB_QUEUE_NOT_ACTIVE  =     1, /* This value is used in external query routines - for jobs which are (currently) not active. */
+    //JOB_QUEUE_LOADING   =     2, /* This value is used by external routines. Not used in the libjob_queue implementation. */
+    JOB_QUEUE_WAITING     =     4, /* A node which is waiting in the internal queue. */
+    JOB_QUEUE_SUBMITTED   =     8, /* Internal status: It has has been submitted - the next status update will (should) place it as pending or running. */
+    JOB_QUEUE_PENDING     =    16, /* A node which is pending - a status returned by the external system. I.e LSF */
+    JOB_QUEUE_RUNNING     =    32, /* The job is running */
+    JOB_QUEUE_DONE        =    64, /* The job is done - but we have not yet checked if the target file is produced */
+    JOB_QUEUE_EXIT        =   128, /* The job has exited - check attempts to determine if we retry or go to complete_fail   */
+    //JOB_QUEUE_RUN_OK    =   256, /* The job has completed - and all checks performed by the queue layer indicate success. */
+    //JOB_QUEUE_RUN_FAIL  =   512, /* The job has completed - but the queue system has detected that it has failed.         */
+    //JOB_QUEUE_ALL_OK    =  1024, /* The job has loaded OK - observe that it is the calling scope which will set the status to this. */
+    //JOB_QUEUE_ALL_FAIL  =  2048, /* The job has failed completely - the calling scope must set this status. */
+    JOB_QUEUE_USER_KILLED =  4096, /* The job has been killed by the user - can restart. */
+    JOB_QUEUE_USER_EXIT   =  8192, /* The whole job_queue has been exited by the user - the job can NOT be restarted. */
+    JOB_QUEUE_SUCCESS     = 16384,
     JOB_QUEUE_RUNNING_CALLBACK = 32768,
-    JOB_QUEUE_FAILED = 65536
+    JOB_QUEUE_FAILED      = 65536,
+    JOB_QUEUE_CONFIRMED_RUNNING = 32 + (1<<17), /* LSF workaround:  A running_file file has been written to disk to confirm job is (has been) alive. */
   } job_status_type;
 
 #define JOB_QUEUE_MAX_STATE 12

--- a/devel/libjob_queue/include/ert/job_queue/queue_driver.h
+++ b/devel/libjob_queue/include/ert/job_queue/queue_driver.h
@@ -63,8 +63,7 @@ extern "C" {
     JOB_QUEUE_USER_EXIT   =  8192, /* The whole job_queue has been exited by the user - the job can NOT be restarted. */
     JOB_QUEUE_SUCCESS     = 16384,
     JOB_QUEUE_RUNNING_CALLBACK = 32768,
-    JOB_QUEUE_FAILED      = 65536,
-    JOB_QUEUE_CONFIRMED_RUNNING = 32 + (1<<17), /* LSF workaround:  A running_file file has been written to disk to confirm job is (has been) alive. */
+    JOB_QUEUE_FAILED      = 65536
   } job_status_type;
 
 #define JOB_QUEUE_MAX_STATE 12

--- a/devel/libjob_queue/src/job_queue.c
+++ b/devel/libjob_queue/src/job_queue.c
@@ -505,7 +505,14 @@ job_status_type job_queue_iget_job_status( job_queue_type * queue , int job_inde
 }
 
 
-
+void job_queue_iset_max_confirm_wait_time(job_queue_type * queue, int job_index, time_t time) {
+  job_list_get_rdlock( queue->job_list );
+   {
+     job_queue_node_type * node = job_list_iget_job( queue->job_list , job_index );
+     job_queue_node_set_max_confirmation_wait_time( node, time );
+   }
+   job_list_unlock( queue->job_list );
+}
 
 
 
@@ -1121,6 +1128,7 @@ int job_queue_add_job(job_queue_type * queue ,
                                                        argv ,
                                                        num_cpu ,
                                                        queue->ok_file ,
+                                                       queue->status_file ,
                                                        queue->exit_file,
                                                        done_callback ,
                                                        retry_callback ,
@@ -1310,14 +1318,3 @@ int job_queue_get_max_running( const job_queue_type * queue ) {
 void job_queue_set_max_running( job_queue_type * queue , int max_running ) {
   job_queue_set_max_running_option(queue->driver, max_running);
 }
-
-/*
-  The return value is the new value for max_running.
-*/
-/// TODO Delete this function? (note: 1, not used. 2, spelled runnning)
-int job_queue_inc_max_runnning( job_queue_type * queue, int delta ) {
-  job_queue_set_max_running( queue , job_queue_get_max_running( queue ) + delta );
-  return job_queue_get_max_running( queue );
-}
-
-

--- a/devel/libjob_queue/src/job_queue.c
+++ b/devel/libjob_queue/src/job_queue.c
@@ -215,6 +215,7 @@ struct job_queue_struct {
   job_queue_status_type    * status;
   char                     * exit_file;                         /* The queue will look for the occurence of this file to detect a failure. */
   char                     * ok_file;                           /* The queue will look for this file to verify that the job was OK - can be NULL - in which case it is ignored. */
+  char                     * running_file;                      /* The queue will look for this file to verify that the job is running or has run.  If not, ok_file is ignored. */
   queue_driver_type        * driver;                            /* A pointer to a driver instance (LSF|LOCAL|RSH) which actually 'does it'. */
 
   bool                       open;                              /* True if the queue has been reset and is ready for use, false if the queue has been used and not reset */
@@ -693,7 +694,6 @@ static void * job_queue_run_DONE_callback( void * arg ) {
   return NULL;
 }
 
-
 static void job_queue_handle_DONE( job_queue_type * queue , job_queue_node_type * node) {
   job_queue_change_node_status(queue , node , JOB_QUEUE_RUNNING_CALLBACK );
   {
@@ -1156,6 +1156,7 @@ UTIL_SAFE_CAST_FUNCTION( job_queue , JOB_QUEUE_TYPE_ID)
 
 job_queue_type * job_queue_alloc(int  max_submit               ,
                                  const char * ok_file ,
+                                 const char * running_file ,
                                  const char * exit_file ) {
 
 
@@ -1170,6 +1171,7 @@ job_queue_type * job_queue_alloc(int  max_submit               ,
   queue->driver           = NULL;
   queue->ok_file          = util_alloc_string_copy( ok_file );
   queue->exit_file        = util_alloc_string_copy( exit_file );
+  queue->running_file     = util_alloc_string_copy( running_file );
   queue->open             = true;
   queue->user_exit        = false;
   queue->pause_on         = false;

--- a/devel/libjob_queue/src/job_queue.c
+++ b/devel/libjob_queue/src/job_queue.c
@@ -215,7 +215,7 @@ struct job_queue_struct {
   job_queue_status_type    * status;
   char                     * exit_file;                         /* The queue will look for the occurence of this file to detect a failure. */
   char                     * ok_file;                           /* The queue will look for this file to verify that the job was OK - can be NULL - in which case it is ignored. */
-  char                     * running_file;                      /* The queue will look for this file to verify that the job is running or has run.  If not, ok_file is ignored. */
+  char                     * status_file;                       /* The queue will look for this file to verify that the job is running or has run.  If not, ok_file is ignored. */
   queue_driver_type        * driver;                            /* A pointer to a driver instance (LSF|LOCAL|RSH) which actually 'does it'. */
 
   bool                       open;                              /* True if the queue has been reset and is ready for use, false if the queue has been used and not reset */
@@ -1156,7 +1156,7 @@ UTIL_SAFE_CAST_FUNCTION( job_queue , JOB_QUEUE_TYPE_ID)
 
 job_queue_type * job_queue_alloc(int  max_submit               ,
                                  const char * ok_file ,
-                                 const char * running_file ,
+                                 const char * status_file ,
                                  const char * exit_file ) {
 
 
@@ -1171,7 +1171,7 @@ job_queue_type * job_queue_alloc(int  max_submit               ,
   queue->driver           = NULL;
   queue->ok_file          = util_alloc_string_copy( ok_file );
   queue->exit_file        = util_alloc_string_copy( exit_file );
-  queue->running_file     = util_alloc_string_copy( running_file );
+  queue->status_file      = util_alloc_string_copy( status_file );
   queue->open             = true;
   queue->user_exit        = false;
   queue->pause_on         = false;
@@ -1314,6 +1314,7 @@ void job_queue_set_max_running( job_queue_type * queue , int max_running ) {
 /*
   The return value is the new value for max_running.
 */
+/// TODO Delete this function? (note: 1, not used. 2, spelled runnning)
 int job_queue_inc_max_runnning( job_queue_type * queue, int delta ) {
   job_queue_set_max_running( queue , job_queue_get_max_running( queue ) + delta );
   return job_queue_get_max_running( queue );

--- a/devel/libjob_queue/src/job_queue_status.c
+++ b/devel/libjob_queue/src/job_queue_status.c
@@ -132,18 +132,16 @@ static void job_queue_status_dec( job_queue_status_type * status_count , job_sta
 
 /*
   The important point is that each individual ++ and -- operation is
-  atomic, if the different status counts do not add upp perfectly at
+  atomic, if the different status counts do not add up perfectly at
   all times that is ok.
 */
-
-
-bool job_queue_status_transition( job_queue_status_type * status_count , job_status_type src_status , job_status_type target_status) {
-  if (src_status != target_status) {
-    job_queue_status_dec( status_count , src_status );
-    job_queue_status_inc( status_count , target_status );
-    return true;
-  } else
+bool job_queue_status_transition(job_queue_status_type * status_count, job_status_type src_status,
+        job_status_type target_status) {
+  if (src_status == target_status)
     return false;
+  job_queue_status_dec( status_count, src_status );
+  job_queue_status_inc( status_count, target_status );
+  return true;
 }
 
 

--- a/devel/libjob_queue/tests/CMakeLists.txt
+++ b/devel/libjob_queue/tests/CMakeLists.txt
@@ -51,7 +51,9 @@ target_link_libraries( job_queue_stress_test job_queue test_util )
 add_test( job_queue_stress_test ${EXECUTABLE_OUTPUT_PATH}/job_queue_stress_test ${EXECUTABLE_OUTPUT_PATH}/job_queue_stress_task False)
 add_test( job_queue_user_exit ${EXECUTABLE_OUTPUT_PATH}/job_queue_stress_test ${EXECUTABLE_OUTPUT_PATH}/job_queue_stress_task True)
 
-
+add_executable( job_queue_timeout_test job_queue_timeout_test.c )
+target_link_libraries( job_queue_timeout_test job_queue test_util )
+add_test( job_queue_timeout_test ${EXECUTABLE_OUTPUT_PATH}/job_queue_timeout_test ${EXECUTABLE_OUTPUT_PATH}/job_queue_stress_task)
 
 add_executable( job_queue_driver_test job_queue_driver_test.c )
 target_link_libraries( job_queue_driver_test job_queue test_util )

--- a/devel/libjob_queue/tests/job_job_queue_test.c
+++ b/devel/libjob_queue/tests/job_job_queue_test.c
@@ -66,7 +66,7 @@ void monitor_job_queue(job_queue_type * queue, int max_job_duration, time_t stop
 
 void run_jobs_with_time_limit_test(char * executable_to_run, int number_of_jobs, int number_of_slowjobs, char * sleep_short, char * sleep_long, int max_sleep) {
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
 
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_set_driver(queue, driver);
@@ -101,7 +101,7 @@ void run_and_monitor_jobs(char * executable_to_run,
                           int interval_between_jobs) {
 
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
   job_queue_manager_type * queue_manager = job_queue_manager_alloc( queue );
   queue_driver_type * driver = queue_driver_alloc_local();
 
@@ -146,7 +146,7 @@ void run_jobs_time_limit_multithreaded(char * executable_to_run, int number_of_j
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
 
 
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_set_driver(queue, driver);
   job_queue_set_max_job_duration(queue, max_sleep);
@@ -185,7 +185,7 @@ void test1(char ** argv) {
 
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
 
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_set_driver(queue, driver);
 
@@ -215,7 +215,7 @@ void test2(char ** argv) {
 
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
 
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_set_driver(queue, driver);
 
@@ -371,7 +371,7 @@ void test14(char ** argv) {
   int number_of_jobs = 10;
 
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_manager_type * queue_manager = job_queue_manager_alloc( queue );
   job_queue_set_driver(queue, driver);
@@ -424,7 +424,7 @@ void test15(char ** argv) {
   int number_of_jobs = 10;
 
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_set_driver(queue, driver);
 
@@ -447,7 +447,7 @@ void test16(char ** argv) {
 
   int number_of_jobs = 10;
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK.status", "STATUS", "ERROR");
 
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_set_driver(queue, driver);

--- a/devel/libjob_queue/tests/job_queue_driver_test.c
+++ b/devel/libjob_queue/tests/job_queue_driver_test.c
@@ -29,7 +29,7 @@
 #include <ert/job_queue/rsh_driver.h>
 
 void job_queue_set_driver_(job_driver_type driver_type) {
-  job_queue_type * queue = job_queue_alloc(10, "OK", "ERROR");
+  job_queue_type * queue = job_queue_alloc(10, "OK", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc(driver_type);
   test_assert_false(job_queue_has_driver(queue));
 

--- a/devel/libjob_queue/tests/job_queue_manager.c
+++ b/devel/libjob_queue/tests/job_queue_manager.c
@@ -27,7 +27,7 @@
 
 
 void test_create() {
-  job_queue_type * job_queue = job_queue_alloc( 100 , "OK" , "ERROR");
+  job_queue_type * job_queue = job_queue_alloc( 100 , "OK" , "STATUS", "ERROR");
   job_queue_manager_type * manager = job_queue_manager_alloc( job_queue );
   
   test_assert_true( job_queue_manager_is_instance( manager ));

--- a/devel/libjob_queue/tests/job_queue_stress_test.c
+++ b/devel/libjob_queue/tests/job_queue_stress_test.c
@@ -274,7 +274,7 @@ int main(int argc , char ** argv) {
   test_work_area_type * work_area = test_work_area_alloc("job_queue");
   job_type **jobs = alloc_jobs( rng , number_of_jobs , job);
 
-  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK", "ERROR");
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK", "STATUS", "ERROR");
   queue_driver_type * driver = queue_driver_alloc_local();
   job_queue_manager_type * queue_manager = job_queue_manager_alloc( queue );
 

--- a/devel/libjob_queue/tests/job_queue_timeout_test.c
+++ b/devel/libjob_queue/tests/job_queue_timeout_test.c
@@ -122,22 +122,12 @@ int main(int argc, char ** argv) {
 
   util_install_signals();
   job_queue_set_driver(queue, driver);
-  job_queue_manager_start_queue(queue_manager, 0, false, true);
+  job_queue_manager_start_queue(queue_manager, number_of_jobs, false, true);
 
   {
     submit_jobs(queue, number_of_jobs, jobs);
 
-    job_queue_submit_complete(queue);
-
-    int x = job_queue_get_num_running( queue)+
-            job_queue_get_num_pending( queue) +
-            job_queue_get_num_waiting( queue) +
-            job_queue_get_num_complete(queue) +
-            job_queue_get_num_failed(  queue) +
-            job_queue_get_num_killed(  queue) +
-            job_queue_get_num_callback(queue);
-
-    if (x > 0) {
+    if (job_queue_get_active_size(queue) > 0) {
       job_queue_iset_max_confirm_wait_time(queue, 0, running_timeout); // job 0
     } else {
       util_exit("Job failed to be queued!\n");

--- a/devel/libjob_queue/tests/job_queue_timeout_test.c
+++ b/devel/libjob_queue/tests/job_queue_timeout_test.c
@@ -1,0 +1,159 @@
+/*
+ Copyright (C) 2016  Statoil ASA, Norway.
+
+ This file  is part of ERT - Ensemble based Reservoir Tool.
+
+ ERT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.
+
+ See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+ for more details.
+ */
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <ert/util/arg_pack.h>
+#include <ert/util/rng.h>
+#include <ert/util/test_util.h>
+#include <ert/util/test_work_area.h>
+#include <ert/util/thread_pool.h>
+#include <ert/util/type_macros.h>
+#include <ert/util/util.h>
+
+#include <ert/job_queue/job_queue.h>
+#include <ert/job_queue/job_queue_manager.h>
+#include <ert/job_queue/queue_driver.h>
+
+
+#define JOB_TYPE_ID 77539
+typedef struct
+{
+  UTIL_TYPE_ID_DECLARATION;
+  char * run_path;
+  bool callback_run;
+  int queue_index;
+  int submit_usleep;
+  int callback_usleep;
+  int run_usleep;
+  int argc;
+  char ** argv;
+  const char * cmd;
+} job_type;
+
+UTIL_SAFE_CAST_FUNCTION(job, JOB_TYPE_ID)
+
+job_type * alloc_job(int ind, const char * cmd) {
+  job_type * job = util_malloc(sizeof *job);
+  UTIL_TYPE_ID_INIT(job, JOB_TYPE_ID)
+  job->callback_run    = false;
+  job->queue_index     = -1;
+  job->submit_usleep   = 0;
+  job->callback_usleep = 0;
+  job->run_usleep      = 2 * 1000*1000; // 4 sec
+  job->run_path        = util_alloc_sprintf("timeout_test_%d", ind);
+  job->cmd             = cmd;
+  job->argc            = 4;
+
+  job->argv    = util_malloc(4 * sizeof *job->argv);
+  job->argv[0] = job->run_path;
+  job->argv[1] = "RUNNING";
+  job->argv[2] = "OK";
+  job->argv[3] = util_alloc_sprintf("%d", job->run_usleep);
+
+  util_make_path(job->run_path);
+  return job;
+}
+
+job_type ** alloc_jobs(int num_jobs, const char * cmd) {
+  job_type ** jobs = util_malloc(num_jobs * sizeof *jobs);
+  for (int i = 0; i < num_jobs; i++) {
+    job_type * job = alloc_job(i, cmd);
+    job_safe_cast(job);
+    jobs[i] = job;
+  }
+  return jobs;
+}
+
+
+void submit_jobs(job_queue_type * queue, int num_jobs, job_type ** jobs) {
+  for (int i = 0; i < num_jobs; i++) {
+    job_type * job = jobs[i];
+
+    job->queue_index = job_queue_add_job(queue, job->cmd, NULL, NULL, NULL, job, 1, job->run_path, job->run_path,
+            job->argc, (const char **) job->argv);
+  }
+}
+
+void check_jobs(int num_jobs, job_type ** jobs) {
+  for (int i = 0; i < num_jobs; i++) {
+    job_type * job = jobs[i];
+    if (!job->callback_run)
+      fprintf(stderr, "The callback has not been registered on job:%d/%d \n", i, job->queue_index);
+    test_assert_true(job->callback_run);
+  }
+}
+
+int main(int argc, char ** argv) {
+  setbuf(stdout, NULL);
+
+  const int number_of_jobs = 1;
+  util_alloc_abs_path(argv[1]);
+
+  const int running_timeout = 0;
+  const int sec = 1000*1000;
+
+  test_work_area_type * work_area = test_work_area_alloc("job_timeout");
+  test_work_area_set_store(work_area, true);
+
+  job_type **jobs = alloc_jobs(number_of_jobs, argv[1]);
+
+  job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK", "DOES_NOT_EXIST", "ERROR");
+  queue_driver_type * driver = queue_driver_alloc_local();
+  job_queue_manager_type * queue_manager = job_queue_manager_alloc(queue);
+
+  util_install_signals();
+  job_queue_set_driver(queue, driver);
+  job_queue_manager_start_queue(queue_manager, 0, false, true);
+
+  {
+    submit_jobs(queue, number_of_jobs, jobs);
+
+    job_queue_submit_complete(queue);
+
+    int x = job_queue_get_num_running( queue)+
+            job_queue_get_num_pending( queue) +
+            job_queue_get_num_waiting( queue) +
+            job_queue_get_num_complete(queue) +
+            job_queue_get_num_failed(  queue) +
+            job_queue_get_num_killed(  queue) +
+            job_queue_get_num_callback(queue);
+
+    if (x > 0) {
+      job_queue_iset_max_confirm_wait_time(queue, 0, running_timeout); // job 0
+    } else {
+      util_exit("Job failed to be queued!\n");
+    }
+
+    usleep(1 * sec); // 1.0 sec
+    int job_status = job_queue_iget_job_status(queue, 0);
+
+    if (job_status != JOB_QUEUE_FAILED) {
+      util_exit("Job should have failed, had status %d != %d\n", job_status, JOB_QUEUE_FAILED);
+    }
+  }
+  if (!job_queue_manager_try_wait(queue_manager, 5 * sec))
+    util_exit("job_queue never completed \n");
+  job_queue_manager_free(queue_manager);
+  job_queue_free(queue);
+  queue_driver_free(driver);
+  test_work_area_free(work_area);
+}


### PR DESCRIPTION
Added feature for confirming a job is running

* `job_node` has member `status_file` (file name)
* `job_queue_node_status_confirmed_running` tests whether STATUS file exists
* `job_node.c::job_queue_node_update_status`, test whether STATUS file has been written two minutes after simulation started
