### PR TITLE
smspec_node::get()

### DIFF
--- a/devel/libeclxx/include/ert/ecl/Smspec.hpp
+++ b/devel/libeclxx/include/ert/ecl/Smspec.hpp
@@ -38,6 +38,8 @@ namespace ERT {
             const char* wgname() const;
             const char* keyword() const;
             int num() const;
+            smspec_node_type* get();
+            const smspec_node_type* get() const;
 
         private:
             smspec_node(

--- a/devel/libeclxx/src/Smspec.cpp
+++ b/devel/libeclxx/src/Smspec.cpp
@@ -82,4 +82,12 @@ namespace ERT {
     int smspec_node::num() const {
         return smspec_node_get_num( this->node.get() );
     }
+
+    smspec_node_type* smspec_node::get() {
+        return this->node.get();
+    }
+
+    const smspec_node_type* smspec_node::get() const {
+        return this->node.get();
+    }
 }

--- a/devel/libeclxx/tests/eclxx_smspec.cpp
+++ b/devel/libeclxx/tests/eclxx_smspec.cpp
@@ -29,6 +29,13 @@ void test_smspec_copy() {
     ERT::smspec_node copy( field );
 }
 
+void test_smspec_get() {
+    std::string kw( "FOPT" );
+    ERT::smspec_node field( kw );
+
+    test_assert_true( field.get() != nullptr );
+}
+
 void test_smspec_wg() {
     std::string kw( "WWCT" );
     std::string wg( "OP1" );
@@ -88,6 +95,7 @@ void test_smspec_completion() {
 
 int main (int argc, char **argv) {
     test_smspec_copy();
+    test_smspec_get();
     test_smspec_wg();
     test_smspec_field();
     test_smspec_block();


### PR DESCRIPTION
Forward the unique_ptr::get to the smspec_node class.