### PR TITLE
Ecl file set parent

### DIFF
--- a/python/python/ert/config/config_content.py
+++ b/python/python/ert/config/config_content.py
@@ -1,18 +1,18 @@
-#  Copyright (C) 2015  Statoil ASA, Norway. 
-#   
-#  The file 'config_content.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2015  Statoil ASA, Norway.
+#
+#  The file 'config_content.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 
 import os.path
 
@@ -55,17 +55,17 @@ class ContentNode(BaseCClass):
         if isinstance(index, int):
             if index < 0:
                 index += len(self)
-                
+
             if not 0 <= index < len(self):
                 raise IndexError
             return index
         else:
             raise TypeError("Invalid argument type: %s" % index)
 
-                
+
     def __getitem__(self, index):
         index = self.__assertIndex(index)
-        
+
         content_type = self._iget_type(index)
         typed_get = self.typed_get[content_type]
         return typed_get(self, index)
@@ -84,7 +84,7 @@ class ContentNode(BaseCClass):
                     return os.path.relpath( abs_path , relative_start )
         else:
             raise TypeError("The getPath() method can only be called on PATH items")
-        
+
     def content(self, sep=" "):
         return self._get_full_string(sep)
 
@@ -167,12 +167,12 @@ class ConfigContent(BaseCClass):
     def getValue(self , key , item_index = -1 , node_index = 0):
         item = self[key]
         return item.getValue( item_index , node_index )
-        
+
 
     def isValid(self):
         return self._is_valid()
 
-        
+
     def free(self):
         self._free()
 

--- a/python/python/ert/ecl/ecl_file.py
+++ b/python/python/ert/ecl/ecl_file.py
@@ -1,18 +1,18 @@
-#  Copyright (C) 2011  Statoil ASA, Norway. 
-#   
-#  The file 'ecl_file.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2011  Statoil ASA, Norway.
+#
+#  The file 'ecl_file.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 """
 The ecl_file module contains functionality to load a an ECLIPSE file
 in 'restart format'. Files of 'restart format' include restart files,
@@ -74,13 +74,13 @@ class EclFile(BaseCClass):
     _has_sim_time                = EclPrototype("bool        ecl_file_has_sim_time( ecl_file , time_t )")
 
 
-    
+
     @staticmethod
     def getFileType(filename):
         fmt_file    = ctypes.c_bool()
         report_step = ctypes.c_int()
 
-        file_type = EclFile._get_file_type( filename , ctypes.byref( fmt_file ) , ctypes.byref(report_step)) 
+        file_type = EclFile._get_file_type( filename , ctypes.byref( fmt_file ) , ctypes.byref(report_step))
         if file_type in [EclFileEnum.ECL_RESTART_FILE , EclFileEnum.ECL_SUMMARY_FILE]:
             report_step = report_step.value
         else:
@@ -94,7 +94,7 @@ class EclFile(BaseCClass):
 
         return (file_type , report_step , fmt_file )
 
-    
+
 
     @classmethod
     def restart_block( cls , filename , dtime = None , report_step = None):
@@ -107,7 +107,7 @@ class EclFile(BaseCClass):
         specified with either one of the optional arguments
         @report_step or @dtime. If present @dtime should be a normal
         python datetime instance:
-        
+
             block1 = EclFile.restart_block( "ECLIPSE.UNRST" , dtime = datetime.datetime( year , month , day ))
             block2 = EclFile.restart_block( "ECLIPSE.UNRST" , report_step = 67 )
 
@@ -115,21 +115,21 @@ class EclFile(BaseCClass):
         will return None.
         """
         obj = EclFile( filename )
-        
+
         if dtime:
             OK = obj._restart_block_time( CTime( dtime ))
         elif not report_step is None:
             OK = obj._restart_block_step( report_step )
         else:
             raise TypeError("restart_block() requires either dtime or report_step argument - none given.")
-        
+
         if not OK:
             if dtime:
                 raise ValueError("Could not locate date:%02d/%02d/%4d in restart file: %s." % (dtime.day , dtime.month , dtime.year , filename))
             else:
                 raise ValueError("Could not locate report step:%d in restart file: %s." % (report_step , filename))
-            
-            
+
+
         return obj
 
 
@@ -149,14 +149,14 @@ class EclFile(BaseCClass):
               print "OK - file contains report step 20"
            else:
               print "File does not contain report step 20"
-              
+
         If you have already loaded the file into an EclFile instance
         you should use the has_report_step() method instead.
         """
         obj = EclFile( filename )
         return obj.has_report_step( report_step )
 
