### PR TITLE
Analysis module logging

### DIFF
--- a/devel/libanalysis/include/ert/analysis/analysis_module.h
+++ b/devel/libanalysis/include/ert/analysis/analysis_module.h
@@ -96,7 +96,7 @@ typedef enum {
                                matrix_type * dObs ,
                                matrix_type * E ,
                                matrix_type * D ,
-                               module_info_type* module_info);
+                               const module_info_type* module_info);
 
 
   void                   analysis_module_init_update( analysis_module_type * module ,

--- a/devel/libanalysis/include/ert/analysis/analysis_module.h
+++ b/devel/libanalysis/include/ert/analysis/analysis_module.h
@@ -26,6 +26,7 @@ extern "C" {
 #include <ert/util/matrix.h>
 #include <ert/util/bool_vector.h>
 
+#include <ert/analysis/module_info.h>
 
 /*
    These are option flag values which are used by the core ert code to
@@ -94,7 +95,8 @@ typedef enum {
                                matrix_type * R ,
                                matrix_type * dObs ,
                                matrix_type * E ,
-                               matrix_type * D );
+                               matrix_type * D ,
+                               module_info_type* module_info);
 
 
   void                   analysis_module_init_update( analysis_module_type * module ,

--- a/devel/libanalysis/include/ert/analysis/analysis_table.h
+++ b/devel/libanalysis/include/ert/analysis/analysis_table.h
@@ -20,7 +20,7 @@ extern "C" {
                                          matrix_type * dObs ,
                                          matrix_type * E ,
                                          matrix_type * D ,
-                                         module_info_type* module_info);
+                                         const module_info_type* module_info);
 
 
   typedef void (analysis_initX_ftype)       (void * module_data ,

--- a/devel/libanalysis/include/ert/analysis/analysis_table.h
+++ b/devel/libanalysis/include/ert/analysis/analysis_table.h
@@ -10,25 +10,29 @@ extern "C" {
 #include <ert/util/rng.h>
 #include <ert/util/bool_vector.h>
 
-  typedef void (analysis_updateA_ftype) (void * module_data , 
-                                         matrix_type * A , 
-                                         matrix_type * S , 
-                                         matrix_type * R , 
-                                         matrix_type * dObs , 
+#include <ert/analysis/module_info.h>
+
+
+  typedef void (analysis_updateA_ftype) (void * module_data ,
+                                         matrix_type * A ,
+                                         matrix_type * S ,
+                                         matrix_type * R ,
+                                         matrix_type * dObs ,
                                          matrix_type * E ,
-                                         matrix_type * D );
-  
-  
-  typedef void (analysis_initX_ftype)       (void * module_data , 
-                                             matrix_type * X , 
-                                             matrix_type * A , 
-                                             matrix_type * S , 
-                                             matrix_type * R , 
-                                             matrix_type * dObs , 
-                                             matrix_type * E , 
+                                         matrix_type * D ,
+                                         module_info_type* module_info);
+
+
+  typedef void (analysis_initX_ftype)       (void * module_data ,
+                                             matrix_type * X ,
+                                             matrix_type * A ,
+                                             matrix_type * S ,
+                                             matrix_type * R ,
+                                             matrix_type * dObs ,
+                                             matrix_type * E ,
                                              matrix_type * D );
-  
-  
+
+
   typedef bool (analysis_set_int_ftype)       (void * module_data , const char * flag , int value);
   typedef bool (analysis_set_bool_ftype)      (void * module_data , const char * flag , bool value);
   typedef bool (analysis_set_double_ftype)    (void * module_data , const char * var , double value);
@@ -37,16 +41,16 @@ extern "C" {
   typedef void * (analysis_alloc_ftype) ( rng_type * rng );
 
 
-  typedef void (analysis_init_update_ftype) (void * module_data, 
-                                             const bool_vector_type * ens_mask , 
-                                             const matrix_type * S , 
-                                             const matrix_type * R , 
-                                             const matrix_type * dObs , 
-                                             const matrix_type * E , 
+  typedef void (analysis_init_update_ftype) (void * module_data,
+                                             const bool_vector_type * ens_mask ,
+                                             const matrix_type * S ,
+                                             const matrix_type * R ,
+                                             const matrix_type * dObs ,
+                                             const matrix_type * E ,
                                              const matrix_type * D);
-  
+
   typedef void (analysis_complete_update_ftype) (void * module_data );
-  
+
   typedef long (analysis_get_options_ftype) (void * module_data , long option);
 
   typedef bool   (analysis_has_var_ftype)    (const void * module_data , const char * var_name);
@@ -70,7 +74,7 @@ typedef struct {
 
   analysis_set_int_ftype         * set_int;
   analysis_set_double_ftype      * set_double;
-  analysis_set_bool_ftype        * set_bool; 
+  analysis_set_bool_ftype        * set_bool;
   analysis_set_string_ftype      * set_string;
   analysis_get_options_ftype     * get_options;
 

--- a/devel/libanalysis/include/ert/analysis/fwd_step_enkf.h
+++ b/devel/libanalysis/include/ert/analysis/fwd_step_enkf.h
@@ -34,7 +34,7 @@ void fwd_step_enkf_updateA(void * module_data ,
                             matrix_type * dObs ,
                             matrix_type * E ,
                             matrix_type * D ,
-                            module_info_type* module_info);
+                            const module_info_type* module_info);
 
 
 void        fwd_step_enkf_set_truncation( fwd_step_enkf_data_type * data , double truncation );

--- a/devel/libanalysis/include/ert/analysis/fwd_step_enkf.h
+++ b/devel/libanalysis/include/ert/analysis/fwd_step_enkf.h
@@ -1,36 +1,40 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'fwd_step_enkf.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'fwd_step_enkf.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <ert/util/rng.h>
 #include <ert/util/matrix.h>
+
+#include <ert/analysis/module_data_block_vector.h>
+#include <ert/analysis/module_info.h>
 
 typedef struct fwd_step_enkf_data_struct fwd_step_enkf_data_type;
 
 void * fwd_step_enkf_data_alloc( rng_type * rng );
 void   fwd_step_enkf_data_free( void * arg );
 
-void fwd_step_enkf_updateA(void * module_data , 
-                            matrix_type * A , 
-                            matrix_type * S , 
-                            matrix_type * R , 
-                            matrix_type * dObs , 
+void fwd_step_enkf_updateA(void * module_data ,
+                            matrix_type * A ,
+                            matrix_type * S ,
+                            matrix_type * R ,
+                            matrix_type * dObs ,
                             matrix_type * E ,
-                            matrix_type * D );
+                            matrix_type * D ,
+                            module_info_type* module_info);
 
 
 void        fwd_step_enkf_set_truncation( fwd_step_enkf_data_type * data , double truncation );

--- a/devel/libanalysis/include/ert/analysis/fwd_step_log.h
+++ b/devel/libanalysis/include/ert/analysis/fwd_step_log.h
@@ -1,0 +1,45 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'fwd_step_log.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef FWD_STEP_LOG_H
+#define FWD_STEP_LOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+  typedef struct fwd_step_log_struct fwd_step_log_type;
+
+  fwd_step_log_type * fwd_step_log_alloc();
+  void fwd_step_log_free(fwd_step_log_type * fwd_step_log);
+  bool fwd_step_log_get_clear_log( const fwd_step_log_type * data );
+  void fwd_step_log_set_clear_log( fwd_step_log_type * data , bool clear_log);
+  void fwd_step_log_set_log_file( fwd_step_log_type * data , const char * log_file );
+  const char * fwd_step_log_get_log_file( const fwd_step_log_type * data);
+  void fwd_step_log_open( fwd_step_log_type * fwd_step_log );
+  void fwd_step_log_close( fwd_step_log_type * fwd_step_log );
+  void fwd_step_log_line( fwd_step_log_type * fwd_step_log , const char * fmt , ...);
+  bool fwd_step_log_is_open( const fwd_step_log_type * fwd_step_log );
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/devel/libanalysis/include/ert/analysis/module_data_block.h
+++ b/devel/libanalysis/include/ert/analysis/module_data_block.h
@@ -1,0 +1,50 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'module_data_blocks.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef MODULE_DATA_BLOCKS_H
+#define MODULE_DATA_BLOCKS_H
+
+#include <ert/util/vector.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  struct module_data_block_struct {
+   UTIL_TYPE_ID_DECLARATION;
+   char                    * key;
+   const int               * index_list;
+   int                       A_row_start;
+   int                       n_active;
+  };
+
+  typedef struct module_data_block_struct module_data_block_type;
+
+  module_data_block_type * module_data_block_alloc( const char * key,  const int * index_list , const int row_start, const int n_active);
+  const char *             module_data_block_get_key(module_data_block_type * module_data_block);
+  const int                module_data_block_get_row_start(module_data_block_type * module_data_block);
+  const int                module_data_block_get_row_end(module_data_block_type * module_data_block);
+  const int  *             module_data_block_get_active_indices(module_data_block_type * module_data_block );
+  void                     module_data_block_free(module_data_block_type * module_data_block);
+  void                     module_data_block_free__( void * arg );
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/devel/libanalysis/include/ert/analysis/module_data_block_vector.h
+++ b/devel/libanalysis/include/ert/analysis/module_data_block_vector.h
@@ -1,0 +1,41 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'module_data_block_vector.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#ifndef ERT_MODULE_DATA_BLOCK_VECTOR_H
+#define ERT_MODULE_DATA_BLOCK_VECTOR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+#include <ert/analysis/module_data_block.h>
+
+  typedef struct module_data_block_vector_struct module_data_block_vector_type;
+
+  module_data_block_vector_type   * module_data_block_vector_alloc(const char* ministep_name);
+  void                              module_data_block_vector_free();
+  void                              module_data_block_vector_add_data_block( module_data_block_vector_type * module_data_block_vector , const module_data_block_type * data_block);
+  module_data_block_type          * module_data_block_vector_iget_module_data_block(const module_data_block_vector_type * module_data_block_vector, int index);
+  int                               module_data_block_vector_get_size(const module_data_block_vector_type * module_data_block_vector);
+  char *                            module_data_block_vector_get_ministep_name(const module_data_block_vector_type * module_data_block_vector);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/devel/libanalysis/include/ert/analysis/module_info.h
+++ b/devel/libanalysis/include/ert/analysis/module_info.h
@@ -1,0 +1,38 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'module_info.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#ifndef ERT_MODULE_INFO_H
+#define ERT_MODULE_INFO_H
+
+#include <ert/analysis/module_data_block_vector.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+  typedef struct module_info_struct module_info_type;
+
+  module_info_type                * module_info_alloc(const char* ministep_name);
+  void                              module_info_free();
+  module_data_block_vector_type *   module_info_get_data_block_vector(const module_info_type * module_info);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/devel/libanalysis/modules/rml_enkf.c
+++ b/devel/libanalysis/modules/rml_enkf.c
@@ -497,7 +497,7 @@ static void rml_enkf_updateA_iter0(rml_enkf_data_type * data, matrix_type * A, m
 }
 
 
-void rml_enkf_updateA(void * module_data, matrix_type * A, matrix_type * S, matrix_type * R, matrix_type * dObs, matrix_type * E, matrix_type * D, module_info_type* module_info) {
+void rml_enkf_updateA(void * module_data, matrix_type * A, matrix_type * S, matrix_type * R, matrix_type * dObs, matrix_type * E, matrix_type * D, const module_info_type* module_info) {
 // A : ensemble matrix
 // R : (Inv?) Obs error cov.
 // S : measured ensemble

--- a/devel/libanalysis/modules/rml_enkf.c
+++ b/devel/libanalysis/modules/rml_enkf.c
@@ -497,13 +497,14 @@ static void rml_enkf_updateA_iter0(rml_enkf_data_type * data, matrix_type * A, m
 }
 
 
-void rml_enkf_updateA(void * module_data, matrix_type * A, matrix_type * S, matrix_type * R, matrix_type * dObs, matrix_type * E, matrix_type * D) {
+void rml_enkf_updateA(void * module_data, matrix_type * A, matrix_type * S, matrix_type * R, matrix_type * dObs, matrix_type * E, matrix_type * D, module_info_type* module_info) {
 // A : ensemble matrix
 // R : (Inv?) Obs error cov.
 // S : measured ensemble
 // dObs: observed data
 // E : perturbations for obs
 // D = dObs + E - S : Innovations (wrt pert. obs)
+// module_info: Information on parameters/data for internal logging
 
 
 

--- a/devel/libanalysis/src/CMakeLists.txt
+++ b/devel/libanalysis/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Common libanalysis library
-set( source_files analysis_module.c enkf_linalg.c std_enkf.c sqrt_enkf.c cv_enkf.c bootstrap_enkf.c null_enkf.c fwd_step_enkf.c )
-set( header_files analysis_module.h enkf_linalg.h analysis_table.h std_enkf.h fwd_step_enkf.h)
+set( source_files analysis_module.c enkf_linalg.c std_enkf.c sqrt_enkf.c cv_enkf.c bootstrap_enkf.c null_enkf.c fwd_step_enkf.c fwd_step_log.c module_data_block.c module_data_block_vector.c module_info.c)
+set( header_files analysis_module.h enkf_linalg.h analysis_table.h std_enkf.h fwd_step_enkf.h fwd_step_log.h module_data_block.h module_data_block_vector.h module_info.h)
 add_library( analysis  SHARED ${source_files} )
 set_target_properties( analysis PROPERTIES COMPILE_DEFINITIONS INTERNAL_LINK)
 set_target_properties( analysis PROPERTIES VERSION ${ERT_VERSION_MAJOR}.${ERT_VERSION_MINOR} SOVERSION ${ERT_VERSION_MAJOR} )

--- a/devel/libanalysis/src/analysis_module.c
+++ b/devel/libanalysis/src/analysis_module.c
@@ -271,9 +271,10 @@ void analysis_module_updateA(analysis_module_type * module ,
                              matrix_type * R ,
                              matrix_type * dObs ,
                              matrix_type * E ,
-                             matrix_type * D ) {
+                             matrix_type * D ,
+                             module_info_type* module_info) {
 
-  module->updateA(module->module_data , A , S , R , dObs , E , D );
+  module->updateA(module->module_data , A , S , R , dObs , E , D, module_info);
 }
 
 
@@ -295,9 +296,6 @@ void analysis_module_complete_update( analysis_module_type * module ) {
   if (module->complete_update != NULL)
     module->complete_update( module->module_data );
 }
-
-
-
 
 /*****************************************************************/
 

--- a/devel/libanalysis/src/analysis_module.c
+++ b/devel/libanalysis/src/analysis_module.c
@@ -272,7 +272,7 @@ void analysis_module_updateA(analysis_module_type * module ,
                              matrix_type * dObs ,
                              matrix_type * E ,
                              matrix_type * D ,
-                             module_info_type* module_info) {
+                             const module_info_type* module_info) {
 
   module->updateA(module->module_data , A , S , R , dObs , E , D, module_info);
 }

--- a/devel/libanalysis/src/bootstrap_enkf.c
+++ b/devel/libanalysis/src/bootstrap_enkf.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'bootstrap_enkf.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'bootstrap_enkf.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
@@ -41,7 +41,7 @@
 #define DEFAULT_TRUNCATION          0.95
 #define DEFAULT_NCOMP               INVALID_SUBSPACE_DIMENSION
 
-#define  DEFAULT_DO_CV               false 
+#define  DEFAULT_DO_CV               false
 #define  DEFAULT_NFOLDS              10
 #define  NFOLDS_KEY                  "BOOTSTRAP_NFOLDS"
 
@@ -50,9 +50,9 @@ typedef struct {
   UTIL_TYPE_ID_DECLARATION;
   std_enkf_data_type   * std_enkf_data;
   cv_enkf_data_type    * cv_enkf_data;
-  rng_type             * rng; 
+  rng_type             * rng;
   long                   option_flags;
-  bool                   doCV;  
+  bool                   doCV;
 } bootstrap_enkf_data_type;
 
 
@@ -84,7 +84,7 @@ void * bootstrap_enkf_data_alloc( rng_type * rng ) {
 
   boot_data->std_enkf_data = std_enkf_data_alloc( NULL );
   boot_data->cv_enkf_data = cv_enkf_data_alloc( rng );
-  
+
   boot_data->rng = rng;
   bootstrap_enkf_set_truncation( boot_data , DEFAULT_TRUNCATION );
   bootstrap_enkf_set_subspace_dimension( boot_data , DEFAULT_NCOMP );
@@ -114,11 +114,11 @@ static int ** alloc_iens_resample( rng_type * rng , int ens_size ) {
   iens_resample = util_calloc( ens_size , sizeof * iens_resample );
   for (iens = 0; iens < ens_size; iens++)
     iens_resample[iens] = util_calloc( ens_size , sizeof( ** iens_resample ) );
-  
+
   {
     int i,j;
     for (i=0; i < ens_size; i++)
-      for (j=0; j < ens_size; j++) 
+      for (j=0; j < ens_size; j++)
         iens_resample[i][j] = rng_get_int( rng , ens_size );
   }
   return iens_resample;
@@ -133,14 +133,15 @@ static void free_iens_resample( int ** iens_resample, int ens_size ) {
 
 
 
-void bootstrap_enkf_updateA(void * module_data , 
-                            matrix_type * A , 
-                            matrix_type * S , 
-                            matrix_type * R , 
-                            matrix_type * dObs , 
+void bootstrap_enkf_updateA(void * module_data ,
+                            matrix_type * A ,
+                            matrix_type * S ,
+                            matrix_type * R ,
+                            matrix_type * dObs ,
                             matrix_type * E ,
-                            matrix_type * D ) {
-  
+                            matrix_type * D ,
+                            module_info_type* module_info) {
+
   bootstrap_enkf_data_type * bootstrap_data = bootstrap_enkf_data_safe_cast( module_data );
   {
     const int num_cpu_threads = 4;
@@ -152,7 +153,7 @@ void bootstrap_enkf_updateA(void * module_data ,
     int ** iens_resample      = alloc_iens_resample( bootstrap_data->rng , ens_size );
     {
       int ensemble_members_loop;
-      for ( ensemble_members_loop = 0; ensemble_members_loop < ens_size; ensemble_members_loop++) { 
+      for ( ensemble_members_loop = 0; ensemble_members_loop < ens_size; ensemble_members_loop++) {
         int unique_bootstrap_components;
         int ensemble_counter;
         /* Resample A and meas_data. Here we are careful to resample the working copy.*/
@@ -169,12 +170,12 @@ void bootstrap_enkf_updateA(void * module_data ,
             unique_bootstrap_components = int_vector_size( bootstrap_components );
             int_vector_free( bootstrap_components );
           }
-          
+
           if (bootstrap_data->doCV) {
             const bool_vector_type * ens_mask = NULL;
             cv_enkf_init_update( bootstrap_data->cv_enkf_data , ens_mask , S_resampled , R , dObs , E , D);
             cv_enkf_initX( bootstrap_data->cv_enkf_data , X , A_resampled , S_resampled , R , dObs , E , D);
-          } else 
+          } else
             std_enkf_initX(bootstrap_data->std_enkf_data , X , NULL , S_resampled,R, dObs, E,D );
 
 
@@ -185,7 +186,7 @@ void bootstrap_enkf_updateA(void * module_data ,
         }
       }
     }
-    
+
 
     free_iens_resample( iens_resample , ens_size);
     matrix_free( X );
@@ -282,18 +283,18 @@ analysis_table_type LINK_NAME = {
   .name            = "BOOTSTRAP_ENKF",
   .alloc           = bootstrap_enkf_data_alloc,
   .freef           = bootstrap_enkf_data_free,
-  .set_int         = bootstrap_enkf_set_int , 
-  .set_double      = bootstrap_enkf_set_double , 
-  .set_bool        = bootstrap_enkf_set_bool , 
-  .set_string      = NULL , 
-  .get_options     = bootstrap_enkf_get_options , 
+  .set_int         = bootstrap_enkf_set_int ,
+  .set_double      = bootstrap_enkf_set_double ,
+  .set_bool        = bootstrap_enkf_set_bool ,
+  .set_string      = NULL ,
+  .get_options     = bootstrap_enkf_get_options ,
   .initX           = NULL,
-  .updateA         = bootstrap_enkf_updateA, 
+  .updateA         = bootstrap_enkf_updateA,
   .init_update     = NULL,
-  .complete_update = NULL, 
+  .complete_update = NULL,
   .has_var         = bootstrap_enkf_has_var,
   .get_int         = bootstrap_enkf_get_int,
   .get_double      = bootstrap_enkf_get_double,
   .get_bool        = NULL,
-  .get_ptr         = NULL, 
+  .get_ptr         = NULL,
 };

--- a/devel/libanalysis/src/bootstrap_enkf.c
+++ b/devel/libanalysis/src/bootstrap_enkf.c
@@ -140,7 +140,7 @@ void bootstrap_enkf_updateA(void * module_data ,
                             matrix_type * dObs ,
                             matrix_type * E ,
                             matrix_type * D ,
-                            module_info_type* module_info) {
+                            const module_info_type* module_info) {
 
   bootstrap_enkf_data_type * bootstrap_data = bootstrap_enkf_data_safe_cast( module_data );
   {

--- a/devel/libanalysis/src/fwd_step_enkf.c
+++ b/devel/libanalysis/src/fwd_step_enkf.c
@@ -184,7 +184,7 @@ void fwd_step_enkf_updateA(void * module_data ,
                            matrix_type * dObs ,
                            matrix_type * E ,
                            matrix_type * D ,
-                           module_info_type* module_info) {
+                           const module_info_type* module_info) {
 
 
 

--- a/devel/libanalysis/src/fwd_step_enkf.c
+++ b/devel/libanalysis/src/fwd_step_enkf.c
@@ -29,8 +29,11 @@
 #include <ert/util/stepwise.h>
 
 #include <ert/analysis/fwd_step_enkf.h>
+#include <ert/analysis/fwd_step_log.h>
 #include <ert/analysis/analysis_table.h>
 #include <ert/analysis/analysis_module.h>
+#include <ert/analysis/module_data_block.h>
+#include <ert/analysis/module_data_block_vector.h>
 
 
 #define FWD_STEP_ENKF_TYPE_ID 765524
@@ -41,15 +44,18 @@
 #define R2_LIMIT_KEY                "FWD_STEP_R2_LIMIT"
 #define DEFAULT_VERBOSE             false
 #define VERBOSE_KEY                 "VERBOSE"
+#define  LOG_FILE_KEY               "LOG_FILE"
+#define  CLEAR_LOG_KEY              "CLEAR_LOG"
 
 struct fwd_step_enkf_data_struct {
   UTIL_TYPE_ID_DECLARATION;
-  stepwise_type        * stepwise_data;
-  rng_type             * rng;
-  int                    nfolds;
-  long                   option_flags;
-  double                 r2_limit;
-  bool                   verbose;
+  stepwise_type            * stepwise_data;
+  rng_type                 * rng;
+  int                        nfolds;
+  long                       option_flags;
+  double                     r2_limit;
+  bool                       verbose;
+  fwd_step_log_type        * fwd_step_log;
 };
 
 
@@ -79,10 +85,96 @@ void * fwd_step_enkf_data_alloc( rng_type * rng ) {
   data->r2_limit     = DEFAULT_R2_LIMIT;
   data->option_flags = ANALYSIS_NEED_ED + ANALYSIS_UPDATE_A + ANALYSIS_SCALE_DATA;
   data->verbose      = DEFAULT_VERBOSE;
-
+  data->fwd_step_log = fwd_step_log_alloc();
   return data;
 }
 
+void fwd_step_enkf_data_free( void * arg ) {
+  fwd_step_enkf_data_type * fwd_step_data = fwd_step_enkf_data_safe_cast( arg );
+  {
+
+    if (fwd_step_data != NULL) {
+      if (fwd_step_data->stepwise_data != NULL) {
+        stepwise_free( fwd_step_data->stepwise_data );
+      }
+    }
+  }
+  fwd_step_log_free( fwd_step_data->fwd_step_log );
+  free( fwd_step_data );
+}
+
+
+//**********************************************
+// Log-file related stuff
+//**********************************************
+
+
+static void fwd_step_enkf_write_log_header( fwd_step_enkf_data_type * fwd_step_data, const char * ministep_name, const int nx, const int nd, const int ens_size) {
+  const char * format = "%-15s%-15s%-15s%-15s%-15s%-15s\n";
+  const char * column1 = "Parameter";
+  const char * column2 = "ActiveIndex";
+  const char * column3 = "GlobalIndex";
+  const char * column4 = "NumAttached";
+  const char * column5 = "FinalR2";
+  const char * column6 = "AttachedObs";
+  int nfolds      = fwd_step_data->nfolds;
+  double r2_limit = fwd_step_data->r2_limit;
+
+  if (fwd_step_log_is_open( fwd_step_data->fwd_step_log )) {
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "===============================================================================================================================\n");
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "Ministep                    : %s\n",ministep_name);
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "Total number of parameters  : %d\n",nx);
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "Total number of observations: %d\n",nd);
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "Number of ensembles         : %d\n",ens_size);
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "CV folds                    : %d\n",nfolds);
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "Relative R2 tolerance       : %f\n",r2_limit);
+    fwd_step_log_line(fwd_step_data->fwd_step_log, "===============================================================================================================================\n");
+    fwd_step_log_line(fwd_step_data->fwd_step_log, format, column1, column2, column3, column4, column5, column6 );
+  }
+
+  printf("===============================================================================================================================\n");
+  printf("Ministep                    : %s\n",ministep_name);
+  printf("Total number of parameters  : %d\n",nx);
+  printf("Total number of observations: %d\n",nd);
+  printf("Number of ensembles         : %d\n",ens_size);
+  printf("CV folds                    : %d\n",nfolds);
+  printf("Relative R2 tolerance       : %f\n",r2_limit);
+  printf("===============================================================================================================================\n");
+  printf(format, column1, column2, column3, column4, column5, column6);
+}
+
+static void fwd_step_enkf_write_iter_info( fwd_step_enkf_data_type * data , stepwise_type * stepwise, const char* key, const int active_index, const int global_index ) {
+  const char * format = "%-15s%-15d%-15d%-15d%-15f";
+  int n_active = stepwise_get_n_active( stepwise);
+  double R2 = stepwise_get_R2(stepwise);
+  bool_vector_type * active_set = stepwise_get_active_set(stepwise);
+  bool has_log = fwd_step_log_is_open( data->fwd_step_log );
+
+  if (has_log)
+    fwd_step_log_line( data->fwd_step_log , format, key, active_index, global_index, n_active, R2);
+
+  printf(format, key, active_index, global_index, n_active, R2);
+
+  if (has_log)
+    fwd_step_log_line( data->fwd_step_log , "%s","[");
+
+  printf("%s","[");
+
+  for (int ivar = 0; ivar < bool_vector_size( active_set); ivar++) {
+    if (!bool_vector_iget( active_set , ivar))
+      continue;
+
+    if (has_log)
+      fwd_step_log_line( data->fwd_step_log , "%d ",ivar);
+
+    printf("%d ",ivar);
+  }
+  if (has_log)
+    fwd_step_log_line( data->fwd_step_log , "]\n");
+
+  printf("]\n");
+
+}
 
 /*Main function: */
 void fwd_step_enkf_updateA(void * module_data ,
@@ -91,11 +183,14 @@ void fwd_step_enkf_updateA(void * module_data ,
                            matrix_type * R ,
                            matrix_type * dObs ,
                            matrix_type * E ,
-                           matrix_type * D ) {
+                           matrix_type * D ,
+                           module_info_type* module_info) {
 
 
 
   fwd_step_enkf_data_type * fwd_step_data = fwd_step_enkf_data_safe_cast( module_data );
+  fwd_step_log_open(fwd_step_data->fwd_step_log);
+  module_data_block_vector_type * data_block_vector = module_info_get_data_block_vector(module_info);
   printf("Running Forward Stepwise regression:\n");
   {
 
@@ -105,6 +200,8 @@ void fwd_step_enkf_updateA(void * module_data ,
     int nfolds      = fwd_step_data->nfolds;
     double r2_limit = fwd_step_data->r2_limit;
     bool verbose    = fwd_step_data->verbose;
+    int num_kw     =  module_data_block_vector_get_size(data_block_vector);
+
 
     if ( ens_size <= nfolds)
       util_abort("%s: The number of ensembles must be larger than the CV fold - aborting\n", __func__);
@@ -128,43 +225,57 @@ void fwd_step_enkf_updateA(void * module_data ,
       matrix_type * di = matrix_alloc( 1 , nd );
 
       if (verbose){
-       printf("===============================================================================================================================\n");
-       printf("Total number of parameters  : %d\n",nx);
-       printf("Total number of observations: %d\n",nd);
-       printf("Number of ensembles         : %d\n",ens_size);
-       printf("CV folds                    : %d\n",nfolds);
-       printf("Relative R2 tolerance       : %f\n",r2_limit);
-       printf("===============================================================================================================================\n");
-       printf("%-15s%-15s%-15s%-15s\n", "Parameter", "NumAttached", "FinalR2", "ActiveIndices");
+        char * ministep_name = module_data_block_vector_get_ministep_name(data_block_vector);
+        fwd_step_enkf_write_log_header(fwd_step_data, ministep_name, nx, nd, ens_size);
       }
 
-      for (int i = 0; i < nx; i++) {
+      for (int kw = 0; kw < num_kw; kw++) {
 
+        module_data_block_type * data_block = module_data_block_vector_iget_module_data_block(data_block_vector, kw);
+        const char * key = module_data_block_get_key(data_block);
+        int row_start = module_data_block_get_row_start(data_block);
+        int row_end   = module_data_block_get_row_end(data_block);
+        const int* active_indices = module_data_block_get_active_indices(data_block);
+        int local_index = 0;
+        int active_index = 0;
+        bool all_active = active_indices == NULL; /* Inactive are not present in A */
 
-        /*Update values of y */
-        /*Start of the actual update */
-        matrix_type * y = matrix_alloc( ens_size , 1 );
+        for (int i = row_start; i < row_end; i++) {
 
-        for (int j = 0; j < ens_size; j++) {
-          matrix_iset(y , j , 0 , matrix_iget( A, i , j ) );
-        }
+          /*Update values of y */
+          /*Start of the actual update */
+          matrix_type * y = matrix_alloc( ens_size , 1 );
 
-        stepwise_set_Y0( stepwise_data , y );
-
-        stepwise_estimate(stepwise_data , r2_limit , nfolds );
-
-        /*manipulate A directly*/
-        for (int j = 0; j < ens_size; j++) {
-          for (int k = 0; k < nd; k++) {
-            matrix_iset(di , 0 , k , matrix_iget( D , k , j ) );
+          for (int j = 0; j < ens_size; j++) {
+            matrix_iset(y , j , 0 , matrix_iget( A, i , j ) );
           }
-          double aij = matrix_iget( A , i , j );
-          double xHat = stepwise_eval(stepwise_data , di );
-          matrix_iset(A , i , j , aij + xHat);
-        }
 
-        if (verbose)
-         stepwise_printf(stepwise_data, i);
+          stepwise_set_Y0( stepwise_data , y );
+
+          stepwise_estimate(stepwise_data , r2_limit , nfolds );
+
+          /*manipulate A directly*/
+          for (int j = 0; j < ens_size; j++) {
+            for (int k = 0; k < nd; k++) {
+              matrix_iset(di , 0 , k , matrix_iget( D , k , j ) );
+            }
+            double aij = matrix_iget( A , i , j );
+            double xHat = stepwise_eval(stepwise_data , di );
+            matrix_iset(A , i , j , aij + xHat);
+          }
+
+          if (verbose){
+            if (all_active)
+             active_index = local_index;
+            else
+             active_index = active_indices[local_index];
+
+            fwd_step_enkf_write_iter_info(fwd_step_data, stepwise_data, key, active_index, i);
+
+          }
+
+          local_index ++;
+        }
       }
 
       if (verbose)
@@ -181,24 +292,12 @@ void fwd_step_enkf_updateA(void * module_data ,
 
   }
 
-
+  fwd_step_log_close( fwd_step_data->fwd_step_log );
 }
 
 
 
 
-void fwd_step_enkf_data_free( void * arg ) {
-  fwd_step_enkf_data_type * fwd_step_data = fwd_step_enkf_data_safe_cast( arg );
-  {
-
-    if (fwd_step_data != NULL) {
-      if (fwd_step_data->stepwise_data != NULL) {
-        stepwise_free( fwd_step_data->stepwise_data );
-      }
-    }
-  }
-  free( fwd_step_data );
-}
 
 
 bool fwd_step_enkf_set_double( void * arg , const char * var_name , double value) {
@@ -239,11 +338,27 @@ bool fwd_step_enkf_set_bool( void * arg , const char * var_name , bool value) {
     /*Set verbose */
     if (strcmp( var_name , VERBOSE_KEY) == 0)
       fwd_step_enkf_set_verbose( module_data , value);
+    else if (strcmp( var_name , CLEAR_LOG_KEY) == 0)
+      fwd_step_log_set_clear_log( module_data->fwd_step_log , value );
     else
       name_recognized = false;
 
     return name_recognized;
    }
+}
+
+bool fwd_step_enkf_set_string( void * arg , const char * var_name , const char * value) {
+  fwd_step_enkf_data_type * module_data = fwd_step_enkf_data_safe_cast( arg );
+  {
+    bool name_recognized = true;
+
+    if (strcmp( var_name , LOG_FILE_KEY) == 0)
+      fwd_step_log_set_log_file( module_data->fwd_step_log , value );
+    else
+      name_recognized = false;
+
+    return name_recognized;
+  }
 }
 
 long fwd_step_enkf_get_options( void * arg , long flag) {
@@ -260,6 +375,10 @@ bool fwd_step_enkf_has_var( const void * arg, const char * var_name) {
     else if (strcmp(var_name , R2_LIMIT_KEY ) == 0)
       return true;
     else if (strcmp(var_name , VERBOSE_KEY ) == 0)
+      return true;
+    else if (strcmp(var_name , LOG_FILE_KEY) == 0)
+      return true;
+    else if (strcmp(var_name , CLEAR_LOG_KEY) == 0)
       return true;
     else
       return false;
@@ -291,10 +410,26 @@ bool fwd_step_enkf_get_bool( const void * arg, const char * var_name) {
   {
     if (strcmp(var_name , VERBOSE_KEY) == 0)
       return module_data->verbose;
+     else if (strcmp(var_name , CLEAR_LOG_KEY) == 0)
+      return fwd_step_log_get_clear_log( module_data->fwd_step_log );
     else
       return false;
   }
 }
+
+void * fwd_step_enkf_get_ptr( const void * arg , const char * var_name ) {
+  const fwd_step_enkf_data_type * module_data = fwd_step_enkf_data_safe_cast_const( arg );
+  {
+    if (strcmp(var_name , LOG_FILE_KEY) == 0)
+      return (void *) fwd_step_log_get_log_file( module_data->fwd_step_log );
+    else
+      return NULL;
+  }
+}
+
+
+
+
 
 #ifdef INTERNAL_LINK
 #define LINK_NAME FWD_STEP_ENKF
@@ -310,7 +445,7 @@ analysis_table_type LINK_NAME = {
   .set_int         = fwd_step_enkf_set_int ,
   .set_double      = fwd_step_enkf_set_double ,
   .set_bool        = fwd_step_enkf_set_bool ,
-  .set_string      = NULL ,
+  .set_string      = fwd_step_enkf_set_string ,
   .get_options     = fwd_step_enkf_get_options ,
   .initX           = NULL ,
   .updateA         = fwd_step_enkf_updateA,
@@ -320,7 +455,7 @@ analysis_table_type LINK_NAME = {
   .get_int         = fwd_step_enkf_get_int ,
   .get_double      = fwd_step_enkf_get_double ,
   .get_bool        = fwd_step_enkf_get_bool ,
-  .get_ptr         = NULL
+  .get_ptr         = fwd_step_enkf_get_ptr
 };
 
 

--- a/devel/libanalysis/src/fwd_step_log.c
+++ b/devel/libanalysis/src/fwd_step_log.c
@@ -1,0 +1,105 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'fwd_step_log.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <ert/util/util.h>
+
+#include <ert/analysis/fwd_step_log.h>
+
+#define DEFAULT_LOG_FILE               "fwd_step.out"
+#define DEFAULT_CLEAR_LOG              true
+
+struct fwd_step_log_struct {
+  bool      clear_log;
+  char    * log_file;
+  FILE    * log_stream;
+};
+
+
+fwd_step_log_type * fwd_step_log_alloc() {
+  fwd_step_log_type * fwd_step_log = util_malloc( sizeof * fwd_step_log );
+  fwd_step_log->log_file = NULL;
+  fwd_step_log->log_stream = NULL;
+  fwd_step_log_set_log_file( fwd_step_log , DEFAULT_LOG_FILE);
+  fwd_step_log_set_clear_log( fwd_step_log , DEFAULT_CLEAR_LOG );
+  return fwd_step_log;
+}
+
+bool fwd_step_log_get_clear_log( const fwd_step_log_type * data ) {
+  return data->clear_log;
+}
+
+void fwd_step_log_set_clear_log( fwd_step_log_type * data , bool clear_log) {
+  data->clear_log = clear_log;
+}
+
+void fwd_step_log_set_log_file( fwd_step_log_type * data , const char * log_file ) {
+  data->log_file = util_realloc_string_copy( data->log_file , log_file );
+}
+
+const char * fwd_step_log_get_log_file( const fwd_step_log_type * data) {
+  return data->log_file;
+}
+
+
+void fwd_step_log_free(fwd_step_log_type * fwd_step_log) {
+  fwd_step_log_close( fwd_step_log );
+  util_safe_free( fwd_step_log->log_file );
+  free( fwd_step_log );
+}
+
+
+void fwd_step_log_open( fwd_step_log_type * fwd_step_log ) {
+  if (fwd_step_log->log_file) {
+    if (fwd_step_log->clear_log)
+      fwd_step_log->log_stream = util_mkdir_fopen( fwd_step_log->log_file , "w");
+    else
+      fwd_step_log->log_stream = util_mkdir_fopen( fwd_step_log->log_file , "a");
+  }
+}
+
+
+bool fwd_step_log_is_open( const fwd_step_log_type * fwd_step_log ) {
+  if (fwd_step_log->log_stream)
+    return true;
+  else
+    return false;
+}
+
+
+void fwd_step_log_close( fwd_step_log_type * fwd_step_log ) {
+  if (fwd_step_log->log_stream)
+    fclose( fwd_step_log->log_stream );
+
+  fwd_step_log->log_stream = NULL;
+}
+
+
+void fwd_step_log_line( fwd_step_log_type * fwd_step_log , const char * fmt , ...) {
+  if (fwd_step_log->log_stream) {
+    va_list ap;
+    va_start(ap , fmt);
+    vfprintf( fwd_step_log->log_stream , fmt , ap );
+    va_end( ap );
+  }
+}
+
+

--- a/devel/libanalysis/src/module_data_block.c
+++ b/devel/libanalysis/src/module_data_block.c
@@ -1,0 +1,66 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'module_data_block.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <ert/util/util.h>
+#include <ert/util/type_macros.h>
+
+#include <ert/analysis/module_data_block.h>
+
+#define MODULE_DATA_BLOCK_TYPE_ID 73217801
+static UTIL_SAFE_CAST_FUNCTION( module_data_block , MODULE_DATA_BLOCK_TYPE_ID);
+
+module_data_block_type * module_data_block_alloc(  const char * key,  const int * index_list , const int row_start, const int n_active) {
+  module_data_block_type * module_data_block = util_malloc( sizeof * module_data_block );
+  UTIL_TYPE_ID_INIT( module_data_block , MODULE_DATA_BLOCK_TYPE_ID );
+  module_data_block->key = util_alloc_string_copy( key );
+  module_data_block->index_list  = index_list;
+  module_data_block->A_row_start = row_start;
+  module_data_block->n_active = n_active;
+  return module_data_block;
+}
+
+
+const char * module_data_block_get_key(module_data_block_type * module_data_block){
+  return module_data_block->key;
+}
+
+const int module_data_block_get_row_start(module_data_block_type * module_data_block){
+  return module_data_block->A_row_start;
+}
+
+const int module_data_block_get_row_end(module_data_block_type * module_data_block){
+  return module_data_block->A_row_start + module_data_block->n_active;
+}
+
+const int  * module_data_block_get_active_indices(module_data_block_type * module_data_block ){
+  return module_data_block->index_list;
+}
+
+void module_data_block_free( module_data_block_type * module_data_block ) {
+  util_safe_free(module_data_block->key);
+  free( module_data_block );
+}
+
+void module_data_block_free__( void * arg ) {
+  module_data_block_type * data_block = module_data_block_safe_cast( arg );
+  module_data_block_free( data_block );
+}

--- a/devel/libanalysis/src/module_data_block_vector.c
+++ b/devel/libanalysis/src/module_data_block_vector.c
@@ -1,0 +1,69 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'module_data_block_vector.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <ert/util/vector.h>
+#include <ert/util/util.h>
+#include <ert/util/type_macros.h>
+
+#include <ert/analysis/module_data_block.h>
+#include <ert/analysis/module_data_block_vector.h>
+
+#define MODULE_DATA_BLOCK_VECTOR_TYPE_ID 732178012
+
+struct module_data_block_vector_struct {
+  UTIL_TYPE_ID_DECLARATION;
+  char                   * ministep_name;
+  vector_type            * data_block_vector;
+};
+
+
+module_data_block_vector_type * module_data_block_vector_alloc( const char* ministep_name) {
+  module_data_block_vector_type * module_data_block_vector = util_malloc( sizeof * module_data_block_vector );
+  UTIL_TYPE_ID_INIT( module_data_block_vector , MODULE_DATA_BLOCK_VECTOR_TYPE_ID );
+  module_data_block_vector->ministep_name =util_alloc_string_copy( ministep_name );
+  module_data_block_vector->data_block_vector = vector_alloc_new();
+  return module_data_block_vector;
+}
+
+
+void module_data_block_vector_free( module_data_block_vector_type * module_data_block_vector ) {
+  util_safe_free(module_data_block_vector->ministep_name);
+  vector_free( module_data_block_vector->data_block_vector );
+  free( module_data_block_vector );
+}
+
+void module_data_block_vector_add_data_block( module_data_block_vector_type * module_data_block_vector , const module_data_block_type * data_block) {
+  vector_append_owned_ref(module_data_block_vector->data_block_vector, data_block , module_data_block_free__);
+}
+
+
+module_data_block_type * module_data_block_vector_iget_module_data_block(const module_data_block_vector_type * module_data_block_vector, int index){
+ return vector_iget(module_data_block_vector->data_block_vector, index);
+}
+
+int module_data_block_vector_get_size(const module_data_block_vector_type * module_data_block_vector){
+ return vector_get_size(module_data_block_vector->data_block_vector);
+}
+
+char * module_data_block_vector_get_ministep_name(const module_data_block_vector_type * module_data_block_vector){
+  return module_data_block_vector->ministep_name;
+}
+

--- a/devel/libanalysis/src/module_info.c
+++ b/devel/libanalysis/src/module_info.c
@@ -1,0 +1,53 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'module_info.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <ert/util/vector.h>
+#include <ert/util/util.h>
+#include <ert/util/type_macros.h>
+
+
+#include <ert/analysis/module_info.h>
+
+#define MODULE_INFO_TYPE_ID 73780123
+
+struct module_info_struct {
+  UTIL_TYPE_ID_DECLARATION;
+  module_data_block_vector_type * data_block_vector;
+  //To come :  module_obs_block_vector_type * obs_block_vector;
+};
+
+
+module_info_type * module_info_alloc( const char* ministep_name ) {
+  module_info_type * module_info = util_malloc( sizeof * module_info );
+  UTIL_TYPE_ID_INIT( module_info , MODULE_INFO_TYPE_ID );
+  module_info->data_block_vector = module_data_block_vector_alloc(ministep_name);
+  return module_info;
+}
+
+
+void module_info_free( module_info_type * module_info ) {
+  module_data_block_vector_free( module_info->data_block_vector );
+  free( module_info );
+}
+
+module_data_block_vector_type *   module_info_get_data_block_vector(const module_info_type * module_info){
+  return module_info->data_block_vector;
+}

--- a/devel/libert_util/include/ert/util/stepwise.h
+++ b/devel/libert_util/include/ert/util/stepwise.h
@@ -25,11 +25,12 @@ extern "C" {
   double          stepwise_get_R2(const stepwise_type * stepwise );
   int             stepwise_get_nvar( stepwise_type * stepwise );
   int             stepwise_get_nsample( stepwise_type * stepwise );
+  int             stepwise_get_n_active( stepwise_type * stepwise );
+  bool_vector_type * stepwise_get_active_set( stepwise_type * stepwise );
 
 
   void            stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV_blocks);
   double          stepwise_eval( const stepwise_type * stepwise , const matrix_type * x );
-  void            stepwise_printf( const stepwise_type * stepwise , const int index);
 
 
 

--- a/devel/libert_util/src/stepwise.c
+++ b/devel/libert_util/src/stepwise.c
@@ -199,12 +199,16 @@ static double stepwise_test_var( stepwise_type * stepwise , int test_var , int b
         {
           int irow;
           matrix_type * x_vector = matrix_alloc( 1 , nvar );
+          //matrix_type * e_vector = matrix_alloc( 1 , nvar );
           for (irow=validation_start; irow <= validation_end; irow++) {
             matrix_copy_row( x_vector , stepwise->X0 , 0 , randperms[irow]);
+            //matrix_copy_row( e_vector , stepwise->E0 , 0 , randperms[irow]);
             {
               double true_value      = matrix_iget( stepwise->Y0 , randperms[irow] , 0 );
               double estimated_value = stepwise_eval__( stepwise , x_vector );
               prediction_error += (true_value - estimated_value) * (true_value - estimated_value);
+              //double e_estimated_value = stepwise_eval__( stepwise , e_vector );
+              //prediction_error += e_estimated_value*e_estimated_value;
             }
 
           }
@@ -221,10 +225,6 @@ static double stepwise_test_var( stepwise_type * stepwise , int test_var , int b
   bool_vector_iset( stepwise->active_set , test_var , false );
   return prediction_error;
 }
-
-
-
-
 
 
 void stepwise_estimate( stepwise_type * stepwise , double deltaR2_limit , int CV_blocks) {
@@ -423,6 +423,14 @@ int stepwise_get_nvar( stepwise_type * stepwise ) {
   return matrix_get_columns( stepwise->X0 );
 }
 
+int stepwise_get_n_active( stepwise_type * stepwise ) {
+  return bool_vector_count_equal( stepwise->active_set , true);
+}
+
+bool_vector_type * stepwise_get_active_set( stepwise_type * stepwise ) {
+  return stepwise->active_set;
+}
+
 void stepwise_isetY0( stepwise_type * stepwise , int i , double value ) {
   matrix_iset( stepwise->Y0, i , 0 , value );
 }
@@ -457,17 +465,3 @@ void stepwise_free( stepwise_type * stepwise ) {
 
 }
 
-void stepwise_printf( const stepwise_type * stepwise , const int index ) {
-
- int n_active = bool_vector_count_equal( stepwise->active_set , true);
-
- printf("%-15d%-15d%-15.4f", index, n_active, stepwise_get_R2(stepwise));
-
- printf("%s","[");
- for (int ivar = 0; ivar < bool_vector_size( stepwise->active_set); ivar++) {
-  if (!bool_vector_iget( stepwise->active_set , ivar))
-    continue;
-   printf("%d ",ivar);
- }
- printf("]\n");
-}

--- a/devel/python/python/ert/analysis/analysis_module.py
+++ b/devel/python/python/ert/analysis/analysis_module.py
@@ -37,7 +37,7 @@ class AnalysisModule(BaseCClass):
     _get_bool            = AnalysisPrototype("bool analysis_module_get_bool(analysis_module, char*)")
     _get_str             = AnalysisPrototype("char* analysis_module_get_ptr(analysis_module, char*)")
     _init_update         = AnalysisPrototype("void analysis_module_init_update(analysis_module, bool_vector , matrix , matrix , matrix , matrix, matrix)")
-    _updateA             = AnalysisPrototype("void analysis_module_updateA(analysis_module, matrix , matrix ,  matrix , matrix, matrix, matrix)")
+    _updateA             = AnalysisPrototype("void analysis_module_updateA(analysis_module, matrix , matrix ,  matrix , matrix, matrix, matrix, void*)")
     _initX               = AnalysisPrototype("void analysis_module_initX(analysis_module, matrix , matrix , matrix , matrix , matrix, matrix, matrix)")
 
 
@@ -149,7 +149,7 @@ class AnalysisModule(BaseCClass):
         self._init_update(mask, S, R, dObs, E, D)
 
     def updateA(self, A, S, R, dObs, E, D):
-        self._updateA(A, S, R, dObs, E, D)
+        self._updateA(A, S, R, dObs, E, D, None)
 
     def initX(self, X, A, S, R, dObs, E, D):
         self._initX(X, A, S, R, dObs, E, D)


### PR DESCRIPTION
This addresses a current need for more detail output in analysis modules. In particular, fwd_step_enkf is a consumer.

The essential idea is the addition of an auxiliary struct that keeps track of the parameter blocks in the ensemble matrix for later reporting. The next step is to add support for data block reporting, possibly building on top of these structs.

Also in this PR you may find a log output functionality for fwd_step_enkf, very similar to rml_enkf.

I'd appreciate your opinion on these additions. 