### PR TITLE
removes required PythonLibs and PythonInterp

### DIFF
--- a/devel/CMakeLists.txt
+++ b/devel/CMakeLists.txt
@@ -16,22 +16,6 @@ set( ERT_VERSION_MICRO git )
 
 #-----------------------------------------------------------------
 
-
-
-
-
-
-
-include(cmake/python_module.cmake)
-
-# These are some python libraries we depend on
-find_python_module( matplotlib 1.2.0  )
-find_python_module( numpy      1.7.1  )
-find_python_module( pandas     0.15.1 )
-find_python_module( scipy      0.16.1 )
-find_python_module( PyQt4      4.8.0  ) # needed for all GUI
-
-
 option( BUILD_ERT           "Build the full ERT application - Linux only"             OFF)
 option( BUILD_TESTS         "Should the tests be built"                               OFF)
 option( BUILD_APPLICATIONS  "Should we build small utility applications"              OFF)
@@ -39,13 +23,7 @@ option( BUILD_ECL_SUMMARY   "Build the commandline application ecl_summary"     
 option( BUILD_PYTHON        "Run py_compile on the python wrappers"                   ON )
 option( BUILD_SHARED_LIBS   "Build shared libraries"                                  ON )
 option( INSTALL_ERT         "Should anything be installed when issuing make install?" ON )
-
-if (DEFINED PY_PyQt4)
-  option( ERT_BUILD_GUI     "Should the PyQt based GUI be compiled and installed"     OFF)
-else()
-  message(WARNING "Cannot build GUI without PyQt4.  ERT_BUILD_GUI disabled.")
-endif()
-
+option( ERT_BUILD_GUI       "Should the PyQt based GUI be compiled and installed"     OFF)
 option( ERT_USE_OPENMP      "Use OpenMP - currently only in EclGrid"                  OFF)
 option( ERT_DOC             "Build ERT documantation"                                 OFF)
 option( ERT_BUILD_CXX       "Build some CXX wrappers"                                 ON)

--- a/devel/CMakeLists.txt
+++ b/devel/CMakeLists.txt
@@ -21,8 +21,6 @@ set( ERT_VERSION_MICRO git )
 
 
 
-find_package( PythonLibs   2.7 REQUIRED )
-find_package( PythonInterp 2.7 REQUIRED )
 
 include(cmake/python_module.cmake)
 

--- a/devel/python/CMakeLists.txt
+++ b/devel/python/CMakeLists.txt
@@ -1,10 +1,23 @@
 include(cmake/find_python_module.cmake)
+include(cmake/python_module_versions.cmake) # finds version
+
+FIND_PACKAGE(PythonInterp 2.7 REQUIRED)
+
+# These are some python libraries we depend on
+python_module(numpy 1.7.1)
+if(NOT DEFINED PY_numpy)
+  message(SEND_ERROR "numpy is required to use ERT with python")
+endif()
+
 
 if (ERT_BUILD_GUI)
-   FIND_PACKAGE(PythonInterp 2.7 REQUIRED)
-   find_python_module(PyQt4 REQUIRED)
-else()
-   FIND_PACKAGE(PythonInterp 2.7 REQUIRED)     
+   python_module(PyQt4 4.8.0)
+   if(NOT DEFINED PY_PyQt4)
+     message(SEND_ERROR "Cannot build GUI without PyQt4")
+   endif()
+   python_module( matplotlib 1.2.0  )
+   python_module( pandas     0.15.1 )
+   python_module( scipy      0.16.1 )
 endif()
 
 if (EXISTS "/etc/debian_version")

--- a/devel/python/cmake/python_module_versions.cmake
+++ b/devel/python/cmake/python_module_versions.cmake
@@ -1,6 +1,6 @@
 # try import python module, if success, check its version, store as PY_module.
 # the module is imported as-is, hence the case (e.g. PyQt4) must be correct.
-function(find_python_module_version module)
+function(python_module_version module)
   set(PY_VERSION_ACCESSOR "__version__")
   set(PY_module_name ${module})
 
@@ -9,7 +9,7 @@ function(find_python_module_version module)
     set(PY_VERSION_ACCESSOR "PYQT_VERSION_STR")
   endif()
 
-  execute_process(COMMAND "python" "-c"
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
     "import ${PY_module_name} as py_m; print(py_m.${PY_VERSION_ACCESSOR})"
     RESULT_VARIABLE _${module}_fail#    error code 0 if success
     OUTPUT_VARIABLE _${module}_version# major.minor.patch
@@ -25,8 +25,8 @@ endfunction()
 # If we find the correct module and new enough version, set PY_package, where
 # "package" is the given argument to the version we found else, display warning
 # and do not set any variables.
-function(find_python_module package version)
-  find_python_module_version(${package})
+function(python_module package version)
+  python_module_version(${package})
 
   if(NOT DEFINED PY_${package})
     message(WARNING "Could not find Python module " ${package})


### PR DESCRIPTION
Removed the following lines from cmake config.  They are not necessary, and they may cause RH6 build to fail.

```cmake
find_package( PythonLibs   2.7 REQUIRED )
find_package( PythonInterp 2.7 REQUIRED )
```