-    
+
     @classmethod
     def contains_sim_time( cls , filename , dtime ):
         """
@@ -179,7 +179,7 @@ class EclFile(BaseCClass):
         """
         obj = EclFile( filename )
         return obj.has_sim_time( dtime )
-    
+
     @property
     def report_list(self):
         report_steps = []
@@ -198,33 +198,33 @@ class EclFile(BaseCClass):
             else:
                 raise TypeError("Tried get list of report steps from file:%s - which is not a restart file" % fname)
 
-            
+
         return report_steps
 
 
-    
+
     @classmethod
     def file_report_list( cls , filename ):
         """
         Will identify the available report_steps from @filename.
         """
-        
+
         file = EclFile( filename )
         return file.report_list
 
-        
+
 
     def __str__(self):
         return "EclFile: %s" % self.getFilename( )
 
-        
+
     def __init__( self , filename , flags = 0):
         """
         Loads the complete file @filename.
 
         Will create a new EclFile instance with the content of file
         @filename. The file @filename must be in 'restart format' -
-        otherwise it will be crash and burn. 
+        otherwise it will be crash and burn.
 
         The optional argument flags can be an or'ed combination of the
         flags:
@@ -236,7 +236,7 @@ class EclFile(BaseCClass):
               when not used; to save number of open file descriptors
               in cases where a high number of EclFile instances are
               open concurrently.
-        
+
         When the file has been loaded the EclFile instance can be used
         to query for and get reference to the EclKW instances
         constituting the file, like e.g. SWAT from a restart file or
@@ -247,7 +247,7 @@ class EclFile(BaseCClass):
             raise IOError("Failed to open file file:%s" % filename)
         else:
             super(EclFile , self).__init__(c_ptr)
-        
+
 
 
     def save_kw( self , kw ):
@@ -261,10 +261,10 @@ class EclFile(BaseCClass):
           3. Call this method to save the modifications to disk.
 
         There are several restrictions to the use of this function:
-        
+
           1. The EclFile instance must have been created with the
              optional read_only flag set to False.
- 
+
           2. You can only modify the content of the keyword; if you
              try to modify the header in any way (i.e. size, datatype
              or name) the function will fail.
@@ -277,11 +277,11 @@ class EclFile(BaseCClass):
             self._save_kw(  kw )
         else:
             raise IOError("save_kw: the file:%s has been opened read only." % self.getFilename( ))
-        
+
 
     def __len__(self):
         return self._get_size( )
-    
+
 
     def close(self):
         if self:
@@ -291,13 +291,13 @@ class EclFile(BaseCClass):
 
     def free(self):
         self.close()
-        
+
 
     def select_block( self, kw , kw_index):
         OK = self._select_block( kw , kw_index )
         if not OK:
             raise ValueError("Could not find block %s:%d" % (kw , kw_index))
-        
+
 
     def select_global( self ):
         self._select_global(  )
@@ -306,16 +306,16 @@ class EclFile(BaseCClass):
     def select_restart_section( self, index = None , report_step = None , sim_time = None):
         """
         Will select a restart section as the active section.
-        
+
         You must specify a report step with the @report_step argument,
         a true time with the @sim_time argument or a plain index to
         select restart block. If none of arguments are given exception
         TypeError will be raised. If present the @sim_time argument
         should be a datetime instance.
-        
+
         If the restart section you ask for can not be found the method
         will raise a ValueError exeception. To protect against this
-        you can query first with the has_report_step(), 
+        you can query first with the has_report_step(),
         has_sim_time() or num_report_steps() methods.
 
         This method should be used when you have already loaded the
@@ -336,11 +336,11 @@ class EclFile(BaseCClass):
         else:
             raise TypeError("select_restart_section() requires either dtime or report_step argument - none given")
 
-        
+
         if not OK:
             raise TypeError("select_restart_section() Could not locate report_step/dtime")
         return self
-        
+
 
     def select_last_restart( self ):
         """
@@ -401,7 +401,7 @@ class EclFile(BaseCClass):
             else:
                 kw = self.__iget( index )
                 return kw
-            
+
         if isinstance( index , slice ):
             indices = index.indices( len(self) )
             kw_list = []
@@ -420,13 +420,13 @@ class EclFile(BaseCClass):
                     raise KeyError("Unrecognized keyword:\'%s\'" % index)
             else:
                 raise TypeError("Index must be integer or string (keyword)")
-        
+
 
 
     def iget_kw( self , index , copy = False):
         """
         Will return EclKW instance nr @index.
