### PR TITLE
Vector operations on summary vectors

### DIFF
--- a/devel/libecl/include/ert/ecl/ecl_sum.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum.h
@@ -80,6 +80,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   const char *     ecl_sum_iget_keyword( const ecl_sum_type * sum , int param_index );
   int              ecl_sum_get_data_length( const ecl_sum_type * ecl_sum );
   void             ecl_sum_scale_vector( ecl_sum_type * ecl_sum, int index, double scalar );
+  void             ecl_sum_shift_vector( ecl_sum_type * ecl_sum, int index, double addend );
   double           ecl_sum_iget_from_sim_time( const ecl_sum_type * ecl_sum , time_t sim_time , int param_index);
   double           ecl_sum_iget_from_sim_days( const ecl_sum_type * ecl_sum , double sim_days , int param_index );
 

--- a/devel/libecl/include/ert/ecl/ecl_sum.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum.h
@@ -79,6 +79,7 @@ typedef struct ecl_sum_struct       ecl_sum_type;
   const char *     ecl_sum_iget_wgname( const ecl_sum_type * sum , int param_index );
   const char *     ecl_sum_iget_keyword( const ecl_sum_type * sum , int param_index );
   int              ecl_sum_get_data_length( const ecl_sum_type * ecl_sum );
+  void             ecl_sum_scale_vector( ecl_sum_type * ecl_sum, int index, double scalar );
   double           ecl_sum_iget_from_sim_time( const ecl_sum_type * ecl_sum , time_t sim_time , int param_index);
   double           ecl_sum_iget_from_sim_days( const ecl_sum_type * ecl_sum , double sim_days , int param_index );
 

--- a/devel/libecl/include/ert/ecl/ecl_sum_data.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_data.h
@@ -79,6 +79,7 @@ typedef struct ecl_sum_data_struct ecl_sum_data_type ;
   double                   ecl_sum_data_get_from_sim_days( const ecl_sum_data_type * data , double sim_days , const smspec_node_type * smspec_node);
 
   int                      ecl_sum_data_get_length( const ecl_sum_data_type * data );
+  void                     ecl_sum_data_scale_vector( ecl_sum_data_type * data , int index, double scalar );
   int                      ecl_sum_data_iget_report_step(const ecl_sum_data_type * data , int internal_index);
   int                      ecl_sum_data_iget_mini_step(const ecl_sum_data_type * data , int internal_index);
   int                      ecl_sum_data_iget_report_end( const ecl_sum_data_type * data , int report_step );

--- a/devel/libecl/include/ert/ecl/ecl_sum_data.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_data.h
@@ -80,6 +80,7 @@ typedef struct ecl_sum_data_struct ecl_sum_data_type ;
 
   int                      ecl_sum_data_get_length( const ecl_sum_data_type * data );
   void                     ecl_sum_data_scale_vector( ecl_sum_data_type * data , int index, double scalar );
+  void                     ecl_sum_data_shift_vector( ecl_sum_data_type * data , int index, double addend );
   int                      ecl_sum_data_iget_report_step(const ecl_sum_data_type * data , int internal_index);
   int                      ecl_sum_data_iget_mini_step(const ecl_sum_data_type * data , int internal_index);
   int                      ecl_sum_data_iget_report_end( const ecl_sum_data_type * data , int report_step );

--- a/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
@@ -55,6 +55,9 @@ typedef struct ecl_sum_tstep_struct ecl_sum_tstep_type;
   /// scales with value; equivalent to iset( iget() * scalar)
   void ecl_sum_tstep_iscale(ecl_sum_tstep_type * tstep, int index, float scalar);
 
+  /// adds addend to tstep[index]; equivalent to iset( iget() + addend)
+  void ecl_sum_tstep_ishift(ecl_sum_tstep_type * tstep, int index, float addend);
+
   void ecl_sum_tstep_set_from_node( ecl_sum_tstep_type * tstep , const smspec_node_type * smspec_node , float value);
   double ecl_sum_tstep_get_from_node( const ecl_sum_tstep_type * tstep , const smspec_node_type * smspec_node);
 

--- a/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
+++ b/devel/libecl/include/ert/ecl/ecl_sum_tstep.h
@@ -52,6 +52,9 @@ typedef struct ecl_sum_tstep_struct ecl_sum_tstep_type;
   void ecl_sum_tstep_fwrite( const ecl_sum_tstep_type * ministep , const int_vector_type * index_map , fortio_type * fortio);
   void ecl_sum_tstep_iset( ecl_sum_tstep_type * tstep , int index , float value);
 
+  /// scales with value; equivalent to iset( iget() * scalar)
+  void ecl_sum_tstep_iscale(ecl_sum_tstep_type * tstep, int index, float scalar);
+
   void ecl_sum_tstep_set_from_node( ecl_sum_tstep_type * tstep , const smspec_node_type * smspec_node , float value);
   double ecl_sum_tstep_get_from_node( const ecl_sum_tstep_type * tstep , const smspec_node_type * smspec_node);
 

