### PR TITLE
Simplified loading of shared libraries.

### DIFF
--- a/python/python/ert/__init__.py
+++ b/python/python/ert/__init__.py
@@ -37,9 +37,7 @@ Python code should be able to locate the shared libraries without
 (necessarily) using the LD_LIBRARY_PATH variable. The default
 behaviour is to try to load from the library ../../lib64, but by using
 the enviornment variable ERT_LIBRARY_PATH you can alter how ert looks
-for shared libraries. This module will set the ert_lib_path of the
-ert.cwrap.clib module; the actual loading will take place in that
-module.
+for shared libraries. 
 
    1. By default the code will try to load the shared libraries from
       '../../lib64' relative to the location of this file.
@@ -58,10 +56,9 @@ alternative fails, the loader will try the default load behaviour
 before giving up completely.
 """
 import os.path
-import cwrap.clib
 import sys
 import warnings
-
+import cwrap.clib
 
 
 try:
@@ -107,23 +104,26 @@ if env_lib_path:
 # Check that the final ert_lib_path setting corresponds to an existing
 # directory.
 if ert_lib_path:
-    if not os.path.exists( ert_lib_path ):
+    if not os.path.isdir( ert_lib_path ):
         ert_lib_path = None
         
-
-
-# Set the module variables ert_lib_path and so_version of the
-# ert.cwrap.clib module; this is where the actual loading will be
-# performed.
-cwrap.clib.ert_lib_path   = ert_lib_path
-cwrap.clib.ert_so_version = ert_so_version
 
 if sys.hexversion < required_version_hex:
     raise Exception("ERT Python requires at least version 2.6 of Python")
 
+# This load() function is *the* function actually loading shared
+# libraries.
+
+def load(name):
+    return cwrap.clib.load( name , path = ert_lib_path , so_version = ert_so_version)
 
 
 from ert.util import Version
 from ert.util import updateAbortSignals
 
 updateAbortSignals( )
+
+#-----------------------------------------------------------------
+
+    
+

--- a/python/python/ert/analysis/__init__.py
+++ b/python/python/ert/analysis/__init__.py
@@ -15,19 +15,19 @@
 #  for more details. 
 
 
-import ert.cwrap.clib as clib
+import ert
 from ert.cwrap.metacwrap import Prototype
 import ert.util
 
 class AnalysisPrototype(Prototype):
-    lib = clib.ert_load("libanalysis")
+    lib = ert.load("libanalysis")
 
     def __init__(self, prototype, bind=True):
         super(AnalysisPrototype, self).__init__(AnalysisPrototype.lib, prototype, bind=bind)
 
 
 
-ANALYSIS_LIB = clib.ert_load("libanalysis")
+ANALYSIS_LIB = ert.load("libanalysis")
 
 from .enums import AnalysisModuleOptionsEnum, AnalysisModuleLoadStatusEnum
 

--- a/python/python/ert/config/__init__.py
+++ b/python/python/ert/config/__init__.py
@@ -13,11 +13,12 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from ert.cwrap import clib, Prototype
+from ert.cwrap import Prototype
+import ert
 import ert.util
 
 class ConfigPrototype(Prototype):
-    lib = clib.ert_load("libconfig")
+    lib = ert.load("libconfig")
 
     def __init__(self, prototype, bind=True):
         super(ConfigPrototype, self).__init__(ConfigPrototype.lib, prototype, bind=bind)

--- a/python/python/ert/cwrap/__init__.py
+++ b/python/python/ert/cwrap/__init__.py
@@ -49,7 +49,7 @@ from .basecvalue import BaseCValue
 from .cclass import CClass
 from .cenum import create_enum
 from .cfile import CFILE
-from .clib import load, ert_lib_path, ert_load
+from .clib import load
 from .cwrap import CWrapper, CWrapperNameSpace,CWrapError
 
 

--- a/python/python/ert/ecl/__init__.py
+++ b/python/python/ert/ecl/__init__.py
@@ -69,17 +69,16 @@ per module organization:
 import ert.util
 import ert.geo
 
-from ert.cwrap import clib
 from ert.cwrap.metacwrap import Prototype
 
 
 class EclPrototype(Prototype):
-    lib = clib.ert_load("libecl")
+    lib = ert.load("libecl")
 
     def __init__(self, prototype, bind=True):
         super(EclPrototype, self).__init__(EclPrototype.lib, prototype, bind=bind)
 
-ECL_LIB = clib.ert_load("libecl")
+ECL_LIB = ert.load("libecl")
 
 from .ecl_util import EclFileEnum, EclFileFlagEnum, EclPhaseEnum, EclTypeEnum, EclUnitTypeEnum , EclUtil
 from .ecl_sum_var_type import EclSumVarType

--- a/python/python/ert/enkf/__init__.py
+++ b/python/python/ert/enkf/__init__.py
@@ -15,7 +15,7 @@
 #  for more details.
 
 
-import ert.cwrap.clib as clib
+import ert
 from ert.cwrap.metacwrap import Prototype
 import ert.util
 import ert.geo
@@ -27,14 +27,14 @@ import ert.config
 import ert.job_queue
 
 class EnkfPrototype(Prototype):
-    lib = clib.ert_load("libenkf")
+    lib = ert.load("libenkf")
 
     def __init__(self, prototype, bind=True):
         super(EnkfPrototype, self).__init__(EnkfPrototype.lib, prototype, bind=bind)
 
         
 
-ENKF_LIB = clib.ert_load("libenkf")
+ENKF_LIB = ert.load("libenkf")
 
 from .enums import *
 

--- a/python/python/ert/geo/__init__.py
+++ b/python/python/ert/geo/__init__.py
@@ -17,12 +17,12 @@
 Simple package for working with 2D geometry.
 
 """
