### PR TITLE
Allow max CV FOLD to be the number of ensembles 

### DIFF
--- a/libanalysis/src/fwd_step_enkf.c
+++ b/libanalysis/src/fwd_step_enkf.c
@@ -251,7 +251,7 @@ void fwd_step_enkf_updateA(void * module_data ,
     int num_kw     =  module_data_block_vector_get_size(data_block_vector);
 
 
-    if ( ens_size <= nfolds)
+    if ( ens_size < nfolds)
       util_abort("%s: The number of ensembles must be larger than the CV fold - aborting\n", __func__);
 
 

--- a/python/python/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
+++ b/python/python/ert_gui/ertwidgets/models/analysismodulevariablesmodel.py
@@ -53,7 +53,7 @@ class AnalysisModuleVariablesModel(object):
     @classmethod
     def getVariableMaximumValue(cls, name):
         if name == "CV_NFOLDS":
-            return getRealizationCount() - 1
+            return getRealizationCount() 
 
         return cls._VARIABLE_NAMES[name]["max"]
 


### PR DESCRIPTION
We want to be able to run a especial case of fwd step when there is only one CV block. In practice this means that no cross-validation will be done.