--- a/devel/libecl/src/ecl_sum.c
+++ b/devel/libecl/src/ecl_sum.c
@@ -1181,6 +1181,10 @@ int ecl_sum_get_data_length( const ecl_sum_type * ecl_sum ) {
   return ecl_sum_data_get_length( ecl_sum->data );
 }
 
+void ecl_sum_scale_vector( ecl_sum_type * ecl_sum, int index, double scalar ) {
+  ecl_sum_data_scale_vector( ecl_sum->data, index, scalar );
+}
+
 
 bool ecl_sum_check_sim_time( const ecl_sum_type * sum , time_t sim_time) {
   return ecl_sum_data_check_sim_time( sum->data , sim_time );

--- a/devel/libecl/src/ecl_sum.c
+++ b/devel/libecl/src/ecl_sum.c
@@ -1185,6 +1185,9 @@ void ecl_sum_scale_vector( ecl_sum_type * ecl_sum, int index, double scalar ) {
   ecl_sum_data_scale_vector( ecl_sum->data, index, scalar );
 }
 
+void ecl_sum_shift_vector( ecl_sum_type * ecl_sum, int index, double addend ) {
+  ecl_sum_data_shift_vector( ecl_sum->data, index, addend );
+}
 
 bool ecl_sum_check_sim_time( const ecl_sum_type * sum , time_t sim_time) {
   return ecl_sum_data_check_sim_time( sum->data , sim_time );

--- a/devel/libecl/src/ecl_sum_data.c
+++ b/devel/libecl/src/ecl_sum_data.c
@@ -1457,6 +1457,14 @@ int ecl_sum_data_get_length( const ecl_sum_data_type * data ) {
   return vector_get_size( data->data );
 }
 
+void ecl_sum_data_scale_vector(ecl_sum_data_type * data, int index, double scalar) {
+  int len = vector_get_size(data->data);
+  for (int i = 0; i < len; i++) {
+    const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(vector_iget(data->data, i), index);
+    float val = ecl_sum_tstep_iget(ministep, index);
+    ecl_sum_tstep_iset(ministep, index, val * scalar);
+  }
+}
 
 bool ecl_sum_data_report_step_equal( const ecl_sum_data_type * data1 , const ecl_sum_data_type * data2) {
   bool equal = true;

--- a/devel/libecl/src/ecl_sum_data.c
+++ b/devel/libecl/src/ecl_sum_data.c
@@ -300,8 +300,8 @@ ecl_sum_data_type * ecl_sum_data_alloc(ecl_smspec_type * smspec) {
 */
 
 
-static const ecl_sum_tstep_type * ecl_sum_data_iget_ministep( const ecl_sum_data_type * data , int internal_index ) {
-  return vector_iget_const( data->data , internal_index );
+static ecl_sum_tstep_type * ecl_sum_data_iget_ministep( const ecl_sum_data_type * data , int internal_index ) {
+  return vector_iget( data->data , internal_index );
 }
 
 
@@ -1460,9 +1460,8 @@ int ecl_sum_data_get_length( const ecl_sum_data_type * data ) {
 void ecl_sum_data_scale_vector(ecl_sum_data_type * data, int index, double scalar) {
   int len = vector_get_size(data->data);
   for (int i = 0; i < len; i++) {
-    const ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(vector_iget(data->data, i), index);
-    float val = ecl_sum_tstep_iget(ministep, index);
-    ecl_sum_tstep_iset(ministep, index, val * scalar);
+    ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data,i);
+    ecl_sum_tstep_iscale(ministep, index, scalar);
   }
 }
 

--- a/devel/libecl/src/ecl_sum_data.c
+++ b/devel/libecl/src/ecl_sum_data.c
@@ -1465,6 +1465,14 @@ void ecl_sum_data_scale_vector(ecl_sum_data_type * data, int index, double scala
   }
 }
 
+void ecl_sum_data_shift_vector(ecl_sum_data_type * data, int index, double addend) {
+  int len = vector_get_size(data->data);
+  for (int i = 0; i < len; i++) {
+    ecl_sum_tstep_type * ministep = ecl_sum_data_iget_ministep(data,i);
+    ecl_sum_tstep_ishift(ministep, index, addend);
+  }
+}
+
 bool ecl_sum_data_report_step_equal( const ecl_sum_data_type * data1 , const ecl_sum_data_type * data2) {
   bool equal = true;
   if (int_vector_size( data1->report_last_index ) == int_vector_size(data2->report_last_index)) {

--- a/devel/libecl/src/ecl_sum_tstep.c
+++ b/devel/libecl/src/ecl_sum_tstep.c
@@ -282,6 +282,9 @@ void ecl_sum_tstep_iset( ecl_sum_tstep_type * tstep , int index , float value) {
     util_abort("%s: index:%d invalid. Valid range: [0,%d) \n",__func__  ,index , tstep->data_size);
 }
 
+void ecl_sum_tstep_iscale(ecl_sum_tstep_type * tstep, int index, float scalar) {
+  ecl_sum_tstep_iset(tstep, index, ecl_sum_tstep_iget(tstep, index) * scalar);
+}
 
 void ecl_sum_tstep_set_from_node( ecl_sum_tstep_type * tstep , const smspec_node_type * smspec_node , float value) {
   int data_index = smspec_node_get_params_index( smspec_node );

--- a/devel/libecl/src/ecl_sum_tstep.c
+++ b/devel/libecl/src/ecl_sum_tstep.c
@@ -286,6 +286,10 @@ void ecl_sum_tstep_iscale(ecl_sum_tstep_type * tstep, int index, float scalar) {
   ecl_sum_tstep_iset(tstep, index, ecl_sum_tstep_iget(tstep, index) * scalar);
 }
 
+void ecl_sum_tstep_ishift(ecl_sum_tstep_type * tstep, int index, float addend) {
+  ecl_sum_tstep_iset(tstep, index, ecl_sum_tstep_iget(tstep, index) + addend);
+}
+
 void ecl_sum_tstep_set_from_node( ecl_sum_tstep_type * tstep , const smspec_node_type * smspec_node , float value) {
   int data_index = smspec_node_get_params_index( smspec_node );
   ecl_sum_tstep_iset( tstep , data_index , value);

--- a/devel/python/python/ert/ecl/ecl_sum.py
+++ b/devel/python/python/ert/ecl/ecl_sum.py
@@ -87,6 +87,7 @@ class EclSum(BaseCClass):
     _iiget                         = EclPrototype("double   ecl_sum_iget( ecl_sum , int , int)")
     _free                          = EclPrototype("void     ecl_sum_free( ecl_sum )")
     _data_length                   = EclPrototype("int      ecl_sum_get_data_length( ecl_sum )")
+    _scale_vector                  = EclPrototype("void     ecl_sum_scale_vector( ecl_sum, int, double )")
     _iget_sim_days                 = EclPrototype("double   ecl_sum_iget_sim_days( ecl_sum , int) ")
     _iget_report_step              = EclPrototype("int      ecl_sum_iget_report_step( ecl_sum , int) ")
     _iget_mini_step                = EclPrototype("int      ecl_sum_iget_mini_step( ecl_sum , int) ")
@@ -431,6 +432,15 @@ class EclSum(BaseCClass):
         """
         return self.get_vector( key )
 
+    def scaleVector(self, key, scalar):
+        """ecl_sum.scaleVector("WOPR:OPX" , 0.78 )
+        will scale all the elements in the 'WOPR:OPX' vector with 0.78.
+        """
+        if not key in self:
+            raise KeyError("Summary object does not have key:%s" % key)
+
+        key_index = self._get_general_var_index( key )
+        self._scale_vector(key_index, float(scalar))
 
     def check_sim_time( self , date):
         """

--- a/devel/python/python/ert/ecl/ecl_sum.py
+++ b/devel/python/python/ert/ecl/ecl_sum.py
@@ -88,6 +88,7 @@ class EclSum(BaseCClass):
     _free                          = EclPrototype("void     ecl_sum_free( ecl_sum )")
     _data_length                   = EclPrototype("int      ecl_sum_get_data_length( ecl_sum )")
     _scale_vector                  = EclPrototype("void     ecl_sum_scale_vector( ecl_sum, int, double )")
+    _shift_vector                  = EclPrototype("void     ecl_sum_shift_vector( ecl_sum, int, double )")
     _iget_sim_days                 = EclPrototype("double   ecl_sum_iget_sim_days( ecl_sum , int) ")
     _iget_report_step              = EclPrototype("int      ecl_sum_iget_report_step( ecl_sum , int) ")
     _iget_mini_step                = EclPrototype("int      ecl_sum_iget_mini_step( ecl_sum , int) ")
@@ -441,6 +442,15 @@ class EclSum(BaseCClass):
 
         key_index = self._get_general_var_index( key )
         self._scale_vector(key_index, float(scalar))
+
+    def shiftVector(self, key, addend):
+        """ecl_sum.shiftVector("WOPR:OPX" , 0.78 )
+        will shift (add) all the elements in the 'WOPR:OPX' vector with 0.78.
+        """
+        if not key in self:
+            raise KeyError("Summary object does not have key:%s" % key)
+        key_index = self._get_general_var_index( key )
+        self._shift_vector(key_index, float(addend))
 
     def check_sim_time( self , date):
         """

--- a/devel/python/tests/core/ecl/test_sum.py
+++ b/devel/python/tests/core/ecl/test_sum.py
@@ -35,13 +35,6 @@ def fgpt(days):
         return days
     else:
         return 100 - days
-    
-
-def close(f1,f2):
-    return abs(f1-f2) < 0.00001 # to test vector scaling
-
-def lists_close(l1,l2):
-    return min( [close(l1[i], l2[i]) for i in range(len(l1))] )
 
 class SumTest(ExtendedTestCase):
 
@@ -180,6 +173,7 @@ class SumTest(ExtendedTestCase):
 
     def test_ecl_sum_vector_algebra(self):
         scalar = 0.78
+        addend = 2.718281828459045
 
         # setup
         length = 100
@@ -192,9 +186,22 @@ class SumTest(ExtendedTestCase):
                                           "FGPT" : fgpt })
         with self.assertRaises( KeyError ):
             case.scaleVector( "MISSING:KEY" , scalar)
+            case.shiftVector( "MISSING:KEY" , addend)
+
+        # scale all vectors with scalar
         for key in case.keys():
             x = case.get_values(key) # get vector key
             case.scaleVector(key , scalar)
             y = case.get_values(key)
             x = x * scalar # numpy vector scaling
-            self.assertTrue( lists_close(x,y) )
+            for i in range(len(x)):
+                self.assertFloatEqual(x[i], y[i])
+
+        # shift all vectors with addend
+        for key in case.keys():
+            x = case.get_values(key) # get vector key
+            case.shiftVector(key , addend)
+            y = case.get_values(key)
+            x = x + addend # numpy vector shifting
+            for i in range(len(x)):
+                self.assertFloatEqual(x[i], y[i])

--- a/devel/python/tests/core/ecl/test_sum.py
+++ b/devel/python/tests/core/ecl/test_sum.py
@@ -172,4 +172,19 @@ class SumTest(ExtendedTestCase):
         t2 = t0 + datetime.timedelta( days = 75 )
         self.assertEqual( sol[0] , t1 )
         self.assertEqual( sol[1] , t2 )
-        
+
+    def test_ecl_sum_vector_algebra(self):
+        # setup
+        length = 100
+        case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
+                            sim_length_days = length,
+                            num_report_step = 10,
+                            num_mini_step = 10,
+                            func_table = {"FOPT" : fopt,
+                                          "FOPR" : fopr ,
+                                          "FGPT" : fgpt })
+        with self.assertRaises( KeyError ):
+            case.solveDays( "MISSING:KEY" , 0.56)
+        sol = case.solveDays( "FOPT" , 150 )
+        x = case
+        x.scaleVector('FOPT' , 0.78)

--- a/devel/python/tests/core/ecl/test_sum.py
+++ b/devel/python/tests/core/ecl/test_sum.py
@@ -37,6 +37,11 @@ def fgpt(days):
         return 100 - days
     
 
+def close(f1,f2):
+    return abs(f1-f2) < 0.00001 # to test vector scaling
+
+def lists_close(l1,l2):
+    return min( [close(l1[i], l2[i]) for i in range(len(l1))] )
 
 class SumTest(ExtendedTestCase):
 
@@ -174,6 +179,8 @@ class SumTest(ExtendedTestCase):
         self.assertEqual( sol[1] , t2 )
 
     def test_ecl_sum_vector_algebra(self):
+        scalar = 0.78
+
         # setup
         length = 100
         case = createEclSum("CSV" , [("FOPT", None , 0) , ("FOPR" , None , 0), ("FGPT" , None , 0)],
@@ -184,7 +191,10 @@ class SumTest(ExtendedTestCase):
                                           "FOPR" : fopr ,
                                           "FGPT" : fgpt })
         with self.assertRaises( KeyError ):
-            case.solveDays( "MISSING:KEY" , 0.56)
-        sol = case.solveDays( "FOPT" , 150 )
-        x = case
-        x.scaleVector('FOPT' , 0.78)
+            case.scaleVector( "MISSING:KEY" , scalar)
+        for key in case.keys():
+            x = case.get_values(key) # get vector key
+            case.scaleVector(key , scalar)
+            y = case.get_values(key)
+            x = x * scalar # numpy vector scaling
+            self.assertTrue( lists_close(x,y) )


### PR DESCRIPTION
Added ability to scale and shift vectors

* Added `ecl_sum_scale_vector` and `EclSum.scaleVector`
* Added `ecl_sum_shift_vector` and `EclSum.shiftVector`
* removed 'const' from `ecl_sum_data_iget_ministep`
* added functions `ecl_sum_tstep_iscale` and `ecl_sum_tstep_ishift`
* added python tests for scaling and shifting vectors and key testing