+import ert
 from ert.cwrap.metacwrap import Prototype
-from ert.cwrap import clib
 import ert.util
 
 class GeoPrototype(Prototype):
-    lib = clib.ert_load("libert_geometry")
+    lib = ert.load("libert_geometry")
 
     def __init__(self, prototype, bind=True):
         super(GeoPrototype, self).__init__(GeoPrototype.lib, prototype, bind=bind)

--- a/python/python/ert/job_queue/__init__.py
+++ b/python/python/ert/job_queue/__init__.py
@@ -54,9 +54,9 @@ external commands.
 
 
 import os
+import ert
 import ert.util
 import ert.config
-import ert.cwrap.clib as clib
 from ert.cwrap.metacwrap import Prototype
 
 def setenv( var, value):
@@ -72,10 +72,10 @@ if LSF_HOME:
     setenv("LSF_SERVERDIR", "%s/etc" % LSF_HOME)
     setenv("LSF_ENVDIR", "%s/conf" % LSF_HOME)   # This is wrong: Statoil: /prog/LSF/conf
 
-JOB_QUEUE_LIB = clib.ert_load("libjob_queue")
+JOB_QUEUE_LIB = ert.load("libjob_queue")
 
 class QueuePrototype(Prototype):
-    lib = clib.ert_load("libjob_queue")
+    lib = ert.load("libjob_queue")
 
     def __init__(self, prototype, bind=True):
         super(QueuePrototype, self).__init__(QueuePrototype.lib, prototype, bind=bind)

--- a/python/python/ert/job_queue/function_ert_script.py
+++ b/python/python/ert/job_queue/function_ert_script.py
@@ -1,4 +1,5 @@
-from ert.cwrap import clib, CWrapper
+import ert as ert_module
+from ert.cwrap import CWrapper
 from ert.job_queue import ErtScript
 from ert.util.stringlist import StringList
 
@@ -8,7 +9,7 @@ class FunctionErtScript(ErtScript):
     def __init__(self, ert, function_name, argument_types, argument_count):
         super(FunctionErtScript, self).__init__(ert)
 
-        lib = clib.ert_load(None)
+        lib = ert_module.load(None)
         wrapper = CWrapper(lib)
 
         parsed_argument_types = []

