### PR TITLE
Possibility to assign an analysis module to a ministep

### DIFF
--- a/libenkf/include/ert/enkf/local_config.h
+++ b/libenkf/include/ert/enkf/local_config.h
@@ -23,6 +23,8 @@
 
 #include <ert/ecl/ecl_grid.h>
 
+#include <ert/analysis/analysis_module.h>
+
 #include <ert/enkf/local_updatestep.h>
 #include <ert/enkf/local_ministep.h>
 #include <ert/enkf/ensemble_config.h>
@@ -124,7 +126,7 @@ typedef struct local_config_struct local_config_type;
 local_config_type           * local_config_alloc( );
 void local_config_clear( local_config_type * local_config );
 void                          local_config_free( local_config_type * local_config );
-local_ministep_type         * local_config_alloc_ministep( local_config_type * local_config , const char * key );
+local_ministep_type         * local_config_alloc_ministep( local_config_type * local_config , const char * key,  analysis_module_type* analysis_module );
 local_ministep_type         * local_config_alloc_ministep_copy( local_config_type * local_config , const char * src_key , const char * new_key);
 void                          local_config_set_default_updatestep( local_config_type * local_config , local_updatestep_type * update_step );
 local_updatestep_type       * local_config_get_updatestep( const local_config_type * local_config );

