### PR TITLE
Add nnc index to the information exported by ecl_nnc_export().

### DIFF
--- a/libecl/include/ert/ecl/ecl_nnc_export.h
+++ b/libecl/include/ert/ecl/ecl_nnc_export.h
@@ -38,7 +38,7 @@ typedef struct {
   int grid_nr2;
   int global_index2;
 
-  int nnc_index;
+  int input_index; /* corresponds to the input ordering of this nnc */
 
   double trans;
 } ecl_nnc_type;

--- a/libecl/include/ert/ecl/ecl_nnc_export.h
+++ b/libecl/include/ert/ecl/ecl_nnc_export.h
@@ -38,6 +38,8 @@ typedef struct {
   int grid_nr2;
   int global_index2;
 
+  int nnc_index;
+
   double trans;
 } ecl_nnc_type;
 

--- a/libecl/src/ecl_nnc_export.c
+++ b/libecl/src/ecl_nnc_export.c
@@ -64,9 +64,9 @@ static int  ecl_nnc_export__( const ecl_grid_type * grid , int lgr_index1 , cons
 
         for (index2 = 0; index2 < nnc_vector_get_size( nnc_vector ); index2++) {
           nnc.global_index2 = int_vector_iget( grid2_index_list , index2 );
-          nnc.nnc_index = int_vector_iget( nnc_index_list, index2 );
+          nnc.input_index = int_vector_iget( nnc_index_list, index2 );
           if(tran_kw) {
-            nnc.trans = ecl_kw_iget_as_double(tran_kw, int_vector_iget(nnc_index_list, index2));
+            nnc.trans = ecl_kw_iget_as_double(tran_kw, nnc.input_index);
             valid_trans++;
           }else{
             nnc.trans = ERT_ECL_DEFAULT_NNC_TRANS;

--- a/libecl/src/ecl_nnc_export.c
+++ b/libecl/src/ecl_nnc_export.c
@@ -64,6 +64,7 @@ static int  ecl_nnc_export__( const ecl_grid_type * grid , int lgr_index1 , cons
 
         for (index2 = 0; index2 < nnc_vector_get_size( nnc_vector ); index2++) {
           nnc.global_index2 = int_vector_iget( grid2_index_list , index2 );
+          nnc.nnc_index = int_vector_iget( nnc_index_list, index2 );
           if(tran_kw) {
             nnc.trans = ecl_kw_iget_as_double(tran_kw, int_vector_iget(nnc_index_list, index2));
             valid_trans++;


### PR DESCRIPTION
This is necessary and sufficient to recover original nnc ordering for the purpose of reading connection fluxes for example, in the absence of local grid refinement.

For the LGR case more information (such as keyword) will be required.