-        
+
         In the files loaded with the EclFile implementation the
         ECLIPSE keywords come sequentially in a long series, an INIT
         file might have the following keywords:
@@ -434,17 +434,17 @@ class EclFile(BaseCClass):
           INTEHEAD
           LOGIHEAD
           DOUBHEAD
-          PORV    
-          DX      
-          DY      
-          DZ      
-          PERMX   
-          PERMY   
-          PERMZ   
-          MULTX   
-          MULTY   
+          PORV
+          DX
+          DY
+          DZ
+          PERMX
+          PERMY
+          PERMZ
+          MULTX
+          MULTY
           .....
-          
+
         The iget_kw() method will give you a EclKW reference to
         keyword nr @index. This functionality is also available
         through the index operator []:
@@ -465,20 +465,20 @@ class EclFile(BaseCClass):
             return EclKW.copy( kw )
         else:
             return kw
-  
-  
+
+
     def iget_named_kw( self , kw_name , index , copy = False):
         """
         Will return EclKW nr @index reference with header @kw_name.
-        
+
         The keywords in a an ECLIPSE file are organized in a long
         linear array; keywords with the same name can occur many
         times. For instance a summary data[1] file might look like
         this:
 
-           SEQHDR  
+           SEQHDR
            MINISTEP
-           PARAMS  
+           PARAMS
            MINISTEP
            PARAMS
            MINISTEP
@@ -486,17 +486,17 @@ class EclFile(BaseCClass):
            ....
 
         To get the third 'PARAMS' keyword you can use the method call:
-  
+
             params_kw = file.iget_named_kw( "PARAMS" , 2 )
 
         The functionality of the iget_named_kw() method is also
         available through the __getitem__() method as:
-        
+
            params_kw = file["PARAMS"][2]
 
         Observe that the returned EclKW instance is only a reference
         to the data owned by the EclFile instance.
-        
+
         Observe that syntactically this is equivalent to
         file[kw_name][index], however the latter form will imply that
         all the keywords of this type are loaded from the file. If you
@@ -576,7 +576,7 @@ class EclFile(BaseCClass):
         into it means that this is quite low level - and potentially
         dangerous!
         """
-        
+
         # We ensure that this scope owns the new_kw instance; the
         # new_kw will be handed over to the ecl_file instance, and we
         # can not give away something we do not alreeady own.
@@ -614,8 +614,8 @@ class EclFile(BaseCClass):
             kw = self[index]
             header_dict[ kw.name ] = True
         return header_dict.keys()
-    
-    
+
+
     @property
     def headers(self):
         """
@@ -626,7 +626,7 @@ class EclFile(BaseCClass):
             kw = self[index]
             header_list.append( kw.header )
         return header_list
-    
+
     @property
     def report_steps( self ):
         """
@@ -642,16 +642,16 @@ class EclFile(BaseCClass):
         for kw in self["SEQNUM"]:
             steps.append( kw[0] )
         return steps
-    
+
     @property
     def report_dates( self ):
         """
         Will return a list of the dates for all report steps.
-        
+
         The method works by iterating through the whole restart file
         looking for 'SEQNUM/INTEHEAD' keywords; the method can
         probably be tricked by other file types also containing an
-        INTEHEAD keyword. 
+        INTEHEAD keyword.
         """
         dates = []
         if self.has_kw('SEQNUM'):
@@ -667,7 +667,7 @@ class EclFile(BaseCClass):
             date = datetime.datetime( year , month , day )
             dates = [ date ]
         return dates
-    
+
 
     @property
     def dates( self ):
@@ -675,7 +675,7 @@ class EclFile(BaseCClass):
         Will return a list of the dates for all report steps.
         """
         return self.report_dates
-    
+
 
     def num_named_kw( self , kw):
         """
@@ -724,8 +724,8 @@ class EclFile(BaseCClass):
         much higher than the return value from this function.
         """
         return len( self["SEQNUM"] )
-    
-    
+
+
 
     def has_sim_time( self , dtime ):
         """
