### PR TITLE
Min realizations fix

### DIFF
--- a/libecl/src/ecl_grid.c
+++ b/libecl/src/ecl_grid.c
@@ -3283,7 +3283,7 @@ static bool ecl_grid_file_GRID_dims( fortio_type * grid_fortio , fortio_type * d
           dims[3] = nactive;
 
    The function as a whole will return true if the grid dimensions
-   (nx,ny,nz) are sucessfully set. If the dimensions are not set the
+   (nx,ny,nz) are successfully set. If the dimensions are not set the
    dims vector is not touched.
 */
 

--- a/libenkf/applications/ert_tui/main.c
+++ b/libenkf/applications/ert_tui/main.c
@@ -78,7 +78,7 @@ void enkf_usage() {
   printf(" **                            E R T                                **\n");
   printf(" **                                                                 **\n");
   printf(" **-----------------------------------------------------------------**\n");
-  printf(" ** You have sucessfully started the ert program developed at       **\n");
+  printf(" ** You have successfully started the ert program developed at       **\n");
   printf(" ** Statoil. Before you can actually start using the program, you   **\n");
   printf(" ** must create a configuration file. When the configuration file   **\n");
   printf(" ** has been created, you can start the ert application with:       **\n");

--- a/libenkf/applications/ert_tui/main.c
+++ b/libenkf/applications/ert_tui/main.c
@@ -78,7 +78,7 @@ void enkf_usage() {
   printf(" **                            E R T                                **\n");
   printf(" **                                                                 **\n");
   printf(" **-----------------------------------------------------------------**\n");
-  printf(" ** You have successfully started the ert program developed at       **\n");
+  printf(" ** You have successfully started the ert program developed at      **\n");
   printf(" ** Statoil. Before you can actually start using the program, you   **\n");
   printf(" ** must create a configuration file. When the configuration file   **\n");
   printf(" ** has been created, you can start the ert application with:       **\n");

--- a/libenkf/include/ert/enkf/analysis_config.h
+++ b/libenkf/include/ert/enkf/analysis_config.h
@@ -100,8 +100,6 @@ void                   analysis_config_set_PC_filename( analysis_config_type * c
 const char           * analysis_config_get_PC_filename( const analysis_config_type * config );
 void                   analysis_config_set_PC_path( analysis_config_type * config , const char * path );
 const char           * analysis_config_get_PC_path( const analysis_config_type * config );
-void                   analysis_config_set_min_realisations( analysis_config_type * config , int min_realisations);
-int                    analysis_config_get_min_realisations( const analysis_config_type * config );
 bool                   analysis_config_have_enough_realisations( const analysis_config_type* config, int realisations, int ensemble_size);
 void                   analysis_config_set_stop_long_running( analysis_config_type * config, bool stop_long_running );
 bool                   analysis_config_get_stop_long_running( const analysis_config_type * config);

--- a/libenkf/include/ert/enkf/analysis_config.h
+++ b/libenkf/include/ert/enkf/analysis_config.h
@@ -102,7 +102,7 @@ void                   analysis_config_set_PC_path( analysis_config_type * confi
 const char           * analysis_config_get_PC_path( const analysis_config_type * config );
 void                   analysis_config_set_min_realisations( analysis_config_type * config , int min_realisations);
 int                    analysis_config_get_min_realisations( const analysis_config_type * config );
-bool                   analysis_config_have_enough_realisations( const analysis_config_type * config , int realisations);
+bool                   analysis_config_have_enough_realisations( const analysis_config_type* config, int realisations, int ensemble_size);
 void                   analysis_config_set_stop_long_running( analysis_config_type * config, bool stop_long_running );
 bool                   analysis_config_get_stop_long_running( const analysis_config_type * config);
 void                   analysis_config_set_max_runtime( analysis_config_type * config, int max_runtime  );

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -108,7 +108,7 @@ extern "C" {
   bool                          enkf_main_UPDATE(enkf_main_type * enkf_main , const int_vector_type * step_list, enkf_fs_type * source_fs, enkf_fs_type * target_fs , int target_step , run_mode_type run_mode);
   bool                          enkf_main_smoother_update(enkf_main_type * enkf_main , enkf_fs_type * source_fs, enkf_fs_type * target_fs);
   void                          enkf_main_create_run_path(enkf_main_type * enkf_main , const bool_vector_type * iactive , int iter);
-  bool                          enkf_main_run_simple_step(enkf_main_type * enkf_main , bool_vector_type * iactive , init_mode_type init_mode, int iter);
+  int                           enkf_main_run_simple_step( enkf_main_type* enkf_main, bool_vector_type* iactive, init_mode_type init_mode, int iter );
 
   void                          enkf_main_run_tui_exp(enkf_main_type * enkf_main ,
                                                       bool_vector_type * iactive);

--- a/libenkf/src/analysis_config.c
+++ b/libenkf/src/analysis_config.c
@@ -125,7 +125,7 @@ ANALYSIS_SELECT  ModuleName
 
 /*****************************************************************/
 
-bool analysis_config_have_enough_realisations( const analysis_config_type * config , int realisations) {
+bool analysis_config_have_enough_realisations( const analysis_config_type * config , int realisations, int ensemble_size) {
   if (config->min_realisations > 0) {
     /* A value > 0 has been set in the config; compare with this value. */
     if (realisations >= config->min_realisations)
@@ -133,8 +133,8 @@ bool analysis_config_have_enough_realisations( const analysis_config_type * conf
       else
         return false;
   } else {
-    /* No value has been set in the config; just compare the input with zero. */
-    if (realisations > 0)
+    /* The min_realizations is set to zero, so rather check that the number of realizations is equal to the given ensemble_size */
+    if (realisations == ensemble_size)
       return true;
     else
       return false;

--- a/libenkf/src/analysis_config.c
+++ b/libenkf/src/analysis_config.c
@@ -128,16 +128,10 @@ ANALYSIS_SELECT  ModuleName
 bool analysis_config_have_enough_realisations( const analysis_config_type * config , int realisations, int ensemble_size) {
   if (config->min_realisations > 0) {
     /* A value > 0 has been set in the config; compare with this value. */
-    if (realisations >= config->min_realisations)
-        return true;
-      else
-        return false;
-  } else {
-    /* The min_realizations is set to zero, so rather check that the number of realizations is equal to the given ensemble_size */
-    if (realisations >= ensemble_size)
-      return true;
-    else
-      return false;
+    return realisations >= config->min_realisations;
+  } 
+  else {
+    return realisations >= ensemble_size;
   }
 }
 

--- a/libenkf/src/analysis_config.c
+++ b/libenkf/src/analysis_config.c
@@ -134,7 +134,7 @@ bool analysis_config_have_enough_realisations( const analysis_config_type * conf
         return false;
   } else {
     /* The min_realizations is set to zero, so rather check that the number of realizations is equal to the given ensemble_size */
-    if (realisations == ensemble_size)
+    if (realisations >= ensemble_size)
       return true;
     else
       return false;
@@ -173,12 +173,8 @@ void analysis_config_set_max_runtime( analysis_config_type * config, int max_run
   config->max_runtime = max_runtime;
 }
 
-void analysis_config_set_min_realisations( analysis_config_type * config , int min_realisations) {
+static void analysis_config_set_min_realisations( analysis_config_type * config , int min_realisations) {
   config->min_realisations = min_realisations;
-}
-
-int analysis_config_get_min_realisations( const analysis_config_type * config ) {
-  return config->min_realisations;
 }
 
 void analysis_config_set_alpha( analysis_config_type * config , double alpha) {
@@ -482,21 +478,26 @@ void analysis_config_init( analysis_config_type * analysis , const config_conten
     analysis_config_set_rerun_start( analysis , config_content_get_value_as_int( config , RERUN_START_KEY ));
 
   if (config_content_has_item( config , MIN_REALIZATIONS_KEY )) {
-    double percent                            = 0.0;
+    
     config_content_node_type * config_content = config_content_get_value_node(config , MIN_REALIZATIONS_KEY);
     char * min_realizations_string            = config_content_node_alloc_joined_string(config_content, " ");
-
+    
+    int num_realizations = config_content_get_value_as_int(config, NUM_REALIZATIONS_KEY);
+    int min_realizations                      = DEFAULT_ANALYSIS_MIN_REALISATIONS;
+    double percent                            = 0.0;
     if (util_sscanf_percent(min_realizations_string, &percent)) {
-      int num_realizations = config_content_get_value_as_int(config, NUM_REALIZATIONS_KEY);
-      int min_realizations = num_realizations * percent/100;
-      analysis_config_set_min_realisations(analysis, min_realizations);
+      
+      min_realizations = num_realizations * percent/100;
     } else {
-      int min_realizations = 0;
-      if (util_sscanf_int(min_realizations_string, &min_realizations))
-        analysis_config_set_min_realisations( analysis , min_realizations);
-      else
-        fprintf(stderr, "Method %s: failed to read integer value for MIN_REALIZATION_KEY\n", __func__);
+      bool min_realizations_int_exists = util_sscanf_int(min_realizations_string, &min_realizations);
+      if (!min_realizations_int_exists)
+        fprintf(stderr, "Method %s: failed to read integer value for MIN_REALIZATIONS_KEY\n", __func__);
     }
+    
+    if (min_realizations > num_realizations)
+      min_realizations = num_realizations;
+    
+    analysis_config_set_min_realisations(analysis, min_realizations);
     free(min_realizations_string);
   }
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1145,11 +1145,11 @@ bool enkf_main_UPDATE(enkf_main_type * enkf_main , const int_vector_type * step_
   const analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
   const int active_ens_size = state_map_count_matching( source_state_map , STATE_HAS_DATA );
 
-  if (analysis_config_have_enough_realisations(analysis_config , active_ens_size)) {
+  const int total_ens_size = enkf_main_get_ensemble_size(enkf_main);
+  if (analysis_config_have_enough_realisations(analysis_config , active_ens_size, total_ens_size)) {
     double alpha       = analysis_config_get_alpha( enkf_main->analysis_config );
     double std_cutoff  = analysis_config_get_std_cutoff( enkf_main->analysis_config );
     int current_step   = int_vector_get_last( step_list );
-    const int total_ens_size = enkf_main_get_ensemble_size(enkf_main);
     state_map_type * target_state_map = enkf_fs_get_state_map( target_fs );
     bool_vector_type * ens_mask = bool_vector_alloc(total_ens_size , false);
     int_vector_type * ens_active_list = int_vector_alloc(0,0);

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1530,12 +1530,11 @@ void enkf_main_submit_jobs( enkf_main_type * enkf_main ,
 
 
 /**
-  If all simulations have completed successfully the function will
-  return true, otherwise it will return false.
+  The function will return number of non-failing jobs.
 */
 
 
-static bool enkf_main_run_step(enkf_main_type * enkf_main       ,
+static int enkf_main_run_step(enkf_main_type * enkf_main       ,
                                ert_run_context_type * run_context) {
 
   if (ert_run_context_get_step1(run_context))
@@ -1582,7 +1581,8 @@ static bool enkf_main_run_step(enkf_main_type * enkf_main       ,
     /* This should be carefully checked for the situation where only a
        subset (with offset > 0) of realisations are simulated. */
 
-    bool totalOK = true;
+    int totalOK = 0;
+    int totalFailed = 0;
     for (iens = 0; iens < active_ens_size; iens++) {
       if (bool_vector_iget(ert_run_context_get_iactive(run_context) , iens)) {
         run_arg_type * run_arg = ert_run_context_iens_get_arg( run_context , iens );
@@ -1590,12 +1590,16 @@ static bool enkf_main_run_step(enkf_main_type * enkf_main       ,
 
         if ((run_status == JOB_LOAD_FAILURE) || (run_status == JOB_RUN_FAILURE)) {
           ert_run_context_deactivate_realization(run_context, iens);
-          totalOK = false;
+          totalFailed++;
+        }
+        else {
+          totalOK++;
         }
       }
     }
+    
     enkf_fs_fsync( ert_run_context_get_result_fs( run_context ) );
-    if (totalOK)
+    if (totalFailed == 0)
       ert_log_add_fmt_message( 1 , NULL , "All jobs complete and data loaded.");
 
 
@@ -1674,6 +1678,7 @@ void enkf_main_init_run( enkf_main_type * enkf_main, const ert_run_context_type 
 void enkf_main_run_tui_exp(enkf_main_type * enkf_main ,
                            bool_vector_type * iactive) {
 
+  int active_before = bool_vector_count_equal(iactive, true);
   hook_manager_type * hook_manager = enkf_main_get_hook_manager(enkf_main);
   ert_run_context_type * run_context;
   init_mode_type init_mode = INIT_CONDITIONAL;
@@ -1686,7 +1691,10 @@ void enkf_main_run_tui_exp(enkf_main_type * enkf_main ,
   enkf_main_init_run( enkf_main , run_context , init_mode);
   enkf_main_create_run_path( enkf_main , iactive , iter );
   hook_manager_run_workflows(hook_manager, PRE_SIMULATION, enkf_main);
-  if (enkf_main_run_step(enkf_main , run_context))
+  enkf_main_run_step(enkf_main , run_context);
+  
+  int active_after = bool_vector_count_equal(iactive, true);
+  if (active_after == active_before)
     hook_manager_run_workflows(hook_manager, POST_SIMULATION, enkf_main);
 
   ert_run_context_free( run_context );
@@ -1695,17 +1703,16 @@ void enkf_main_run_tui_exp(enkf_main_type * enkf_main ,
 
 
 
-bool enkf_main_run_simple_step(enkf_main_type * enkf_main , bool_vector_type * iactive , init_mode_type init_mode, int iter) {
-  bool run_ok;
+int enkf_main_run_simple_step(enkf_main_type * enkf_main , bool_vector_type * iactive , init_mode_type init_mode, int iter) {
   ert_run_context_type * run_context = enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT( enkf_main ,
                                                                                             enkf_main_get_fs( enkf_main ) ,
                                                                                             iactive ,
                                                                                             iter );
   enkf_main_init_run( enkf_main , run_context , init_mode);
-  run_ok = enkf_main_run_step( enkf_main , run_context );
+  int successful_realizations = enkf_main_run_step( enkf_main , run_context );
   ert_run_context_free( run_context );
 
-  return run_ok;
+  return successful_realizations;
 }
 
 
@@ -1744,9 +1751,8 @@ static bool enkf_main_run_simulation_and_postworkflow(enkf_main_type * enkf_main
   bool ret = true;
   analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
 
-  bool total_ok = enkf_main_run_step(enkf_main , run_context);
-  int active_after_step = bool_vector_count_equal(ert_run_context_get_iactive( run_context ), true);
-  if (total_ok || analysis_config_have_enough_realisations(analysis_config, active_after_step, enkf_main_get_ensemble_size(enkf_main))) {
+  int active_after_step = enkf_main_run_step(enkf_main , run_context);
+  if (analysis_config_have_enough_realisations(analysis_config, active_after_step, enkf_main_get_ensemble_size(enkf_main))) {
     hook_manager_type * hook_manager = enkf_main_get_hook_manager(enkf_main);
     hook_manager_run_workflows(hook_manager, POST_SIMULATION, enkf_main);
   }  else {

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1331,14 +1331,14 @@ static void enkf_main_monitor_job_queue ( const enkf_main_type * enkf_main) {
         cont = false;
       }
 
-      //Check if all possible sucesses satisfies the minimum number of realizations threshold. If not so, it is time to give up
-      int possible_sucesses = job_queue_get_num_running(job_queue) +
+      //Check if all possible successes satisfies the minimum number of realizations threshold. If not so, it is time to give up
+      int possible_successes = job_queue_get_num_running(job_queue) +
         job_queue_get_num_waiting(job_queue) +
         job_queue_get_num_pending(job_queue) +
         job_queue_get_num_complete(job_queue);
 
       
-      if (analysis_config_have_enough_realisations(analysis_config, possible_sucesses, enkf_main_get_ensemble_size(enkf_main))) {
+      if (analysis_config_have_enough_realisations(analysis_config, possible_successes, enkf_main_get_ensemble_size(enkf_main))) {
         cont = false;
       }
 

--- a/libenkf/tests/enkf_analysis_config.c
+++ b/libenkf/tests/enkf_analysis_config.c
@@ -46,14 +46,15 @@ void test_create() {
 }
 
 
-void test_min_realizations_percent(const char * num_realizations_str, const char * min_realizations_str, int min_realizations){
-  test_work_area_type * work_area = test_work_area_alloc("test_min_realizations");
+void test_min_realizations(const char * num_realizations_str, const char * min_realizations_str, int min_realizations_expected_needed) {
+  test_work_area_type * work_area = test_work_area_alloc("test_min_realizations_string");
 
   {
     FILE * config_file_stream = util_mkdir_fopen("config_file", "w");
     test_assert_not_NULL(config_file_stream);
-    fprintf(config_file_stream, num_realizations_str);
-    fprintf(config_file_stream, min_realizations_str);
+
+    fputs(num_realizations_str, config_file_stream);
+    fputs(min_realizations_str, config_file_stream);
     fclose(config_file_stream);
 
     config_parser_type * c = config_alloc();
@@ -71,8 +72,9 @@ void test_min_realizations_percent(const char * num_realizations_str, const char
       analysis_config_init(ac, content);
       
       int num_realizations = config_content_get_value_as_int(content, NUM_REALIZATIONS_KEY);
-      test_assert_int_equal( min_realizations , analysis_config_get_min_realisations( ac ) );
-
+      test_assert_false(analysis_config_have_enough_realisations(ac, min_realizations_expected_needed - 1, num_realizations ));
+      test_assert_true(analysis_config_have_enough_realisations(ac, min_realizations_expected_needed, num_realizations ));
+      test_assert_true(analysis_config_have_enough_realisations(ac, min_realizations_expected_needed + 1, num_realizations ));
       analysis_config_free( ac );
       config_content_free( content );
       config_free( c );
@@ -83,19 +85,7 @@ void test_min_realizations_percent(const char * num_realizations_str, const char
 }
 
 
-
-void test_min_realisations( ) {
-  analysis_config_type * ac = create_analysis_config( );
-  test_assert_int_equal( 0 , analysis_config_get_min_realisations( ac ) );
-  analysis_config_set_min_realisations( ac , 8 );
-  test_assert_int_equal( 8 , analysis_config_get_min_realisations( ac ) );
-  analysis_config_set_min_realisations( ac , 26 );
-  test_assert_int_equal( 26 , analysis_config_get_min_realisations( ac ) );
-  analysis_config_free( ac );
-}
-
-
-void test_have_enough_realisations( ) {
+void test_have_enough_realisations_defaulted( ) {
   analysis_config_type * ac = create_analysis_config( );
   int ensemble_size = 20;
   
@@ -103,18 +93,6 @@ void test_have_enough_realisations( ) {
   test_assert_false( analysis_config_have_enough_realisations( ac , 0, ensemble_size ));
   test_assert_false( analysis_config_have_enough_realisations( ac , 10, ensemble_size ));
   test_assert_true( analysis_config_have_enough_realisations( ac , 20, ensemble_size ));
-
-  analysis_config_set_min_realisations( ac , 5 );
-  test_assert_true( analysis_config_have_enough_realisations( ac , 10, ensemble_size ));
-
-  analysis_config_set_min_realisations( ac , 15 );
-  test_assert_false( analysis_config_have_enough_realisations( ac , 10, ensemble_size ));
-
-  analysis_config_set_min_realisations( ac , 10 );
-  test_assert_true( analysis_config_have_enough_realisations( ac , 10, ensemble_size ));
-
-  analysis_config_set_min_realisations( ac , 0 );
-  test_assert_false( analysis_config_have_enough_realisations( ac , 10, ensemble_size ));
 
   analysis_config_free( ac );
 }
@@ -143,47 +121,76 @@ void test_stop_long_running( ) {
   analysis_config_free( ac );
 }
 
-int main(int argc , char ** argv) {
-  test_create();
-  test_min_realisations();
-  test_have_enough_realisations();
+void test_min_realizations_percent() {
+  {
+    const char * num_realizations_str = "NUM_REALIZATIONS 80\n";
+    const char * min_realizations_str = "MIN_REALIZATIONS 10%\n";
+    int min_realizations_expected_needed              = 8;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed);
+  }
+  {
+    const char * num_realizations_str = "NUM_REALIZATIONS 8\n";
+    const char * min_realizations_str = "MIN_REALIZATIONS 50%\n";
+    int min_realizations_expected_needed              = 4;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed );
+  }
+  {
+    const char * num_realizations_str = "NUM_REALIZATIONS 8\n";
+    const char * min_realizations_str = "MIN_REALIZATIONS 100%\n";
+    int min_realizations_expected_needed              = 8;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed );
+  }
+  {
+    const char * num_realizations_str = "NUM_REALIZATIONS 8\n";
+    const char * min_realizations_str = "MIN_REALIZATIONS 10%\n";
+    int min_realizations_expected_needed              = 8; // Expect 8 because 10 % of 8 will be calculated to zero.
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed );
+  }
+}
 
+void test_min_realizations_number() {
   {
     const char * num_realizations_str = "NUM_REALIZATIONS 80\n";
-    const char * min_realizations_str = "MIN_REALIZATIONS 10%%\n";
-    int min_realizations              = 8;
-    test_min_realizations_percent(num_realizations_str, min_realizations_str, min_realizations);
+    const char * min_realizations_str = "MIN_REALIZATIONS 0\n";
+    int min_realizations_expected_needed              = 80;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed);
   }
   {
-    const char * num_realizations_str = "NUM_REALIZATIONS 8\n";
-    const char * min_realizations_str = "MIN_REALIZATIONS 50%%\n";
-    int min_realizations              = 4;
-    test_min_realizations_percent(num_realizations_str, min_realizations_str, min_realizations);
-  }
-  {
-    const char * num_realizations_str = "NUM_REALIZATIONS 80\n";
-    const char * min_realizations_str = "MIN_REALIZATIONS 2\n";
-    int min_realizations              = 2;
-    test_min_realizations_percent(num_realizations_str, min_realizations_str, min_realizations);
-  }
-  {
-    const char * num_realizations_str = "NUM_REALIZATIONS 8\n";
-    const char * min_realizations_str = "MIN_REALIZATIONS 10%%\n";
-    int min_realizations              = 0;
-    test_min_realizations_percent(num_realizations_str, min_realizations_str, min_realizations);
+    const char * num_realizations_str = "NUM_REALIZATIONS 900\n";
+    int min_realizations_expected_needed              = 900; // Nothing specified, expect NUM_REALIZATIONS
+    test_min_realizations(num_realizations_str, "", min_realizations_expected_needed);
   }
   {
     const char * num_realizations_str = "NUM_REALIZATIONS 900\n";
     const char * min_realizations_str = "MIN_REALIZATIONS 10 \n";
-    int min_realizations              = 10;
-    test_min_realizations_percent(num_realizations_str, min_realizations_str, min_realizations);
+    int min_realizations_expected_needed              = 10;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed);
   }
   {
-    const char * num_realizations_str = "NUM_REALIZATIONS 900\n";
-    int min_realizations              = 0;
-    test_min_realizations_percent(num_realizations_str, "", min_realizations);
+    const char * num_realizations_str = "NUM_REALIZATIONS 80\n";
+    const char * min_realizations_str = "MIN_REALIZATIONS 50\n";
+    int min_realizations_expected_needed              = 50;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed);
   }
+  {
+    const char * num_realizations_str = "NUM_REALIZATIONS 80\n";
+    const char * min_realizations_str = "MIN_REALIZATIONS 80\n";
+    int min_realizations_expected_needed              = 80;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed);
+  }
+  {
+    const char * num_realizations_str = "NUM_REALIZATIONS 80\n";
+    const char * min_realizations_str = "MIN_REALIZATIONS 100\n";
+    int min_realizations_expected_needed              = 80;
+    test_min_realizations(num_realizations_str, min_realizations_str, min_realizations_expected_needed);
+  }
+}
 
+int main(int argc , char ** argv) {
+  test_create();
+  test_have_enough_realisations_defaulted();
+  test_min_realizations_percent();
+  test_min_realizations_number();
   test_current_module_options();
   test_stop_long_running();
   exit(0);

--- a/libenkf/tests/tests.cmake
+++ b/libenkf/tests/tests.cmake
@@ -57,7 +57,7 @@ add_test( enkf_cases_config  ${EXECUTABLE_OUTPUT_PATH}/enkf_cases_config )
 
 add_executable( enkf_analysis_config enkf_analysis_config.c )
 target_link_libraries( enkf_analysis_config enkf test_util )
-add_test( enkf_analysis  ${EXECUTABLE_OUTPUT_PATH}/enkf_analysis_config)
+add_test( enkf_analysis_config  ${EXECUTABLE_OUTPUT_PATH}/enkf_analysis_config)
 
 add_executable( enkf_analysis_config_ext_module enkf_analysis_config_ext_module.c )
 target_link_libraries( enkf_analysis_config_ext_module enkf test_util )

--- a/libjob_queue/src/job_queue_status.c
+++ b/libjob_queue/src/job_queue_status.c
@@ -36,7 +36,7 @@ static const int status_index[] = {  JOB_QUEUE_NOT_ACTIVE ,  // Initial, allocat
                                      JOB_QUEUE_SUBMITTED  ,  // Job is submitted to driver - temporary state                               - controlled by job_queue
                                      JOB_QUEUE_PENDING    ,  // Job is pending, before actual execution                                    - controlled by queue_driver
                                      JOB_QUEUE_RUNNING    ,  // Job is executing                                                           - controlled by queue_driver
-                                     JOB_QUEUE_DONE       ,  // Job is done (sucessful or not), temporary state                            - controlled/returned by by queue_driver
+                                     JOB_QUEUE_DONE       ,  // Job is done (successful or not), temporary state                            - controlled/returned by by queue_driver
                                      JOB_QUEUE_EXIT       ,  // Job is done, with exit status != 0, temporary state                        - controlled/returned by by queue_driver
                                      JOB_QUEUE_USER_EXIT  ,  // User / queue system has requested killing of job                           - controlled by job_queue / external scope
                                      JOB_QUEUE_USER_KILLED,  // Job has been killed, due to JOB_QUEUE_USER_EXIT, FINAL STATE               - controlled by job_queue

--- a/python/python/ert/enkf/analysis_config.py
+++ b/python/python/ert/enkf/analysis_config.py
@@ -68,13 +68,6 @@ class AnalysisConfig(BaseCClass):
         """ @rtype: AnalysisIterConfig """
         return AnalysisConfig.cNamespace().get_iter_config(self).setParent(self)
 
-    def getMinRealisations(self):
-        """ @rtype: int """
-        return AnalysisConfig.cNamespace().get_min_realisations( self )
-
-    def set_min_realisations(self , min_realisations):
-        AnalysisConfig.cNamespace().set_min_realisations( self , min_realisations )
-
     def get_stop_long_running(self):
         """ @rtype: bool """
         return AnalysisConfig.cNamespace().get_stop_long_running( self )
@@ -123,41 +116,43 @@ class AnalysisConfig(BaseCClass):
     def getGlobalStdScaling(self):
         return AnalysisConfig.cNamespace().get_global_std_scaling(self)
 
+    def haveEnoughRealisations(self, realizations, ensemble_size):
+        return AnalysisConfig.cNamespace().have_enough_realisations(self, realizations, ensemble_size)
+
 
 cwrapper = CWrapper(ENKF_LIB)
 cwrapper.registerType("analysis_config", AnalysisConfig)
 cwrapper.registerType("analysis_config_obj", AnalysisConfig.createPythonObject)
 cwrapper.registerType("analysis_config_ref", AnalysisConfig.createCReference)
 
-AnalysisConfig.cNamespace().alloc                  = cwrapper.prototype("c_void_p analysis_config_alloc()")
-AnalysisConfig.cNamespace().free                   = cwrapper.prototype("void analysis_config_free( analysis_config )")
-AnalysisConfig.cNamespace().get_rerun              = cwrapper.prototype("int analysis_config_get_rerun( analysis_config )")
-AnalysisConfig.cNamespace().set_rerun              = cwrapper.prototype("void analysis_config_set_rerun( analysis_config, bool)")
-AnalysisConfig.cNamespace().get_rerun_start        = cwrapper.prototype("int analysis_config_get_rerun_start( analysis_config )")
-AnalysisConfig.cNamespace().set_rerun_start        = cwrapper.prototype("void analysis_config_set_rerun_start( analysis_config, int)")
-AnalysisConfig.cNamespace().get_log_path           = cwrapper.prototype("char* analysis_config_get_log_path( analysis_config)")
-AnalysisConfig.cNamespace().set_log_path           = cwrapper.prototype("void analysis_config_set_log_path( analysis_config, char*)")
+AnalysisConfig.cNamespace().alloc                    = cwrapper.prototype("c_void_p analysis_config_alloc()")
+AnalysisConfig.cNamespace().free                     = cwrapper.prototype("void analysis_config_free( analysis_config )")
+AnalysisConfig.cNamespace().get_rerun                = cwrapper.prototype("int analysis_config_get_rerun( analysis_config )")
+AnalysisConfig.cNamespace().set_rerun                = cwrapper.prototype("void analysis_config_set_rerun( analysis_config, bool)")
+AnalysisConfig.cNamespace().get_rerun_start          = cwrapper.prototype("int analysis_config_get_rerun_start( analysis_config )")
+AnalysisConfig.cNamespace().set_rerun_start          = cwrapper.prototype("void analysis_config_set_rerun_start( analysis_config, int)")
+AnalysisConfig.cNamespace().get_log_path             = cwrapper.prototype("char* analysis_config_get_log_path( analysis_config)")
+AnalysisConfig.cNamespace().set_log_path             = cwrapper.prototype("void analysis_config_set_log_path( analysis_config, char*)")
 
-AnalysisConfig.cNamespace().get_merge_observations = cwrapper.prototype("bool analysis_config_get_merge_observations(analysis_config)")
-AnalysisConfig.cNamespace().set_merge_observations = cwrapper.prototype("void analysis_config_set_merge_observations(analysis_config, bool)")
-AnalysisConfig.cNamespace().get_iter_config        = cwrapper.prototype("analysis_iter_config_ref analysis_config_get_iter_config(analysis_config)")
-AnalysisConfig.cNamespace().get_min_realisations   = cwrapper.prototype("int analysis_config_get_min_realisations(analysis_config)")
-AnalysisConfig.cNamespace().set_min_realisations   = cwrapper.prototype("void analysis_config_set_min_realisations(analysis_config, int)")
-AnalysisConfig.cNamespace().get_max_runtime        = cwrapper.prototype("int analysis_config_get_max_runtime(analysis_config)")
-AnalysisConfig.cNamespace().set_max_runtime        = cwrapper.prototype("void analysis_config_set_max_runtime(analysis_config, int)")
-AnalysisConfig.cNamespace().get_stop_long_running  = cwrapper.prototype("bool analysis_config_get_stop_long_running(analysis_config)")
-AnalysisConfig.cNamespace().set_stop_long_running  = cwrapper.prototype("void analysis_config_set_stop_long_running(analysis_config, bool)")
+AnalysisConfig.cNamespace().get_merge_observations   = cwrapper.prototype("bool analysis_config_get_merge_observations(analysis_config)")
+AnalysisConfig.cNamespace().set_merge_observations   = cwrapper.prototype("void analysis_config_set_merge_observations(analysis_config, bool)")
+AnalysisConfig.cNamespace().get_iter_config          = cwrapper.prototype("analysis_iter_config_ref analysis_config_get_iter_config(analysis_config)")
+AnalysisConfig.cNamespace().have_enough_realisations = cwrapper.prototype("bool analysis_config_have_enough_realisations(analysis_config, int, int)")
+AnalysisConfig.cNamespace().get_max_runtime          = cwrapper.prototype("int analysis_config_get_max_runtime(analysis_config)")
+AnalysisConfig.cNamespace().set_max_runtime          = cwrapper.prototype("void analysis_config_set_max_runtime(analysis_config, int)")
+AnalysisConfig.cNamespace().get_stop_long_running    = cwrapper.prototype("bool analysis_config_get_stop_long_running(analysis_config)")
+AnalysisConfig.cNamespace().set_stop_long_running    = cwrapper.prototype("void analysis_config_set_stop_long_running(analysis_config, bool)")
 
-AnalysisConfig.cNamespace().get_active_module_name = cwrapper.prototype("char* analysis_config_get_active_module_name(analysis_config)")
-AnalysisConfig.cNamespace().get_module_list        = cwrapper.prototype("stringlist_obj analysis_config_alloc_module_names(analysis_config)")
-AnalysisConfig.cNamespace().get_module             = cwrapper.prototype("analysis_module_ref analysis_config_get_module(analysis_config, char*)")
-AnalysisConfig.cNamespace().select_module          = cwrapper.prototype("bool analysis_config_select_module(analysis_config, char*)")
-AnalysisConfig.cNamespace().has_module             = cwrapper.prototype("bool analysis_config_has_module(analysis_config, char*)")
+AnalysisConfig.cNamespace().get_active_module_name   = cwrapper.prototype("char* analysis_config_get_active_module_name(analysis_config)")
+AnalysisConfig.cNamespace().get_module_list          = cwrapper.prototype("stringlist_obj analysis_config_alloc_module_names(analysis_config)")
+AnalysisConfig.cNamespace().get_module               = cwrapper.prototype("analysis_module_ref analysis_config_get_module(analysis_config, char*)")
+AnalysisConfig.cNamespace().select_module            = cwrapper.prototype("bool analysis_config_select_module(analysis_config, char*)")
+AnalysisConfig.cNamespace().has_module               = cwrapper.prototype("bool analysis_config_has_module(analysis_config, char*)")
 
-AnalysisConfig.cNamespace().get_alpha              = cwrapper.prototype("double analysis_config_get_alpha(analysis_config)")
-AnalysisConfig.cNamespace().set_alpha              = cwrapper.prototype("void analysis_config_set_alpha(analysis_config, double)")
-AnalysisConfig.cNamespace().get_std_cutoff         = cwrapper.prototype("double analysis_config_get_std_cutoff(analysis_config)")
-AnalysisConfig.cNamespace().set_std_cutoff         = cwrapper.prototype("void analysis_config_set_std_cutoff(analysis_config, double)")
+AnalysisConfig.cNamespace().get_alpha                = cwrapper.prototype("double analysis_config_get_alpha(analysis_config)")
+AnalysisConfig.cNamespace().set_alpha                = cwrapper.prototype("void analysis_config_set_alpha(analysis_config, double)")
+AnalysisConfig.cNamespace().get_std_cutoff           = cwrapper.prototype("double analysis_config_get_std_cutoff(analysis_config)")
+AnalysisConfig.cNamespace().set_std_cutoff           = cwrapper.prototype("void analysis_config_set_std_cutoff(analysis_config, double)")
 
-AnalysisConfig.cNamespace().set_global_std_scaling = cwrapper.prototype("void analysis_config_set_global_std_scaling(analysis_config, double)")
-AnalysisConfig.cNamespace().get_global_std_scaling = cwrapper.prototype("double analysis_config_get_global_std_scaling(analysis_config)")
+AnalysisConfig.cNamespace().set_global_std_scaling   = cwrapper.prototype("void analysis_config_set_global_std_scaling(analysis_config, double)")
+AnalysisConfig.cNamespace().get_global_std_scaling   = cwrapper.prototype("double analysis_config_get_global_std_scaling(analysis_config)")

--- a/python/python/ert/enkf/analysis_config.py
+++ b/python/python/ert/enkf/analysis_config.py
@@ -14,6 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
 from ert.cwrap import BaseCClass, CWrapper
+from ert.enkf import EnkfPrototype
 from ert.enkf import ENKF_LIB
 from ert.enkf import AnalysisIterConfig
 from ert.analysis import AnalysisModule
@@ -21,138 +22,131 @@ from ert.util import StringList
 
 
 class AnalysisConfig(BaseCClass):
+    TYPE_NAME = "analysis_config"
+    _alloc = EnkfPrototype("void* analysis_config_alloc()", bind = False)
+    _free = EnkfPrototype("void analysis_config_free( analysis_config )")
+    _get_rerun = EnkfPrototype("int analysis_config_get_rerun( analysis_config )")
+    _set_rerun = EnkfPrototype("void analysis_config_set_rerun( analysis_config, bool)")
+    _get_rerun_start = EnkfPrototype("int analysis_config_get_rerun_start( analysis_config )")
+    _set_rerun_start = EnkfPrototype("void analysis_config_set_rerun_start( analysis_config, int)")
+    _get_log_path = EnkfPrototype("char* analysis_config_get_log_path( analysis_config)")
+    _set_log_path = EnkfPrototype("void analysis_config_set_log_path( analysis_config, char*)")
+    _get_merge_observations = EnkfPrototype("bool analysis_config_get_merge_observations(analysis_config)")
+    _set_merge_observations = EnkfPrototype("void analysis_config_set_merge_observations(analysis_config, bool)")
+    _get_iter_config = EnkfPrototype("analysis_iter_config_ref analysis_config_get_iter_config(analysis_config)")
+    _have_enough_realisations = EnkfPrototype("bool analysis_config_have_enough_realisations(analysis_config, int, int)")
+    _get_max_runtime = EnkfPrototype("int analysis_config_get_max_runtime(analysis_config)")
+    _set_max_runtime = EnkfPrototype("void analysis_config_set_max_runtime(analysis_config, int)")
+    _get_stop_long_running = EnkfPrototype("bool analysis_config_get_stop_long_running(analysis_config)")
+    _set_stop_long_running = EnkfPrototype("void analysis_config_set_stop_long_running(analysis_config, bool)")
+    _get_active_module_name = EnkfPrototype("char* analysis_config_get_active_module_name(analysis_config)")
+    _get_module_list = EnkfPrototype("stringlist_obj analysis_config_alloc_module_names(analysis_config)")
+    _get_module = EnkfPrototype("analysis_module_ref analysis_config_get_module(analysis_config, char*)")
+    _select_module = EnkfPrototype("bool analysis_config_select_module(analysis_config, char*)")
+    _has_module = EnkfPrototype("bool analysis_config_has_module(analysis_config, char*)")
+    _get_alpha = EnkfPrototype("double analysis_config_get_alpha(analysis_config)")
+    _set_alpha = EnkfPrototype("void analysis_config_set_alpha(analysis_config, double)")
+    _get_std_cutoff = EnkfPrototype("double analysis_config_get_std_cutoff(analysis_config)")
+    _set_std_cutoff = EnkfPrototype("void analysis_config_set_std_cutoff(analysis_config, double)")
+    _set_global_std_scaling = EnkfPrototype("void analysis_config_set_global_std_scaling(analysis_config, double)")
+    _get_global_std_scaling = EnkfPrototype("double analysis_config_get_global_std_scaling(analysis_config)")
+
     def __init__(self):
-        c_ptr = AnalysisConfig.cNamespace().alloc()
+        c_ptr = AnalysisConfig._alloc()
         super(AnalysisConfig , self).__init__(c_ptr)
 
 
     def get_rerun(self):
-        return AnalysisConfig.cNamespace().get_rerun(self)
+        return self._get_rerun()
 
     def set_rerun(self, rerun):
-        AnalysisConfig.cNamespace().set_rerun(self, rerun)
+        self._set_rerun(rerun)
 
     def get_rerun_start(self):
-        return AnalysisConfig.cNamespace().get_rerun_start(self)
+        return self._get_rerun_start()
 
     def set_rerun_start(self, index):
-        AnalysisConfig.cNamespace().set_rerun_start(self, index)
+        self._set_rerun_start(index)
 
     def get_log_path(self):
-        return AnalysisConfig.cNamespace().get_log_path(self)
+        return self._get_log_path()
 
     def set_log_path(self, path):
-        AnalysisConfig.cNamespace().set_log_path(self, path)
+        self._set_log_path(path)
 
     def getEnkfAlpha(self):
         """ :rtype: float """
-        return AnalysisConfig.cNamespace().get_alpha(self)
+        return self._get_alpha()
 
     def setEnkfAlpha(self, alpha):
-        AnalysisConfig.cNamespace().set_alpha(self, alpha)
+        self._set_alpha(alpha)
 
     def getStdCutoff(self):
         """ :rtype: float """
-        return AnalysisConfig.cNamespace().get_std_cutoff(self)
+        return self._get_std_cutoff()
 
     def setStdCutoff(self, std_cutoff):
-        AnalysisConfig.cNamespace().set_std_cutoff(self, std_cutoff)
+        self._set_std_cutoff(std_cutoff)
 
     def get_merge_observations(self):
-        return AnalysisConfig.cNamespace().get_merge_observations(self)
+        return self._get_merge_observations()
 
     def set_merge_observations(self, merge_observations):
-        return AnalysisConfig.cNamespace().set_merge_observations(self, merge_observations)
+        return self._set_merge_observations(merge_observations)
 
     def getAnalysisIterConfig(self):
         """ @rtype: AnalysisIterConfig """
-        return AnalysisConfig.cNamespace().get_iter_config(self).setParent(self)
+        return self._get_iter_config().setParent(self)
 
     def get_stop_long_running(self):
         """ @rtype: bool """
-        return AnalysisConfig.cNamespace().get_stop_long_running( self )
+        return self._get_stop_long_running()
     
     def set_stop_long_running(self, stop_long_running):
-        AnalysisConfig.cNamespace().set_stop_long_running(self, stop_long_running)
+        self._set_stop_long_running(stop_long_running)
   
     def get_max_runtime(self):
         """ @rtype: int """
-        return AnalysisConfig.cNamespace().get_max_runtime( self )
+        return self._get_max_runtime()
 
     def set_max_runtime(self, max_runtime):
-        AnalysisConfig.cNamespace().set_max_runtime( self, max_runtime )
+        self._set_max_runtime(max_runtime)
 
     def free(self):
-        AnalysisConfig.cNamespace().free(self)
+        self._free()
         
     def activeModuleName(self):
         """ :rtype: str """
-        return AnalysisConfig.cNamespace().get_active_module_name(self)
+        return self._get_active_module_name()
 
     def getModuleList(self):
         """ :rtype: StringList """
-        return AnalysisConfig.cNamespace().get_module_list(self)
+        return self._get_module_list()
 
     def getModule(self, module_name):
         """ @rtype: AnalysisModule """
-        return AnalysisConfig.cNamespace().get_module(self, module_name)
+        return self._get_module(module_name)
 
     def hasModule(self, module_name):
         """ @rtype: bool """
-        return AnalysisConfig.cNamespace().has_module(self, module_name)
+        return self._has_module(module_name)
 
     
     def selectModule(self, module_name):
         """ @rtype: bool """
-        return AnalysisConfig.cNamespace().select_module(self, module_name)
+        return self._select_module(module_name)
 
     def getActiveModule(self):
         """ :rtype: AnalysisModule """
         return self.getModule(self.activeModuleName())
 
     def setGlobalStdScaling(self, std_scaling):
-        AnalysisConfig.cNamespace().set_global_std_scaling(self, std_scaling)
+        self._set_global_std_scaling(std_scaling)
 
     def getGlobalStdScaling(self):
-        return AnalysisConfig.cNamespace().get_global_std_scaling(self)
+        return self._get_global_std_scaling()
 
     def haveEnoughRealisations(self, realizations, ensemble_size):
-        return AnalysisConfig.cNamespace().have_enough_realisations(self, realizations, ensemble_size)
+        return self._have_enough_realisations(realizations, ensemble_size)
 
 
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("analysis_config", AnalysisConfig)
-cwrapper.registerType("analysis_config_obj", AnalysisConfig.createPythonObject)
-cwrapper.registerType("analysis_config_ref", AnalysisConfig.createCReference)
-
-AnalysisConfig.cNamespace().alloc                    = cwrapper.prototype("c_void_p analysis_config_alloc()")
-AnalysisConfig.cNamespace().free                     = cwrapper.prototype("void analysis_config_free( analysis_config )")
-AnalysisConfig.cNamespace().get_rerun                = cwrapper.prototype("int analysis_config_get_rerun( analysis_config )")
-AnalysisConfig.cNamespace().set_rerun                = cwrapper.prototype("void analysis_config_set_rerun( analysis_config, bool)")
-AnalysisConfig.cNamespace().get_rerun_start          = cwrapper.prototype("int analysis_config_get_rerun_start( analysis_config )")
-AnalysisConfig.cNamespace().set_rerun_start          = cwrapper.prototype("void analysis_config_set_rerun_start( analysis_config, int)")
-AnalysisConfig.cNamespace().get_log_path             = cwrapper.prototype("char* analysis_config_get_log_path( analysis_config)")
-AnalysisConfig.cNamespace().set_log_path             = cwrapper.prototype("void analysis_config_set_log_path( analysis_config, char*)")
-
-AnalysisConfig.cNamespace().get_merge_observations   = cwrapper.prototype("bool analysis_config_get_merge_observations(analysis_config)")
-AnalysisConfig.cNamespace().set_merge_observations   = cwrapper.prototype("void analysis_config_set_merge_observations(analysis_config, bool)")
-AnalysisConfig.cNamespace().get_iter_config          = cwrapper.prototype("analysis_iter_config_ref analysis_config_get_iter_config(analysis_config)")
-AnalysisConfig.cNamespace().have_enough_realisations = cwrapper.prototype("bool analysis_config_have_enough_realisations(analysis_config, int, int)")
-AnalysisConfig.cNamespace().get_max_runtime          = cwrapper.prototype("int analysis_config_get_max_runtime(analysis_config)")
-AnalysisConfig.cNamespace().set_max_runtime          = cwrapper.prototype("void analysis_config_set_max_runtime(analysis_config, int)")
-AnalysisConfig.cNamespace().get_stop_long_running    = cwrapper.prototype("bool analysis_config_get_stop_long_running(analysis_config)")
-AnalysisConfig.cNamespace().set_stop_long_running    = cwrapper.prototype("void analysis_config_set_stop_long_running(analysis_config, bool)")
-
-AnalysisConfig.cNamespace().get_active_module_name   = cwrapper.prototype("char* analysis_config_get_active_module_name(analysis_config)")
-AnalysisConfig.cNamespace().get_module_list          = cwrapper.prototype("stringlist_obj analysis_config_alloc_module_names(analysis_config)")
-AnalysisConfig.cNamespace().get_module               = cwrapper.prototype("analysis_module_ref analysis_config_get_module(analysis_config, char*)")
-AnalysisConfig.cNamespace().select_module            = cwrapper.prototype("bool analysis_config_select_module(analysis_config, char*)")
-AnalysisConfig.cNamespace().has_module               = cwrapper.prototype("bool analysis_config_has_module(analysis_config, char*)")
-
-AnalysisConfig.cNamespace().get_alpha                = cwrapper.prototype("double analysis_config_get_alpha(analysis_config)")
-AnalysisConfig.cNamespace().set_alpha                = cwrapper.prototype("void analysis_config_set_alpha(analysis_config, double)")
-AnalysisConfig.cNamespace().get_std_cutoff           = cwrapper.prototype("double analysis_config_get_std_cutoff(analysis_config)")
-AnalysisConfig.cNamespace().set_std_cutoff           = cwrapper.prototype("void analysis_config_set_std_cutoff(analysis_config, double)")
-
-AnalysisConfig.cNamespace().set_global_std_scaling   = cwrapper.prototype("void analysis_config_set_global_std_scaling(analysis_config, double)")
-AnalysisConfig.cNamespace().get_global_std_scaling   = cwrapper.prototype("double analysis_config_get_global_std_scaling(analysis_config)")

--- a/python/python/ert/enkf/enkf_simulation_runner.py
+++ b/python/python/ert/enkf/enkf_simulation_runner.py
@@ -1,10 +1,15 @@
 from ert.cwrap import CWrapper, BaseCClass
-from ert.enkf import ENKF_LIB, EnkfFs
+from ert.enkf import ENKF_LIB, EnkfFs, EnkfPrototype
+from ert.enkf import EnkfPrototype
 from ert.enkf.enums import EnkfInitModeEnum
 from ert.util import BoolVector
 
 
 class EnkfSimulationRunner(BaseCClass):
+    TYPE_NAME = "enkf_simulation_runner"
+
+    _create_run_path = EnkfPrototype("bool enkf_main_create_run_path(enkf_simulation_runner, bool_vector, int)")
+    _run_simple_step = EnkfPrototype("int enkf_main_run_simple_step(enkf_simulation_runner, bool_vector, enkf_init_mode_enum, int)")
 
     def __init__(self, enkf_main):
         assert isinstance(enkf_main, BaseCClass)
@@ -16,12 +21,12 @@ class EnkfSimulationRunner(BaseCClass):
         """ @rtype: int """
         assert isinstance(active_realization_mask, BoolVector)
         assert isinstance(initialization_mode, EnkfInitModeEnum)
-        return EnkfSimulationRunner.cNamespace().run_simple_step(self, active_realization_mask, initialization_mode , iter_nr)
+        return self._run_simple_step(active_realization_mask, initialization_mode , iter_nr)
 
     def createRunPath(self, active_realization_mask, iter_nr):
         """ @rtype: bool """
         assert isinstance(active_realization_mask, BoolVector)
-        return EnkfSimulationRunner.cNamespace().create_run_path(self, active_realization_mask, iter_nr)
+        return self._create_run_path(active_realization_mask, iter_nr)
 
     def runEnsembleExperiment(self, active_realization_mask=None):
         """ @rtype: int """
@@ -37,13 +42,3 @@ class EnkfSimulationRunner(BaseCClass):
         """:type ert.enkf.enum.HookRuntimeEnum"""
         hook_manager = self.ert.getHookManager()
         hook_manager.runWorkflows( runtime  , self.ert )
-
-
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("enkf_simulation_runner", EnkfSimulationRunner)
-
-EnkfSimulationRunner.cNamespace().run_smoother      = cwrapper.prototype("void enkf_main_run_smoother(enkf_simulation_runner, char*, bool)")
-EnkfSimulationRunner.cNamespace().create_run_path   = cwrapper.prototype("bool enkf_main_create_run_path(enkf_simulation_runner, bool_vector, int)")
-EnkfSimulationRunner.cNamespace().run_simple_step   = cwrapper.prototype("int enkf_main_run_simple_step(enkf_simulation_runner, bool_vector, enkf_init_mode_enum, int)")

--- a/python/python/ert/enkf/enkf_simulation_runner.py
+++ b/python/python/ert/enkf/enkf_simulation_runner.py
@@ -13,7 +13,7 @@ class EnkfSimulationRunner(BaseCClass):
         """:type: ert.enkf.EnKFMain """
 
     def runSimpleStep(self, active_realization_mask, initialization_mode, iter_nr):
-        """ @rtype: bool """
+        """ @rtype: int """
         assert isinstance(active_realization_mask, BoolVector)
         assert isinstance(initialization_mode, EnkfInitModeEnum)
         return EnkfSimulationRunner.cNamespace().run_simple_step(self, active_realization_mask, initialization_mode , iter_nr)
@@ -24,7 +24,7 @@ class EnkfSimulationRunner(BaseCClass):
         return EnkfSimulationRunner.cNamespace().create_run_path(self, active_realization_mask, iter_nr)
 
     def runEnsembleExperiment(self, active_realization_mask=None):
-        """ @rtype: bool """
+        """ @rtype: int """
         if active_realization_mask is None:
             count = self.ert.getEnsembleSize()
             active_realization_mask = BoolVector(default_value=True, initial_size=count)
@@ -46,4 +46,4 @@ cwrapper.registerType("enkf_simulation_runner", EnkfSimulationRunner)
 
 EnkfSimulationRunner.cNamespace().run_smoother      = cwrapper.prototype("void enkf_main_run_smoother(enkf_simulation_runner, char*, bool)")
 EnkfSimulationRunner.cNamespace().create_run_path   = cwrapper.prototype("bool enkf_main_create_run_path(enkf_simulation_runner, bool_vector, int)")
-EnkfSimulationRunner.cNamespace().run_simple_step   = cwrapper.prototype("bool enkf_main_run_simple_step(enkf_simulation_runner, bool_vector, enkf_init_mode_enum, int)")
+EnkfSimulationRunner.cNamespace().run_simple_step   = cwrapper.prototype("int enkf_main_run_simple_step(enkf_simulation_runner, bool_vector, enkf_init_mode_enum, int)")

--- a/python/python/ert_gui/shell/simulations.py
+++ b/python/python/ert_gui/shell/simulations.py
@@ -40,7 +40,7 @@ class Simulations(ErtShellCollection):
 
         success = self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, self.ert().getEnsembleSize())
         if not success:
-            print("Error: Number of successful realizations is too low, you can change this by altering the MIN_REALIZATIONS element!")
+            print("Error: Number of successful realizations is too low.\nYou can allow more failed realizations by setting / changing the MIN_REALIZATIONS configuration element!")
             return
 
         print("Ensemble Experiment post processing!")

--- a/python/python/ert_gui/shell/simulations.py
+++ b/python/python/ert_gui/shell/simulations.py
@@ -36,10 +36,11 @@ class Simulations(ErtShellCollection):
 
         print("Ensemble Experiment started at: %s" % datetime.now().isoformat(sep=" "))
 
-        success = simulation_runner.runEnsembleExperiment()
+        num_successful_realizations = simulation_runner.runEnsembleExperiment()
 
+        success = self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, self.ert().getEnsembleSize())
         if not success:
-            print("Error: Simulations failed!")
+            print("Error: Number of successful realizations is too low, you can change this by altering the MIN_REALIZATIONS element!")
             return
 
         print("Ensemble Experiment post processing!")

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -192,12 +192,11 @@ class BaseRunModel(object):
         return not self.isFinished() and self._indeterminate
 
 
-    def checkHaveSufficientRealizations(self, active_realization_mask):
-        success_count = active_realization_mask.count()
-        if success_count == 0:
+    def checkHaveSufficientRealizations(self, num_successful_realizations):
+        if num_successful_realizations == 0:
             raise ErtRunError("Simulation failed! All realizations failed!")
-        elif not self.ert().analysisConfig().haveEnoughRealisations(success_count, self.ert().getEnsembleSize()):
-            raise ErtRunError("Too many simulations have failed! You can adjust MIN_REALIZATIONS to allow more failures.\n\n"
+        elif not self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, self.ert().getEnsembleSize()):
+            raise ErtRunError("Too many simulations have failed! You can add/adjust MIN_REALIZATIONS to allow failures in your simulations.\n\n"
                               "Check ERT log file '%s' or simulation folder for details." % ErtLog.getFilename())
 
 

--- a/python/python/ert_gui/simulation/models/base_run_model.py
+++ b/python/python/ert_gui/simulation/models/base_run_model.py
@@ -1,6 +1,7 @@
 import time
 from ert.job_queue import JobStatusType
 from ert_gui import ERT
+from ert.enkf import ErtLog
 
 
 class ErtRunError(Exception):
@@ -189,6 +190,15 @@ class BaseRunModel(object):
     def isIndeterminate(self):
         """ @rtype: bool """
         return not self.isFinished() and self._indeterminate
+
+
+    def checkHaveSufficientRealizations(self, active_realization_mask):
+        success_count = active_realization_mask.count()
+        if success_count == 0:
+            raise ErtRunError("Simulation failed! All realizations failed!")
+        elif not self.ert().analysisConfig().haveEnoughRealisations(success_count, self.ert().getEnsembleSize()):
+            raise ErtRunError("Too many simulations have failed! You can adjust MIN_REALIZATIONS to allow more failures.\n\n"
+                              "Check ERT log file '%s' or simulation folder for details." % ErtLog.getFilename())
 
 
     def __str__(self):

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -1,5 +1,4 @@
 from ert.enkf.enums import HookRuntime
-from ert.enkf import ErtLog
 from ert_gui.simulation.models import BaseRunModel, ErtRunError
 
 
@@ -21,8 +20,7 @@ class EnsembleExperiment(BaseRunModel):
         success = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(active_realization_mask)
 
         if not success:
-            raise ErtRunError("Simulation or loading of results failed! \n"
-                              "Check ERT log file '%s' or simulation folder for details." % ErtLog.getFilename())
+            self.checkHaveSufficientRealizations(active_realization_mask)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )

--- a/python/python/ert_gui/simulation/models/ensemble_experiment.py
+++ b/python/python/ert_gui/simulation/models/ensemble_experiment.py
@@ -17,10 +17,9 @@ class EnsembleExperiment(BaseRunModel):
 
         self.setPhaseName("Running ensemble experiment...", indeterminate=False)
 
-        success = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(active_realization_mask)
+        num_successful_realizations = self.ert().getEnkfSimulationRunner().runEnsembleExperiment(active_realization_mask)
 
-        if not success:
-            self.checkHaveSufficientRealizations(active_realization_mask)
+        self.checkHaveSufficientRealizations(num_successful_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )

--- a/python/python/ert_gui/simulation/models/ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/ensemble_smoother.py
@@ -26,10 +26,9 @@ class EnsembleSmoother(BaseRunModel):
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
 
         self.setPhaseName("Running forecast...", indeterminate=False)
-        success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_CONDITIONAL , 0)
+        num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_CONDITIONAL , 0)
 
-        if not success:
-            self.checkHaveSufficientRealizations(active_realization_mask)
+        self.checkHaveSufficientRealizations(num_successful_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
@@ -54,10 +53,9 @@ class EnsembleSmoother(BaseRunModel):
 
         self.setPhaseName("Running forecast...", indeterminate=False)
 
-        success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_NONE, 1)
+        num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_NONE, 1)
 
-        if not success:
-            self.checkHaveSufficientRealizations(active_realization_mask)
+        self.checkHaveSufficientRealizations(num_successful_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )

--- a/python/python/ert_gui/simulation/models/ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/ensemble_smoother.py
@@ -29,15 +29,7 @@ class EnsembleSmoother(BaseRunModel):
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_CONDITIONAL , 0)
 
         if not success:
-            min_realization_count = self.ert().analysisConfig().getMinRealisations()
-            success_count = active_realization_mask.count()
-
-            if min_realization_count > success_count:
-                raise ErtRunError("Simulation failed! Number of successful realizations less than MIN_REALIZATIONS %d < %d" % (success_count, min_realization_count))
-            elif success_count == 0:
-                raise ErtRunError("Simulation failed! All realizations failed!")
-            #else ignore and continue
-
+            self.checkHaveSufficientRealizations(active_realization_mask)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )
@@ -65,7 +57,7 @@ class EnsembleSmoother(BaseRunModel):
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_NONE, 1)
 
         if not success:
-            raise ErtRunError("Simulation failed!")
+            self.checkHaveSufficientRealizations(active_realization_mask)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )

--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -25,10 +25,9 @@ class IteratedEnsembleSmoother(BaseRunModel):
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
 
         self.setPhaseName("Running forecast...", indeterminate=False)
-        success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, mode, phase)
+        num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, mode, phase)
 
-        if not success:
-            self.checkHaveSufficientRealizations(active_realization_mask)
+        self.checkHaveSufficientRealizations(num_successful_realizations)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )

--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -28,14 +28,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, mode, phase)
 
         if not success:
-            min_realization_count = self.ert().analysisConfig().getMinRealisations()
-            success_count = active_realization_mask.count()
-
-            if min_realization_count > success_count:
-                raise ErtRunError("Simulation failed! Number of successful realizations less than MIN_REALIZATIONS %d < %d" % (success_count, min_realization_count))
-            elif success_count == 0:
-                raise ErtRunError("Simulation failed! All realizations failed!")
-            #ignore and continue
+            self.checkHaveSufficientRealizations(active_realization_mask)
 
         self.setPhaseName("Post processing...", indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.POST_SIMULATION )

--- a/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
+++ b/python/python/ert_gui/simulation/models/multiple_data_assimilation.py
@@ -79,7 +79,7 @@ class MultipleDataAssimilation(BaseRunModel):
 
 
         for iteration, weight in enumerate(weights):
-            success = self.simulateAndPostProcess(target_case_format, active_realization_mask, iteration)
+            num_successful_realizations = self.simulateAndPostProcess(target_case_format, active_realization_mask, iteration)
 
             # We exit because the user has pressed 'Kill all simulations'.
             if self.userExitCalled( ):
@@ -87,8 +87,7 @@ class MultipleDataAssimilation(BaseRunModel):
                 return
 
             # We exit if there are too few realisations left for updating.
-            if not success:
-                self.checkHaveSufficientRealizations(active_realization_mask)
+            self.checkHaveSufficientRealizations(num_successful_realizations)
 
             self.update(target_case_format, iteration, weights[iteration])
 
@@ -129,16 +128,15 @@ class MultipleDataAssimilation(BaseRunModel):
         self.setPhaseName(phase_string)
         self.ert().getEnkfSimulationRunner().runWorkflows( HookRuntime.PRE_SIMULATION )
 
-
         phase_string = "Running forecast for iteration: %d" % iteration
         self.setPhaseName(phase_string, indeterminate=False)
-        success = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_CONDITIONAL, iteration)
+        num_successful_realizations = self.ert().getEnkfSimulationRunner().runSimpleStep(active_realization_mask, EnkfInitModeEnum.INIT_CONDITIONAL, iteration)
         
         phase_string = "Post processing for iteration: %d" % iteration
         self.setPhaseName(phase_string, indeterminate=True)
         self.ert().getEnkfSimulationRunner().runWorkflows(HookRuntime.POST_SIMULATION)
 
-        return success
+        return num_successful_realizations
 
 
     @staticmethod

--- a/python/tests/ert/enkf/test_analysis_config.py
+++ b/python/tests/ert/enkf/test_analysis_config.py
@@ -24,9 +24,11 @@ class AnalysisConfigTest(ExtendedTestCase):
 
     def test_keywords_for_monitoring_simulation_runtime(self):
         ac = AnalysisConfig()
-        ac.set_min_realisations( 100 )
-        self.assertEqual( 100 , ac.getMinRealisations() )
-        
+
+        # Unless the MIN_REALIZATIONS is set in config, one is required to have "all" realizations.
+        self.assertFalse(ac.haveEnoughRealisations(5, 10))
+        self.assertTrue(ac.haveEnoughRealisations(10, 10))
+
         ac.set_max_runtime( 50 )
         self.assertEqual( 50 , ac.get_max_runtime() )
 

--- a/script/job_dispatch.py
+++ b/script/job_dispatch.py
@@ -214,7 +214,7 @@ def run_one(job):
             (return_pid , exit_status) = os.waitpid(pid , 0)
 
 
-    # Check sucess of job; look for both target_file and
+    # Check success of job; look for both target_file and
     # error_file. Both can be used to signal failure
     # independently.
 

--- a/share/bin/job_dispatch.py
+++ b/share/bin/job_dispatch.py
@@ -301,7 +301,7 @@ def run_one(job):
             (return_pid , exit_status) = os.waitpid(pid , 0)
 
 
-    # Check sucess of job; look for both target_file and
+    # Check success of job; look for both target_file and
     # error_file. Both can be used to signal failure
     # independently.
 


### PR DESCRIPTION
Have removed the get / set _min_realizations public functions in C and Python. Replaced with have_enough_realizations.

Changed behavior when the config MIN_REALIZATIONS is not set (is defaulted to zero), or explicitly set to zero. 

Now, zero is a no-op for this, and one require all simulations to succeed in stead.