--- a/python/python/ert/rms/__init__.py
+++ b/python/python/ert/rms/__init__.py
@@ -1,7 +1,6 @@
-from ert.cwrap import clib
-
+import ert
 import ert.util
 import ert.geo
 import ert.ecl
 
-RMS_LIB = clib.ert_load("librms")
+RMS_LIB = ert.load("librms")

--- a/python/python/ert/sched/__init__.py
+++ b/python/python/ert/sched/__init__.py
@@ -13,13 +13,12 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from ert.cwrap import clib
-
+import ert
 import ert.ecl
 import ert.util
 import ert.geo
 
-SCHED_LIB = clib.ert_load("libsched")
+SCHED_LIB = ert.load("libsched")
 
 
 from .sched_file import SchedFile

--- a/python/python/ert/util/__init__.py
+++ b/python/python/ert/util/__init__.py
@@ -36,23 +36,12 @@ The modules included in the util package are:
    
 """
 
-import ert.cwrap.clib as clib
-
-# The libert_util library requires the libraries libz, libblas and
-# liblapack. It is assumed that the library has been compiled with a
-# suitable RPATH option (i.e. ERT_USE_RPATH has been set to True in
-# the build process) and we 'just' load the final libert_util library
-# directly. In principle it would be possible preload these libraries
-# with calls like:
-#
-# clib.load("libz" , "libz.so.1")
-# clib.load("libblas" , "libblas.so" , "libblas.so.3")
-# clib.load("liblapack" , "liblapack.so")
+import ert
 from ert.cwrap.metacwrap import Prototype
 
 
 class UtilPrototype(Prototype):
-    lib = clib.ert_load("libert_util")
+    lib = ert.load("libert_util")
 
     def __init__(self, prototype, bind=True):
         super(UtilPrototype, self).__init__(UtilPrototype.lib, prototype, bind=bind)

--- a/python/python/ert/well/__init__.py
+++ b/python/python/ert/well/__init__.py
@@ -1,9 +1,9 @@
-import ert.cwrap.clib as clib
+import ert
 import ert.util
 import ert.geo
 import ert.ecl
 
-ECL_WELL_LIB = clib.ert_load("libecl_well")
+ECL_WELL_LIB = ert.load("libecl_well")
 
 
 from .well_type_enum import WellTypeEnum

--- a/python/python/ert_gui/shell/storage.py
+++ b/python/python/ert_gui/shell/storage.py
@@ -1,3 +1,4 @@
+import ert
 from ert_gui.shell import ErtShellCollection
 from ert_gui.shell.libshell import splitArguments, getPossibleFilenameCompletions, extractFullArgument
 
@@ -10,7 +11,7 @@ STRING_SORT = 1
 OFFSET_SORT = 2
 
 import ert.cwrap.clib as clib
-UTIL_LIB = clib.ert_load("libert_util")
+UTIL_LIB = ert.load("libert_util")
 
 UTIL_LIB.block_fs_is_mount.restype = ctypes.c_bool
 UTIL_LIB.block_fs_mount.restype = ctypes.c_void_p

--- a/python/tests/core/cwrap/test_basecvalue.py
+++ b/python/tests/core/cwrap/test_basecvalue.py
@@ -1,9 +1,10 @@
+import ert
 from ctypes import c_ubyte, c_double
-from ert.cwrap import BaseCValue, clib, Prototype
+from ert.cwrap import BaseCValue, Prototype
 from ert.test import ExtendedTestCase
 
 class TestPrototype(Prototype):
-    lib = clib.ert_load("libert_util")
+    lib = ert.load("libert_util")
 
     def __init__(self, prototype):
         super(TestPrototype, self).__init__(self.lib, prototype)

--- a/python/tests/core/cwrap/test_cfile.py
+++ b/python/tests/core/cwrap/test_cfile.py
@@ -1,11 +1,12 @@
-from ert.cwrap import Prototype, CFILE, clib
+import ert
+from ert.cwrap import Prototype, CFILE
 from ert.test.extended_testcase import ExtendedTestCase
 from ert.test.test_area import TestAreaContext
 
 
 # Local copies so that the real ones don't get changed
 class TestUtilPrototype(Prototype):
-    lib = clib.ert_load("libert_util")
+    lib = ert.load("libert_util")
     def __init__(self, prototype, bind=False):
         super(TestUtilPrototype, self).__init__(TestUtilPrototype.lib, prototype, bind=bind)
 

--- a/python/tests/core/cwrap/test_cwrap.py
+++ b/python/tests/core/cwrap/test_cwrap.py
@@ -1,8 +1,9 @@
 import ctypes
-from ert.cwrap import CWrapper, BaseCClass, clib, CWrapError
+import ert
+from ert.cwrap import CWrapper, BaseCClass, CWrapError
 from ert.test  import ExtendedTestCase
 
-test_lib  = clib.ert_load("libert_util") # create a local namespace (so we don't overwrite StringList)
+test_lib  = ert.load("libert_util") # create a local namespace (so we don't overwrite StringList)
 cwrapper =  CWrapper(test_lib)
 
 class StringListTest(BaseCClass):

--- a/python/tests/core/cwrap/test_metawrap.py
+++ b/python/tests/core/cwrap/test_metawrap.py
@@ -1,6 +1,7 @@
 import ctypes
 from types import StringType, IntType
 
+import ert
 from ert.cwrap import BaseCClass, Prototype, PrototypeError
 from ert.test import ExtendedTestCase
 import ert.cwrap.clib as clib
@@ -8,7 +9,7 @@ import ert.cwrap.clib as clib
 
 # Local copies so that the real ones don't get changed
 class TestUtilPrototype(Prototype):
-    lib = clib.ert_load("libert_util")
+    lib = ert.load("libert_util")
     def __init__(self, prototype, bind=False):
         super(TestUtilPrototype, self).__init__(TestUtilPrototype.lib, prototype, bind=bind)
 

--- a/python/tests/core/ecl/test_indexed_read.py
+++ b/python/tests/core/ecl/test_indexed_read.py
@@ -1,11 +1,12 @@
 import ctypes
-from ert.cwrap import clib, CWrapper
+import ert
+from ert.cwrap import CWrapper
 from ert.ecl import EclKW, EclFile, EclTypeEnum, FortIO
 from ert.test import ExtendedTestCase, TestAreaContext
 from ert.util import IntVector
 
 
-ecl_lib = clib.ert_load("libecl")
+ecl_lib = ert.load("libecl")
 ecl_wrapper = CWrapper(ecl_lib)
 
 

--- a/python/tests/core/util/test_arg_pack.py
+++ b/python/tests/core/util/test_arg_pack.py
@@ -1,8 +1,8 @@
-from ert.cwrap import clib
+import ert
 from ert.test import ExtendedTestCase
 from ert.util import ArgPack, StringList
 
-TEST_LIB = clib.ert_load("libtest_util")
+TEST_LIB = ert.load("libtest_util")
 
 
 class ArgPackTest(ExtendedTestCase):

--- a/python/tests/core/util/test_cstring.py
+++ b/python/tests/core/util/test_cstring.py
@@ -1,9 +1,10 @@
-from ert.cwrap import clib, Prototype
+import ert
+from ert.cwrap import Prototype
 from ert.test.extended_testcase import ExtendedTestCase
 
 # Local copies so that the real ones don't get changed
 class TestUtilPrototype(Prototype):
-    lib = clib.ert_load("libert_util")
+    lib = ert.load("libert_util")
 
     def __init__(self, prototype, bind=False):
         super(TestUtilPrototype, self).__init__(TestUtilPrototype.lib, prototype, bind=bind)

--- a/python/tests/core/util/test_cthread_pool.py
+++ b/python/tests/core/util/test_cthread_pool.py
@@ -1,10 +1,9 @@
 import ctypes
-
-from ert.cwrap import clib
+import ert
 from ert.test import ExtendedTestCase
 from ert.util import CThreadPool, startCThreadPool
 
-TEST_LIB = clib.ert_load("libtest_util")
+TEST_LIB = ert.load("libtest_util")
 
 
 class CThreadPoolTest(ExtendedTestCase):

--- a/python/tests/core/util/test_spawn.py
+++ b/python/tests/core/util/test_spawn.py
@@ -3,11 +3,12 @@ import stat
 
 import sys
 
-from ert.cwrap import clib, CWrapper
+import ert
+from ert.cwrap import CWrapper
 from ert.test.extended_testcase import ExtendedTestCase
 from ert.test.test_area import TestAreaContext
 
-test_lib = clib.ert_load("libert_util") # create a local namespace (so we don't overwrite StringList)
+test_lib = ert.load("libert_util") # create a local namespace (so we don't overwrite StringList)
 cwrapper = CWrapper(test_lib)
 
 spawn = cwrapper.prototype("int util_spawn_blocking(char*, int, void*, char*, char*)")

--- a/python/tests/ert/analysis/test_analysis_module.py
+++ b/python/tests/ert/analysis/test_analysis_module.py
@@ -14,17 +14,17 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+import ert
 from ert.test import ExtendedTestCase
 from ert.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 
 from ert.util.enums import RngAlgTypeEnum, RngInitModeEnum
 from ert.util.rng import RandomNumberGenerator
-import ert.cwrap.clib as clib
 
 
 class AnalysisModuleTest(ExtendedTestCase):
     def setUp(self):
-        self.libname = clib.ert_lib_path + "/rml_enkf.so"
+        self.libname = ert.ert_lib_path + "/rml_enkf.so"
         self.rng = RandomNumberGenerator(RngAlgTypeEnum.MZRAN, RngInitModeEnum.INIT_DEFAULT)
 
     def createAnalysisModule(self):

--- a/python/tests/ert/analysis/test_rml.py
+++ b/python/tests/ert/analysis/test_rml.py
@@ -22,7 +22,7 @@ from ert.util import Matrix, BoolVector , RandomNumberGenerator
 from ert.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 from ert.enkf import MeasData , ObsData
 
-import ert.cwrap.clib as clib
+import ert
 
 
 def forward_model(params , model_error = False):
@@ -78,7 +78,7 @@ def init_matrices(ens , mask , obs , rng):
 
 class RMLTest(ExtendedTestCase):
     def setUp(self):
-        self.libname = clib.ert_lib_path + "/rml_enkf.so"
+        self.libname = ert.ert_lib_path + "/rml_enkf.so"
         self.user    = "TEST"
 
     def createAnalysisModule(self):

--- a/python/tests/ert/analysis/test_std_enkf.py
+++ b/python/tests/ert/analysis/test_std_enkf.py
@@ -19,7 +19,6 @@ from ert.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisM
 
 from ert.util.enums import RngAlgTypeEnum, RngInitModeEnum
 from ert.util.rng import RandomNumberGenerator
-import ert.cwrap.clib as clib
 
 
 class StdEnKFTest(ExtendedTestCase):

--- a/python/tests/ert/config/test_config.py
+++ b/python/tests/ert/config/test_config.py
@@ -16,13 +16,14 @@
 #  for more details. 
 import os
 
+import ert
 from ert.config import ContentTypeEnum, UnrecognizedEnum, SchemaItem, ContentItem, ContentNode, ConfigParser, ConfigContent
 from ert.cwrap import Prototype, clib
 from ert.test import ExtendedTestCase, TestAreaContext
 
 
 class TestConfigPrototype(Prototype):
-    lib = clib.ert_load("libconfig")
+    lib = ert.load("libconfig")
 
     def __init__(self, prototype, bind=False):
         super(TestConfigPrototype, self).__init__(TestConfigPrototype.lib, prototype, bind=bind)

--- a/python/tests/ert/enkf/data/test_gen_data.py
+++ b/python/tests/ert/enkf/data/test_gen_data.py
@@ -1,3 +1,4 @@
+import ert
 from ert.cwrap import clib, CWrapper
 from ert.enkf.data.enkf_node import EnkfNode
 from ert.enkf.node_id import NodeId
@@ -5,7 +6,7 @@ from ert.test import ErtTestContext
 from ert.test.extended_testcase import ExtendedTestCase
 from ert.util import BoolVector
 
-test_lib  = clib.ert_load("libenkf")
+test_lib  = ert.load("libenkf")
 cwrapper =  CWrapper(test_lib)
 
 

--- a/python/tests/ert/enkf/data/test_gen_data_config.py
+++ b/python/tests/ert/enkf/data/test_gen_data_config.py
@@ -1,3 +1,4 @@
+import ert
 from ert.cwrap import clib, CWrapper
 from ert.enkf.data import EnkfNode
 from ert.enkf.config import GenDataConfig
@@ -6,7 +7,7 @@ from ert.enkf import ForwardLoadContext
 from ert.test import ErtTestContext, ExtendedTestCase
 from ert.util import BoolVector
 
-test_lib  = clib.ert_load("libenkf")
+test_lib  = ert.load("libenkf")
 cwrapper =  CWrapper(test_lib)
 
 get_active_mask = cwrapper.prototype("bool_vector_ref gen_data_config_get_active_mask( gen_data_config )")

--- a/python/tests/ert/enkf/test_runpath_list.py
+++ b/python/tests/ert/enkf/test_runpath_list.py
@@ -1,11 +1,12 @@
 from os import path, symlink, remove
 
-from ert.cwrap import clib, CWrapper
+import ert
+from ert.cwrap import CWrapper
 from ert.test import ExtendedTestCase, TestAreaContext,ErtTestContext
 from ert.enkf import RunpathList, RunpathNode
 from ert.util import BoolVector
 
-test_lib  = clib.ert_load("libenkf") # create a local namespace
+test_lib  = ert.load("libenkf") # create a local namespace
 cwrapper =  CWrapper(test_lib)
 
 runpath_list_alloc = cwrapper.prototype("runpath_list_obj runpath_list_alloc(char*)")

--- a/python/tests/ert/enkf/test_update.py
+++ b/python/tests/ert/enkf/test_update.py
@@ -16,13 +16,14 @@
 
 import random
 
+import ert
 from ert.test import ExtendedTestCase, ErtTestContext
 from ert.util.enums import RngAlgTypeEnum, RngInitModeEnum
 from ert.util import Matrix, BoolVector , RandomNumberGenerator
 from ert.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 from ert.enkf import MeasData , ObsData , LocalObsdata
 
-import ert.cwrap.clib as clib
+
 
 
 def update(rng , mask , module , ert , meas_data , obs_data , state_size):
@@ -44,7 +45,7 @@ def update(rng , mask , module , ert , meas_data , obs_data , state_size):
 
 class UpdateTest(ExtendedTestCase):
     def setUp(self):
-        self.libname = clib.ert_lib_path + "/rml_enkf.so"
+        self.libname = ert.ert_lib_path + "/rml_enkf.so"
         self.config_file = self.createTestPath("Statoil/config/obs_testing2/config")
         self.rng = RandomNumberGenerator(RngAlgTypeEnum.MZRAN, RngInitModeEnum.INIT_DEFAULT)
 

--- a/python/tests/ert/job_queue/test_workflow_job.py
+++ b/python/tests/ert/job_queue/test_workflow_job.py
@@ -1,9 +1,10 @@
-from ert.cwrap import clib, CWrapper
+import ert
+from ert.cwrap import CWrapper
 from ert.job_queue import WorkflowJob
 from ert.test import TestAreaContext, ExtendedTestCase
 from .workflow_common import WorkflowCommon
 
-test_lib  = clib.ert_load("libjob_queue") # create a local namespace
+test_lib  = ert.load("libjob_queue") # create a local namespace
 cwrapper =  CWrapper(test_lib)
 
 alloc_config = cwrapper.prototype("c_void_p workflow_job_alloc_config()")


### PR DESCRIPTION
 - Removed the monkey-patching of the ert.cwrap.clib module, some monkey
   patching remains in ert/__init__.py

 - Removed the ability to try a list of different so names when loading
   a library.