@@ -737,9 +737,9 @@ class EclFile(BaseCClass):
         keyword(s), but is still not a restart file. The @dtime
         argument should be a normal python datetime instance.
         """
-        return self._has_sim_time( CTime(dtime) )    
+        return self._has_sim_time( CTime(dtime) )
 
-    
+
     def iget_restart_sim_time( self , index ):
         """
         Will locate restart block nr @index and return the true time
@@ -753,9 +753,9 @@ class EclFile(BaseCClass):
         """
         Will locate restart block nr @index and return the number of days
         (in METRIC at least ...) since the simulation started.
-        
+
         """
-        return self._iget_restart_days( index ) 
+        return self._iget_restart_days( index )
 
 
     def getFilename(self):
@@ -763,14 +763,14 @@ class EclFile(BaseCClass):
         Name of the file currently loaded.
         """
         return self._get_src_file( )
-    
+
 
     @property
     def name(self):
         warnings.warn("The name property is deprecated - use getFilename( )" , DeprecationWarning)
         return self.getFilename()
 
-    
+
     def fwrite( self , fortio ):
         """
         Will write current EclFile instance to fortio stream.
@@ -779,13 +779,13 @@ class EclFile(BaseCClass):
         Fortran IO must be used when reading and writing these files.
         This method will write the current EclFile instance to a
         FortIO stream already opened for writing:
-        
+
            import ert.ecl.ecl as ecl
            ...
            fortio = ecl.FortIO( "FILE.XX" )
            file.fwrite( fortio )
            fortio.close()
-           
+
         """
         self._fwrite(  fortio , 0 )
 
@@ -794,17 +794,17 @@ class EclFileContextManager(object):
 
     def __init__(self , ecl_file):
         self.__ecl_file = ecl_file
-    
+
     def __enter__(self):
         return self.__ecl_file
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.__ecl_file.close()
-        return False          
+        return False
 
 
 def openEclFile( file_name , flags = 0):
     return EclFileContextManager( EclFile( file_name , flags ))
-    
+
 
 

--- a/python/python/ert/ecl/ecl_file.py
+++ b/python/python/ert/ecl/ecl_file.py
@@ -358,6 +358,15 @@ class EclFile(BaseCClass):
             return False
 
 
+    def __iget(self , index):
+        return self._iget_kw( index ).setParent( parent = self )
+
+
+    def __iget_named(self, kw_name , index):
+        return self._iget_named_kw( kw_name , index ).setParent( parent = self )
+
+
+
     def __getitem__(self , index):
         """
         Implements [] operator; index can be integer or key.
@@ -390,7 +399,7 @@ class EclFile(BaseCClass):
             if index < 0 or index >= len(self):
                 raise IndexError
             else:
-                kw = self._iget_kw( index )
+                kw = self.__iget( index )
                 return kw
             
         if isinstance( index , slice ):