--- a/libenkf/include/ert/enkf/local_ministep.h
+++ b/libenkf/include/ert/enkf/local_ministep.h
@@ -26,6 +26,8 @@ extern "C" {
 #include <ert/util/hash.h>
 #include <ert/util/stringlist.h>
 
+#include <ert/analysis/analysis_module.h>
+
 #include <ert/enkf/active_list.h>
 #include <ert/enkf/local_dataset.h>
 #include <ert/enkf/local_obsdata.h>
@@ -33,7 +35,7 @@ extern "C" {
 
 typedef struct local_ministep_struct local_ministep_type;
 
-local_ministep_type * local_ministep_alloc(const char * name);
+local_ministep_type * local_ministep_alloc(const char * name, analysis_module_type* analysis_module);
 void                  local_ministep_free(local_ministep_type * ministep);
 void                  local_ministep_free__(void * arg);
 void                  local_ministep_add_obs(local_ministep_type * ministep, const char * obs_key);
@@ -56,6 +58,8 @@ local_obsdata_type  * local_ministep_get_obsdata(const local_ministep_type * min
 local_dataset_type  * local_ministep_get_dataset( const local_ministep_type * ministep, const char * dataset_name);
 bool                  local_ministep_has_dataset( const local_ministep_type * ministep, const char * dataset_name);
 int                   local_ministep_get_num_dataset( const local_ministep_type * ministep );
+bool                  local_ministep_has_analysis_module( const local_ministep_type * ministep );
+analysis_module_type* local_ministep_get_analysis_module( const local_ministep_type * ministep );
 
 UTIL_SAFE_CAST_HEADER(local_ministep);
 UTIL_IS_INSTANCE_HEADER(local_ministep);

--- a/libenkf/src/local_config.c
+++ b/libenkf/src/local_config.c
@@ -572,8 +572,8 @@ void local_config_free(local_config_type * local_config) {
 
 
 
-local_ministep_type * local_config_alloc_ministep( local_config_type * local_config , const char * key) {
-  local_ministep_type * ministep = local_ministep_alloc( key );
+local_ministep_type * local_config_alloc_ministep( local_config_type * local_config , const char * key, analysis_module_type* analysis_module) {
+  local_ministep_type * ministep = local_ministep_alloc( key, analysis_module );
   hash_insert_hash_owned_ref( local_config->ministep_storage , key , ministep , local_ministep_free__);
   return ministep;
 }
@@ -949,7 +949,7 @@ static void local_config_CREATE_UPDATESTEP( local_config_type * config , local_c
 
 static void local_config_CREATE_MINISTEP( local_config_type * config , local_context_type * context , FILE * stream , bool binary) {
   char * mini_name = read_alloc_string( stream , binary );
-  local_config_alloc_ministep( config , mini_name );
+  local_config_alloc_ministep( config , mini_name, NULL );
   free( mini_name );
 }
 

--- a/libenkf/src/local_ministep.c
+++ b/libenkf/src/local_ministep.c
@@ -19,6 +19,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 
 #include <ert/util/hash.h>
 #include <ert/util/util.h>
@@ -55,6 +56,7 @@ struct local_ministep_struct {
   char              * name;             /* A name used for this ministep - string is also used as key in a hash table holding this instance. */
   hash_type         * datasets;         /* A hash table of local_dataset_type instances - indexed by the name of the datasets. */
   local_obsdata_type * observations;
+  analysis_module_type * analysis_module;
 };
 
 
@@ -66,7 +68,7 @@ struct local_ministep_struct {
 UTIL_SAFE_CAST_FUNCTION(local_ministep , LOCAL_MINISTEP_TYPE_ID)
 UTIL_IS_INSTANCE_FUNCTION(local_ministep , LOCAL_MINISTEP_TYPE_ID)
 
-local_ministep_type * local_ministep_alloc(const char * name) {
+local_ministep_type * local_ministep_alloc(const char * name, analysis_module_type* analysis_module) {
   local_ministep_type * ministep = util_malloc( sizeof * ministep );
 
   ministep->name         = util_alloc_string_copy( name );
@@ -79,6 +81,7 @@ local_ministep_type * local_ministep_alloc(const char * name) {
 
 
   ministep->datasets     = hash_alloc();
+  ministep->analysis_module = analysis_module;
   UTIL_TYPE_ID_INIT( ministep , LOCAL_MINISTEP_TYPE_ID);
 
   return ministep;
@@ -236,6 +239,14 @@ bool local_ministep_has_data_key(const local_ministep_type * ministep , const ch
     hash_iter_free( dataset_iter );
   }
   return has_key;
+}
+
+bool local_ministep_has_analysis_module( const local_ministep_type * ministep){
+  return ministep->analysis_module != NULL;
+}
+
+analysis_module_type* local_ministep_get_analysis_module( const local_ministep_type * ministep ){
+  return ministep->analysis_module;
 }
 
 /*****************************************************************/

--- a/python/python/ert/enkf/enkf_main.py
+++ b/python/python/ert/enkf/enkf_main.py
@@ -109,7 +109,7 @@ class EnKFMain(BaseCClass):
     def getLocalConfig(self):
         """ @rtype: LocalConfig """
         config = EnKFMain.cNamespace().get_local_config(self).setParent(self)
-        config.initAttributes( self.ensembleConfig() , self.getObservations() , self.eclConfig().get_grid() )
+        config.initAttributes( self.ensembleConfig() , self.getObservations() , self.eclConfig().getGrid() )
         return config
 
 

--- a/python/python/ert/enkf/local_config.py
+++ b/python/python/ert/enkf/local_config.py
@@ -16,6 +16,7 @@
 from ert.cwrap import BaseCClass, CWrapper
 from ert.enkf import ENKF_LIB, LocalUpdateStep
 from ert.enkf.local_ministep import LocalMinistep
+from ert.analysis import AnalysisModule
 
 
 class LocalConfig(BaseCClass):
@@ -70,10 +71,12 @@ class LocalConfig(BaseCClass):
         assert isinstance(filename, str)
         LocalConfig.cNamespace().add_config_file(self, filename)
                          
-    def createMinistep(self, mini_step_key):
+    def createMinistep(self, mini_step_key, analysis_module = None):
         """ @rtype: Ministep """
         assert isinstance(mini_step_key, str)
-        LocalConfig.cNamespace().create_ministep(self, mini_step_key)         
+        if analysis_module:
+            assert isinstance(analysis_module, AnalysisModule)
+        LocalConfig.cNamespace().create_ministep(self, mini_step_key, analysis_module)         
         return self.getMinistep(mini_step_key)  
     
     def createObsdata(self, obsdata_key):
@@ -170,7 +173,7 @@ LocalConfig.cNamespace().add_config_file                 = cwrapper.prototype("v
 LocalConfig.cNamespace().get_updatestep                  = cwrapper.prototype("local_updatestep_ref local_config_get_updatestep( local_config )")
                                                          
 LocalConfig.cNamespace().get_ministep                    = cwrapper.prototype("local_ministep_ref local_config_get_ministep( local_config, char*)")
-LocalConfig.cNamespace().create_ministep                 = cwrapper.prototype("void local_config_alloc_ministep( local_config, char*)")
+LocalConfig.cNamespace().create_ministep                 = cwrapper.prototype("void local_config_alloc_ministep( local_config, char*, analysis_module)")
 LocalConfig.cNamespace().attach_ministep                 = cwrapper.prototype("void local_updatestep_add_ministep( local_updatestep, local_ministep)")
                                                          
 LocalConfig.cNamespace().get_obsdata                     = cwrapper.prototype("local_obsdata_ref local_config_get_obsdata( local_config, char*)")

--- a/python/tests/ert/enkf/test_local_config.py
+++ b/python/tests/ert/enkf/test_local_config.py
@@ -24,13 +24,14 @@ class LocalConfigTest(ExtendedTestCase):
             main = test_context.getErt()
             self.assertTrue(main, "Load failed")
             
-            local_config = main.getLocalConfig()  
+            local_config = main.getLocalConfig()
+            analysis_module = main.analysisConfig().getModule("STD_ENKF")
 
             self.AllActive(local_config)
 
             local_config.clear()
 
-            self.MiniStep(local_config)
+            self.MiniStep(local_config, analysis_module)
             
             self.AttachMinistep(local_config)
             
@@ -70,10 +71,10 @@ class LocalConfigTest(ExtendedTestCase):
         self.assertEqual( len(obsdata) , 3 )
         
  
-    def MiniStep( self, local_config ):                        
+    def MiniStep( self, local_config, analysis_module ):                        
             
-        # Ministep                                      
-        ministep = local_config.createMinistep("MINISTEP")
+        # Ministep        
+        ministep = local_config.createMinistep("MINISTEP", analysis_module)
         self.assertTrue(isinstance(ministep, LocalMinistep))
 
         self.assertFalse( "DATA" in ministep )


### PR DESCRIPTION
With this PR we open up the possibility for the user of local configs to change the analysis modules for distinct ministeps. 

The python syntax for this assignment is:

`ministep.setAnalysisModule(ert.analysisConfig(), "FWD_STEP_ENKF")`

The documentation for local configuration will be updated in a separated PR.
