### PR TITLE
ERT-1060 Fixed a crash related to viewing plots during simulations

### DIFF
--- a/devel/python/python/ert_gui/pages/run_dialog.py
+++ b/devel/python/python/ert_gui/pages/run_dialog.py
@@ -13,11 +13,12 @@ from ert_gui.widgets.simple_progress import SimpleProgress
 
 class RunDialog(QDialog):
 
-    def __init__(self, run_model):
-        QDialog.__init__(self)
+    def __init__(self, run_model, parent):
+        QDialog.__init__(self, parent)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowCloseButtonHint)
         self.setModal(True)
+        self.setWindowModality(Qt.WindowModal)
         self.setWindowTitle("Simulations")
 
         assert isinstance(run_model, RunModelMixin)
@@ -63,7 +64,7 @@ class RunDialog(QDialog):
             ert = run_model.ert()
 
         self.plot_tool = PlotTool(ert)
-        self.plot_tool.setParent(self)
+        self.plot_tool.setParent(None)
         self.plot_button = QPushButton(self.plot_tool.getName())
         self.plot_button.clicked.connect(self.plot_tool.trigger)
         self.plot_button.setEnabled(ert is not None)

--- a/devel/python/python/ert_gui/simulation/simulation_panel.py
+++ b/devel/python/python/ert_gui/simulation/simulation_panel.py
@@ -93,7 +93,7 @@ class SimulationPanel(QWidget):
         if start_simulations == QMessageBox.Yes:
             run_model = self.getCurrentSimulationMode()
 
-            dialog = RunDialog(run_model)
+            dialog = RunDialog(run_model, self)
             dialog.startSimulation()
             dialog.exec_()
 


### PR DESCRIPTION
Viewing plots during simulations and then clicking done while the plotting windows was still open resulted in a fatal crash.
Changed modality and parent of the plotting window so that the open plotting window did not loose its parent at runtime.