@@ -498,7 +507,7 @@ class EclFile(BaseCClass):
              using the EclSum class.
         """
         if index < self.num_named_kw( kw_name ):
-            kw = self._iget_named_kw( kw_name , index )
+            kw = self.__iget_named( kw_name , index )
             if copy:
                 return EclKW.copy( kw )
             else:

--- a/python/python/ert/ecl/ecl_sum.py
+++ b/python/python/ert/ecl/ecl_sum.py
@@ -191,13 +191,14 @@ class EclSum(BaseCClass):
 
 
     def addVariable(self , variable , wgname = None , num = 0 , unit = "None" , default_value = 0):
-        return self._add_variable(variable , wgname , num , unit , default_value)
+        return self._add_variable(variable , wgname , num , unit , default_value).setParent( parent = self )
 
 
     def addTStep(self , report_step , sim_days):
         """ @rtype: EclSumTStep """
         sim_seconds = sim_days * 24 * 60 * 60
-        return self._add_tstep( report_step, sim_seconds)
+        return self._add_tstep( report_step, sim_seconds).setParent( parent = self )
+
 
 
     def __private_init(self):

--- a/python/python/ert/geo/cpolyline_collection.py
+++ b/python/python/ert/geo/cpolyline_collection.py
@@ -112,6 +112,7 @@ class CPolylineCollection(BaseCClass):
             raise KeyError("The polyline collection already has an object:%s" % name)
             
         polyline = self._create_polyline(name)
+        polyline.setParent( parent = self )
         return polyline
 
 

--- a/python/tests/core/ecl/CMakeLists.txt
+++ b/python/tests/core/ecl/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TEST_SOURCES
     __init__.py
     test_deprecation.py
     test_ecl_3dkw.py
-    test_ecl_file.py
+    test_ecl_file_statoil.py
     test_ecl_init_file.py
     test_ecl_restart_file.py
     test_ecl_submit.py
@@ -57,7 +57,7 @@ addPythonTest(ecl.fortio ecl.test_fortio.FortIOTest)
 
 
 if (STATOIL_TESTDATA_ROOT)
-  addPythonTest(ecl.ecl_file ecl.test_ecl_file.EclFileTest LABELS StatoilData)
+  addPythonTest(ecl.ecl_file_statoil ecl.test_ecl_file_statoil.EclFileStatoilTest LABELS StatoilData)
   addPythonTest(ecl.ecl_grdecl ecl.test_grdecl.GRDECLTest LABELS StatoilData)
   addPythonTest(ecl.ecl_grid_statoil ecl.test_grid_statoil.GridTest LABELS StatoilData:Slow)
   addPythonTest(ecl.ecl_kw_statoil ecl.test_ecl_kw_statoil.KWTest LABELS StatoilData)

--- a/python/tests/core/ecl/CMakeLists.txt
+++ b/python/tests/core/ecl/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SOURCES
     test_deprecation.py
     test_ecl_3dkw.py
     test_ecl_file_statoil.py
+    test_ecl_file.py
     test_ecl_init_file.py
     test_ecl_restart_file.py
     test_ecl_submit.py
@@ -54,7 +55,7 @@ addPythonTest(ecl.ecl_deprecation1.9 ecl.test_deprecation.Deprecation_1_9_Test )
 addPythonTest(ecl.ecl_deprecation2.0 ecl.test_deprecation.Deprecation_2_0_Test )
 addPythonTest(ecl.ecl_util ecl.test_ecl_util.EclUtilTest )
 addPythonTest(ecl.fortio ecl.test_fortio.FortIOTest)
-
+addPythonTest(ecl.ecl_file ecl.test_ecl_file.EclFileTest)
 
 if (STATOIL_TESTDATA_ROOT)
   addPythonTest(ecl.ecl_file_statoil ecl.test_ecl_file_statoil.EclFileStatoilTest LABELS StatoilData)

--- a/python/tests/core/ecl/test_ecl_file.py
+++ b/python/tests/core/ecl/test_ecl_file.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+#  Copyright (C) 2011  Statoil ASA, Norway. 
+#   
+#  The file 'sum_test.py' is part of ERT - Ensemble based Reservoir Tool. 
+#   
+#  ERT is free software: you can redistribute it and/or modify 
+#  it under the terms of the GNU General Public License as published by 
+#  the Free Software Foundation, either version 3 of the License, or 
+#  (at your option) any later version. 
+#   
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+#  FITNESS FOR A PARTICULAR PURPOSE.   
+#   
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  for more details.
+import datetime
+import os.path
+from unittest import skipIf
+
+from ert.ecl import EclFile, FortIO, EclKW , openFortIO , openEclFile
+from ert.ecl import EclFileFlagEnum, EclTypeEnum, EclFileEnum
+
+from ert.test import ExtendedTestCase , TestAreaContext
+
+
+    
+
+class EclFileTest(ExtendedTestCase):
+
+    def assertFileType(self , filename , expected):
+        file_type , step , fmt_file = EclFile.getFileType(filename)
+        self.assertEqual( file_type , expected[0] )
+        self.assertEqual( fmt_file , expected[1] )
+        self.assertEqual( step , expected[2] )
+
+        
+    def test_file_type(self):
+        self.assertFileType( "ECLIPSE.UNRST" , (EclFileEnum.ECL_UNIFIED_RESTART_FILE , False , None))
+        self.assertFileType( "ECLIPSE.X0030" , (EclFileEnum.ECL_RESTART_FILE , False , 30 ))
+        self.assertFileType( "ECLIPSE.DATA"  , (EclFileEnum.ECL_DATA_FILE , None , None ))
+        self.assertFileType( "ECLIPSE.FINIT" , (EclFileEnum.ECL_INIT_FILE , True , None ))
+        self.assertFileType( "ECLIPSE.A0010" , (EclFileEnum.ECL_SUMMARY_FILE , True , 10 ))
+        self.assertFileType( "ECLIPSE.EGRID" , (EclFileEnum.ECL_EGRID_FILE , False  , None ))
+
+        
+    def test_IOError(self):
+        with self.assertRaises(IOError):
+            EclFile("No/Does/not/exist")
+
+
+    def test_context( self ):
+        with TestAreaContext("python/ecl_file/context"):
+            kw1 = EclKW.create( "KW1" , 100 , EclTypeEnum.ECL_INT_TYPE)
+            kw2 = EclKW.create( "KW2" , 100 , EclTypeEnum.ECL_INT_TYPE)
+            with openFortIO("TEST" , mode = FortIO.WRITE_MODE) as f:
+                kw1.fwrite( f )
+                kw2.fwrite( f )
+
+            with openEclFile("TEST") as ecl_file:
+                self.assertEqual( len(ecl_file) , 2 )
+                self.assertTrue( ecl_file.has_kw("KW1"))
+                self.assertTrue( ecl_file.has_kw("KW2"))
+
+        
+                
+                
+        
+            

--- a/python/tests/core/ecl/test_ecl_file_statoil.py
+++ b/python/tests/core/ecl/test_ecl_file_statoil.py
@@ -26,7 +26,7 @@ from ert.test import ExtendedTestCase , TestAreaContext
 
     
 
-class EclFileTest(ExtendedTestCase):
+class EclFileStatoilTest(ExtendedTestCase):
     def setUp(self):
         self.test_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.UNRST")
         self.test_fmt_file = self.createTestPath("Statoil/ECLIPSE/Gurbat/ECLIPSE.FUNRST")

--- a/python/tests/core/ecl/test_ecl_file_statoil.py
+++ b/python/tests/core/ecl/test_ecl_file_statoil.py
@@ -39,15 +39,6 @@ class EclFileStatoilTest(ExtendedTestCase):
 
         
         
-    def test_file_type(self):
-        self.assertFileType( "ECLIPSE.UNRST" , (EclFileEnum.ECL_UNIFIED_RESTART_FILE , False , None))
-        self.assertFileType( "ECLIPSE.X0030" , (EclFileEnum.ECL_RESTART_FILE , False , 30 ))
-        self.assertFileType( "ECLIPSE.DATA" , (EclFileEnum.ECL_DATA_FILE , None , None ))
-        self.assertFileType( "ECLIPSE.FINIT" , (EclFileEnum.ECL_INIT_FILE , True , None ))
-        self.assertFileType( "ECLIPSE.A0010" , (EclFileEnum.ECL_SUMMARY_FILE , True , 10 ))
-        self.assertFileType( "ECLIPSE.EGRID" , (EclFileEnum.ECL_EGRID_FILE , False  , None ))
-
-        
     def test_restart_days(self):
         rst_file = EclFile( self.test_file )
         self.assertAlmostEqual(  0.0 , rst_file.iget_restart_sim_days(0) )
@@ -61,12 +52,6 @@ class EclFileStatoilTest(ExtendedTestCase):
             rst_file.restart_get_kw("SWAT" , dtime = datetime.date( 1985 , 1 , 1))
             
             
-
-
-    def test_IOError(self):
-        with self.assertRaises(IOError):
-            EclFile("No/Does/not/exist")
-
 
     def test_iget_named(self):
         f = EclFile(self.test_file)
@@ -87,20 +72,6 @@ class EclFileStatoilTest(ExtendedTestCase):
             self.assertFilesAreEqual("ECLIPSE.UNRST", self.test_file)
 
 
-    def test_context( self ):
-        with TestAreaContext("python/ecl_file/context"):
-            kw1 = EclKW.create( "KW1" , 100 , EclTypeEnum.ECL_INT_TYPE)
-            kw2 = EclKW.create( "KW2" , 100 , EclTypeEnum.ECL_INT_TYPE)
-            with openFortIO("TEST" , mode = FortIO.WRITE_MODE) as f:
-                kw1.fwrite( f )
-                kw2.fwrite( f )
-
-            with openEclFile("TEST") as ecl_file:
-                self.assertEqual( len(ecl_file) , 2 )
-                self.assertTrue( ecl_file.has_kw("KW1"))
-                self.assertTrue( ecl_file.has_kw("KW2"))
-
-        
 
 
     @skipIf(ExtendedTestCase.slowTestShouldNotRun(), "Slow file test skipped!")


### PR DESCRIPTION
The most important commit here is: c56d0d0 which fixes a real bug with dangling EclKW instances when the parent EclFile goes out of scope. This worked before :-(

Tried some a slightly more magic approach based on Metaclasses - but that failed.
