### PR TITLE
Added (MDA ES) in dropdown choice for Multiple Data Assimilation

### DIFF
--- a/devel/python/python/ert_gui/models/connectors/run/multiple_data_assimilation.py
+++ b/devel/python/python/ert_gui/models/connectors/run/multiple_data_assimilation.py
@@ -29,7 +29,7 @@ class MultipleDataAssimilation(BaseRunModel):
     """
 
     def __init__(self):
-        super(MultipleDataAssimilation, self).__init__(name="Multiple Data Assimilation", phase_count=2)
+        super(MultipleDataAssimilation, self).__init__(name="Multiple Data Assimilation (ES MDA)", phase_count=2)
         self.weights = "1" # default value
 
     def getWeights(self):


### PR DESCRIPTION
As per request
> In the name for the MDA as a first class citizen, can you write “Multiple Data Assimilation (ES MDA)” instead?

have renamed dropdown menu label to "Multiple Data Assimilation (ES MDA)"