### PR TITLE
WIP: ctime defaults to UTC.

### DIFF
--- a/python/python/ert/util/ctime.py
+++ b/python/python/ert/util/ctime.py
@@ -47,16 +47,21 @@ class CTime(BaseCValue):
         """ @rtype: int """
         return self.value()
 
-    def time(self):
-        """Return this time_t as a time.localtime() object"""
-        return time.localtime(self.value())
+    def time(self, localtime = True):
+        """Return this time_t as a time.localtime() or time.gmtime() object"""
+        if localtime:
+            return time.localtime(self.value())
+        else:
+            return time.gmtime(self.value())
 
-    def date(self):
+    def date(self, localtime = True):
         """Return this time_t as a datetime.date([year, month, day])"""
-        return datetime.date(*self.time()[0:3])
+        t = self.time( localtime )
+        return datetime.date(*t[0:3])
 
-    def datetime(self):
-        return datetime.datetime(*self.time()[0:6])
+    def datetime(self, localtime = True):
+        t = self.time( localtime )
+        return datetime.datetime(*t[0:6])
 
     def __str__(self):
         return self.datetime().strftime("%Y-%m-%d %H:%M:%S%z")

--- a/python/tests/core/util/test_ctime.py
+++ b/python/tests/core/util/test_ctime.py
@@ -148,4 +148,8 @@ class CTimeTest(TestCase):
         self.assertEqual(localized_dt.astimezone(utc), datetime(1970, 1, 1, 0, tzinfo=utc))
 
         localized_d = datetime(1970, 1, 1, 0, tzinfo=utc).astimezone(local_timezone)
-        self.assertEqual(t.date(), localized_d.date())
+        self.assertEqual(t.date( True ), localized_d.date())
+        
+        utc_d = datetime(1970, 1, 1, 0, tzinfo=utc)
+        self.assertEqual(t.date( False ), utc_d.date())
+        self.assertEqual(t.date( False ), utc_d.date())


### PR DESCRIPTION
For discussion. 

With this patch the `ert.util.ctime` class can optionally use `time.gmtime()` instead of `time.localtime()`; default behavior is still to use `time.localtime()`.