### PR TITLE
Set QT as backend to matplotlib

### DIFF
--- a/devel/python/python/ert_gui/__init__.py
+++ b/devel/python/python/ert_gui/__init__.py
@@ -6,4 +6,14 @@ REQUIRED_VERSION_HEX = 0x02070000
 
 if sys.hexversion < REQUIRED_VERSION_HEX:
     raise Exception("ERT GUI Python requires at least version 2.7 of Python")
-    
+
+import os
+import matplotlib
+
+def headless():
+    return "DISPLAY" not in os.environ
+
+if headless():
+    matplotlib.use("Agg")
+else:
+    matplotlib.use("Qt4Agg")

--- a/devel/python/python/ert_gui/plottery/plots/__init__.py
+++ b/devel/python/python/ert_gui/plottery/plots/__init__.py
@@ -1,14 +1,6 @@
 import os
 import matplotlib
 
-def headless():
-    return "DISPLAY" not in os.environ
-
-if headless():
-    matplotlib.use("Agg")
-else:
-    matplotlib.use("Qt4Agg")
-
 from .histogram import plotHistogram
 from .gaussian_kde import plotGaussianKDE
 


### PR DESCRIPTION
Set QT as backend to matplotlib

When importing matplotlib for the first time, set backend to
QT4.  If plot is imported or called prior to `matplotlib.use()`,
the `.use()` call will be _useless_.