### PR TITLE
Ecl grid opm copy

### DIFF
--- a/libecl/include/ert/ecl/ecl_grid.h
+++ b/libecl/include/ert/ecl/ecl_grid.h
@@ -201,6 +201,7 @@ extern "C" {
   void                    ecl_grid_fwrite_EGRID_header__( int dims[3] , const float mapaxes[6], int dualp_flag , fortio_type * fortio);
   void                    ecl_grid_fwrite_EGRID_header( int dims[3] , const float mapaxes[6], fortio_type * fortio);
 
+  int              ecl_grid_zcorn_index(const ecl_grid_type * grid , int i, int j , int k , int c);
   float          * ecl_grid_alloc_zcorn_data( const ecl_grid_type * grid );
   ecl_kw_type    * ecl_grid_alloc_zcorn_kw( const ecl_grid_type * grid );
   int            * ecl_grid_alloc_actnum_data( const ecl_grid_type * grid );
@@ -208,6 +209,7 @@ extern "C" {
   ecl_kw_type    * ecl_grid_alloc_hostnum_kw( const ecl_grid_type * grid );
   ecl_kw_type    * ecl_grid_alloc_gridhead_kw( int nx, int ny , int nz , int grid_nr);
   ecl_grid_type  * ecl_grid_alloc_copy( const ecl_grid_type * src_grid );
+  ecl_grid_type  * ecl_grid_alloc_processed_copy( const ecl_grid_type * src_grid , const double * zcorn , const int * actnum);
 
   void             ecl_grid_ri_export( const ecl_grid_type * ecl_grid , double * ri_points);
   void             ecl_grid_cell_ri_export( const ecl_grid_type * ecl_grid , int global_index , double * ri_points);

--- a/libecl/tests/ecl_grid_export.c
+++ b/libecl/tests/ecl_grid_export.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 
 #include <ert/util/test_util.h>
+#include <ert/util/test_work_area.h>
 
 #include <ert/ecl/ecl_grid.h>
 #include <ert/ecl/ecl_kw.h>
@@ -78,30 +79,105 @@ void export_zcorn( const ecl_grid_type * grid , ecl_file_type * ecl_file ) {
 }
 
 
-void export_mapaxes( const ecl_grid_type * grid , ecl_file_type * ecl_file ) {
-  ecl_kw_type * mapaxes_kw = ecl_file_iget_named_kw( ecl_file , "MAPAXES" , 0);
-  double mapaxes[6];
-  int i;
+void copy_processed( const ecl_grid_type * src ) {
+  {
+    ecl_grid_type * copy = ecl_grid_alloc_processed_copy( src , NULL , NULL );
+    test_assert_true( ecl_grid_compare(src, copy,true,true,false) );
+    ecl_grid_free( copy );
+  }
 
-  test_assert_true( ecl_grid_use_mapaxes( grid ));
-  ecl_grid_init_mapaxes_data_double( grid , mapaxes );
-  for (i= 0; i < 6; i++)
-    test_assert_double_equal( ecl_kw_iget_float( mapaxes_kw , i) , mapaxes[i]);
+
+  {
+    int * actnum = util_malloc( ecl_grid_get_global_size( src ) * sizeof * actnum );
+    int index = 0;
+    ecl_grid_init_actnum_data( src , actnum );
+
+    while (true) {
+      if (actnum[index] == 1) {
+        actnum[index] = 0;
+        break;
+      }
+      index++;
+    }
+
+    {
+      ecl_grid_type * copy = ecl_grid_alloc_processed_copy( src , NULL , actnum );
+      test_assert_int_equal( 1 , ecl_grid_get_active_size(src) - ecl_grid_get_active_size( copy ));
+      ecl_grid_free( copy );
+    }
+    free( actnum );
+  }
+
+
+  {
+    double * zcorn_double = util_malloc( ecl_grid_get_zcorn_size( src ) * sizeof * zcorn_double );
+    int i = 0;
+    int j = 0;
+    int k = 0;
+
+    ecl_grid_init_zcorn_data_double( src , zcorn_double );
+    {
+      ecl_grid_type * copy = ecl_grid_alloc_processed_copy( src , zcorn_double , NULL );
+      test_assert_double_equal( ecl_grid_get_cell_volume3(src,i,j,k) , ecl_grid_get_cell_volume3( copy , i , j , k ));
+      ecl_grid_free( copy );
+    }
+
+    
+    for (int c = 0; c < 4; c++) {
+      double dz = zcorn_double[ ecl_grid_zcorn_index( src , i , j , k , c + 4 ) ] - zcorn_double[ ecl_grid_zcorn_index( src , i , j , k , c ) ];
+      zcorn_double[ ecl_grid_zcorn_index( src , i , j , k , c + 4 ) ] += dz;
+    }
+    {
+      ecl_grid_type * copy = ecl_grid_alloc_processed_copy( src , zcorn_double , NULL );
+      test_assert_double_equal( ecl_grid_get_cell_volume3(src,i,j,k) * 2 , ecl_grid_get_cell_volume3( copy , i , j , k ));
+      ecl_grid_free( copy );
+    }
+
+    free( zcorn_double );
+  }
+}
+
+
+void export_mapaxes( const ecl_grid_type * grid , ecl_file_type * ecl_file ) {
+  if (ecl_file_has_kw(ecl_file , "MAPAXES")) {
+    ecl_kw_type * mapaxes_kw = ecl_file_iget_named_kw( ecl_file , "MAPAXES" , 0);
+    double mapaxes[6];
+    int i;
+
+    test_assert_true( ecl_grid_use_mapaxes( grid ));
+    ecl_grid_init_mapaxes_data_double( grid , mapaxes );
+    for (i= 0; i < 6; i++)
+      test_assert_double_equal( ecl_kw_iget_float( mapaxes_kw , i) , mapaxes[i]);
+  }
 }
 
 
 
 int main(int argc , char ** argv) {
-  const char * grid_file = argv[1];
-  ecl_grid_type * ecl_grid = ecl_grid_alloc( grid_file );
-  ecl_file_type * ecl_file = ecl_file_open( grid_file , 0) ;
+  test_work_area_type * work_area = test_work_area_alloc("grid_export");
+  {
+    char * test_grid = "TEST.EGRID";
+    char * grid_file;
+    if (argc == 1) {
+      ecl_grid_type * grid = ecl_grid_alloc_rectangular(4,4,2,1,1,1,NULL);
+      grid_file = test_grid;
+      ecl_grid_fwrite_EGRID( grid , grid_file , true );
+      ecl_grid_free( grid );
+    } else
+      grid_file = argv[1];
 
+    {
+      ecl_grid_type * ecl_grid = ecl_grid_alloc( grid_file );
+      ecl_file_type * ecl_file = ecl_file_open( grid_file , 0) ;
 
-  export_actnum( ecl_grid , ecl_file );
-  export_coord( ecl_grid , ecl_file );
-  export_zcorn( ecl_grid , ecl_file );
-  export_mapaxes( ecl_grid , ecl_file );
-
-  ecl_file_close( ecl_file );
-  ecl_grid_free( ecl_grid );
+      export_actnum( ecl_grid , ecl_file );
+      export_coord( ecl_grid , ecl_file );
+      export_zcorn( ecl_grid , ecl_file );
+      export_mapaxes( ecl_grid , ecl_file );
+      copy_processed( ecl_grid );
+      ecl_file_close( ecl_file );
+      ecl_grid_free( ecl_grid );
+    }
+  }
+  test_work_area_free( work_area );
 }

--- a/libecl/tests/ecl_grid_export.c
+++ b/libecl/tests/ecl_grid_export.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
-   The file 'ecl_grid_export.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2014  Statoil ASA, Norway.
+
+   The file 'ecl_grid_export.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -30,7 +30,7 @@ void export_actnum( const ecl_grid_type * ecl_grid , ecl_file_type * ecl_file ) 
   int * actnum = util_malloc( ecl_kw_get_size( actnum_kw ) * sizeof * actnum );
 
   ecl_grid_init_actnum_data( ecl_grid , actnum );
-  for (int i=0; i < ecl_kw_get_size( actnum_kw); i++) 
+  for (int i=0; i < ecl_kw_get_size( actnum_kw); i++)
     test_assert_int_equal( actnum[i] , ecl_kw_iget_int( actnum_kw , i ));
 
   free( actnum );
@@ -46,10 +46,10 @@ void export_coord( const ecl_grid_type * grid , ecl_file_type * ecl_file ) {
 
     ecl_grid_init_coord_data( grid , coord_float );
     ecl_grid_init_coord_data_double( grid , coord_double );
-    
-    for (int i=0; i < ecl_grid_get_coord_size( grid ); i++) 
+
+    for (int i=0; i < ecl_grid_get_coord_size( grid ); i++)
       test_assert_double_equal( coord_double[i] , coord_float[i]);
-    
+
     free( coord_float );
     free( coord_double );
   }
@@ -65,13 +65,13 @@ void export_zcorn( const ecl_grid_type * grid , ecl_file_type * ecl_file ) {
 
     ecl_grid_init_zcorn_data( grid , zcorn_float );
     ecl_grid_init_zcorn_data_double( grid , zcorn_double );
-    
+
     for (int i=0; i < ecl_grid_get_zcorn_size( grid ); i++) {
       test_assert_double_equal( zcorn_double[i] , zcorn_float[i]);
       test_assert_float_equal( zcorn_float[i] , ecl_kw_iget_float( zcorn_kw , i ));
     }
 
-    
+
     free( zcorn_float );
     free( zcorn_double );
   }
@@ -82,7 +82,7 @@ void export_mapaxes( const ecl_grid_type * grid , ecl_file_type * ecl_file ) {
   ecl_kw_type * mapaxes_kw = ecl_file_iget_named_kw( ecl_file , "MAPAXES" , 0);
   double mapaxes[6];
   int i;
-  
+
   test_assert_true( ecl_grid_use_mapaxes( grid ));
   ecl_grid_init_mapaxes_data_double( grid , mapaxes );
   for (i= 0; i < 6; i++)

--- a/libecl/tests/ecl_grid_volume.c
+++ b/libecl/tests/ecl_grid_volume.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'ecl_grid_volume.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'ecl_grid_volume.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,7 +34,7 @@ int main(int argc , char ** argv) {
   const char * path_case = argv[1];
   char * grid_file = ecl_util_alloc_filename( NULL , path_case , ECL_EGRID_FILE , false , 0 );
   char * init_file = ecl_util_alloc_filename( NULL , path_case , ECL_INIT_FILE , false , 0 );
-  
+
   ecl_file_type * init = ecl_file_open( init_file , 0 );
   ecl_grid_type * grid = ecl_grid_alloc( grid_file );
   const ecl_kw_type * poro_kw = ecl_file_iget_named_kw( init , "PORO" , 0 );
@@ -42,7 +42,9 @@ int main(int argc , char ** argv) {
   ecl_kw_type * multpv = NULL;
   ecl_kw_type * NTG = NULL;
   bool error_found = false;
-  
+
+  double total_volume = 0;
+  double total_diff = 0;
   int error_count = 0;
   int iactive;
 
@@ -51,26 +53,28 @@ int main(int argc , char ** argv) {
 
   if (ecl_file_has_kw( init , "MULTPV"))
     multpv = ecl_file_iget_named_kw( init , "MULTPV" , 0);
-  
+
   for (iactive = 0; iactive < ecl_grid_get_nactive( grid ); ++iactive) {
     int iglobal = ecl_grid_get_global_index1A( grid , iactive );
-    
     double grid_volume = ecl_grid_get_cell_volume1( grid , iglobal );
     double eclipse_volume = ecl_kw_iget_float( porv_kw , iglobal ) / ecl_kw_iget_float( poro_kw , iactive );
-  
+
     if (NTG)
-      eclipse_volume *= ecl_kw_iget_float( NTG , iactive );
+      eclipse_volume /= ecl_kw_iget_float( NTG , iactive );
 
     if (multpv)
       eclipse_volume *= ecl_kw_iget_float( multpv , iactive);
-  
-    if (!util_double_approx_equal__( grid_volume , eclipse_volume , 1e-3)) {
-      printf("Error in cell: %d V: %g    V2: %g   \n", iglobal , grid_volume , eclipse_volume);
+
+    total_volume += grid_volume;
+    total_diff += fabs( eclipse_volume - grid_volume );
+    if (!util_double_approx_equal__( grid_volume , eclipse_volume , 2.5e-3)) {
+      double diff = 100 * (grid_volume - eclipse_volume) / eclipse_volume;
+      printf("Error in cell: %d V1: %g    V2: %g   diff:%g %% \n", iglobal , grid_volume , eclipse_volume , diff);
       error_count++;
       error_found = true;
     }
   }
-  
+  printf("Total volume difference: %g %% \n", 100 * total_diff / total_volume );
 
 
 
@@ -79,7 +83,7 @@ int main(int argc , char ** argv) {
   free( grid_file );
   free( init_file );
   if (error_found) {
-    printf("Error_count: %d \n",error_count);
+    printf("Error_count: %d / %d \n",error_count , ecl_grid_get_nactive( grid ));
     exit(1);
   }  else
     exit(0);

--- a/libecl/tests/statoil_tests.cmake
+++ b/libecl/tests/statoil_tests.cmake
@@ -93,10 +93,9 @@ add_test( ecl_grid_simple ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_simple  ${PROJECT_S
 add_test( ecl_grid_ecl2015_1 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_simple  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Eclipse2015_NNC_BUG/FF15_2015B2_LGRM_RDI15_HIST_RDIREAL1_NOSIM_GRID.EGRID )
 add_test( ecl_grid_ecl2015_2 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_simple  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Eclipse2015_NNC_BUG/FF15_2015B2_LGRM_RDI15_HIST_RDIREAL1_20142.EGRID )
 
-
-add_executable( ecl_grid_export ecl_grid_export.c )
-target_link_libraries( ecl_grid_export ecl test_util )
-add_test( ecl_grid_export ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_export  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE.EGRID )
+add_executable( ecl_grid_export_statoil ecl_grid_export.c )
+target_link_libraries( ecl_grid_export_statoil ecl test_util )
+add_test( ecl_grid_export_statoil ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_export_statoil  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE.EGRID )
 
 add_executable( ecl_grid_volume ecl_grid_volume.c )
 target_link_libraries( ecl_grid_volume ecl test_util )

--- a/libecl/tests/statoil_tests.cmake
+++ b/libecl/tests/statoil_tests.cmake
@@ -101,13 +101,15 @@ add_executable( ecl_grid_volume ecl_grid_volume.c )
 target_link_libraries( ecl_grid_volume ecl test_util )
 add_test( ecl_grid_volume1 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_volume  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE )
 add_test( ecl_grid_volume2 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_volume  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/VolumeTest/TEST1 )
+add_test( ecl_grid_volume3 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_volume  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/OsebergSyd/Omega/OMEGA-0)
+add_test( ecl_grid_volume4 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_volume  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Norne/reservoir_models/Norne_ATW2013/NORNE_ATW2013)
 
-# The grid volume test fails miserably on the test case given as example three; looking at
+# The grid volume test fails miserably on the test case given as example five; looking at
 # the failures one could actually suspect that the ECLIPSE algorithm for PORV calculations
 # has been different in this file - i.e. that the absolute value of the individual
 # tetrahedron parts have been taken during the sum, and not at the end. At least the ert
 # algorithm gets volumes ~ 0 whereas ECLIPSE reports ~10^9 for the same cell.
-# add_test( ecl_grid_volume3 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_volume  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Heidrun/Summary/FF12_2013B3_CLEAN_RS)
+# add_test( ecl_grid_volume5 ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_volume  ${PROJECT_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Heidrun/Summary/FF12_2013B3_CLEAN_RS)
 
 add_executable( ecl_grid_dims ecl_grid_dims.c )
 target_link_libraries( ecl_grid_dims ecl test_util )

--- a/libecl/tests/tests.cmake
+++ b/libecl/tests/tests.cmake
@@ -100,3 +100,6 @@ add_executable( ecl_fault_block_layer ecl_fault_block_layer.c )
 target_link_libraries( ecl_fault_block_layer ecl test_util )
 add_test( ecl_fault_block_layer ${EXECUTABLE_OUTPUT_PATH}/ecl_fault_block_layer ) 
 
+add_executable( ecl_grid_export ecl_grid_export.c )
+target_link_libraries( ecl_grid_export ecl test_util )
+add_test( ecl_grid_export ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_export  )


### PR DESCRIPTION
Will create a copy of a grid where  ACTNUM and/or zcorn has been modified.