### PR TITLE
Implemented ecl_rst_file_open_write_seek( )

### DIFF
--- a/libecl/include/ert/ecl/ecl_kw.h
+++ b/libecl/include/ert/ecl/ecl_kw.h
@@ -109,6 +109,7 @@ extern "C" {
   double         ecl_kw_iget_as_double(const ecl_kw_type * ecl_kw , int i);
   void           ecl_kw_get_data_as_double(const ecl_kw_type *, double *);
   void           ecl_kw_get_data_as_float(const ecl_kw_type * ecl_kw , float * float_data);
+  bool           ecl_kw_name_equal( const ecl_kw_type * ecl_kw , const char * name);
   bool           ecl_kw_header_eq(const ecl_kw_type *ecl_kw1 , const ecl_kw_type * ecl_kw2);
   bool           ecl_kw_equal(const ecl_kw_type *ecl_kw1, const ecl_kw_type *ecl_kw2);
   bool           ecl_kw_size_and_type_equal( const ecl_kw_type *ecl_kw1 , const ecl_kw_type * ecl_kw2 );

--- a/libecl/include/ert/ecl/ecl_rst_file.h
+++ b/libecl/include/ert/ecl/ecl_rst_file.h
@@ -33,13 +33,14 @@ typedef struct ecl_rst_file_struct ecl_rst_file_type;
   ecl_rst_file_type * ecl_rst_file_open_read( const char * filename );
   ecl_rst_file_type * ecl_rst_file_open_write( const char * filename );
   ecl_rst_file_type * ecl_rst_file_open_append( const char * filename );
+  ecl_rst_file_type * ecl_rst_file_open_write_seek( const char * filename , int report_step);
   void                ecl_rst_file_close( ecl_rst_file_type * rst_file );
   
   void                ecl_rst_file_start_solution( ecl_rst_file_type * rst_file );
   void                ecl_rst_file_end_solution( ecl_rst_file_type * rst_file );
   void                ecl_rst_file_fwrite_header( ecl_rst_file_type * rst_file , int seqnum, ecl_rsthead_type * rsthead_data );
   void                ecl_rst_file_add_kw(ecl_rst_file_type * rst_file , const ecl_kw_type * ecl_kw );
-
+  offset_type         ecl_rst_file_ftell(const ecl_rst_file_type * rst_file );
 
 #ifdef __cplusplus
 }

--- a/libecl/include/ert/ecl/fortio.h
+++ b/libecl/include/ert/ecl/fortio.h
@@ -62,6 +62,7 @@ typedef struct fortio_struct fortio_type;
   void               fortio_fwrite_record(fortio_type * , const char * buffer, int buffer_size);
   FILE        *      fortio_get_FILE(const fortio_type *);
   void               fortio_fflush(fortio_type * ) ;
+  bool               fortio_ftruncate_current( fortio_type * fortio);
   bool               fortio_is_fortio_file(fortio_type * );
   void               fortio_rewind(const fortio_type *fortio);
   const char  *      fortio_filename_ref(const fortio_type * );

--- a/libecl/src/ecl_kw.c
+++ b/libecl/src/ecl_kw.c
@@ -274,6 +274,12 @@ const char * ecl_kw_get_header(const ecl_kw_type * ecl_kw ) {
   return ecl_kw->header;
 }
 
+bool ecl_kw_name_equal( const ecl_kw_type * ecl_kw , const char * name) {
+  return (strcmp( ecl_kw->header , name) == 0);
+}
+
+
+
 void ecl_kw_get_memcpy_data(const ecl_kw_type *ecl_kw , void *target) {
   memcpy(target , ecl_kw->data , ecl_kw->size * ecl_kw->sizeof_ctype);
 }

--- a/libecl/src/ecl_rst_file.c
+++ b/libecl/src/ecl_rst_file.c
@@ -1,19 +1,20 @@
+
 /*
-   Copyright (C) 2012  Statoil ASA, Norway. 
-   
-   The file 'ecl_rst_file.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'ecl_rst_file.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdio.h>
@@ -63,7 +64,7 @@ static ecl_rst_file_type * ecl_rst_file_alloc( const char * filename ) {
 /**
    Observe that all the open() functions expect that filename conforms
    to the standard ECLIPSE conventions, i.e. with extension .FUNRST /
-   .UNRST / .Xnnnn / .Fnnnn.  
+   .UNRST / .Xnnnn / .Fnnnn.
 */
 
 ecl_rst_file_type * ecl_rst_file_open_read( const char * filename ) {
@@ -72,6 +73,68 @@ ecl_rst_file_type * ecl_rst_file_open_read( const char * filename ) {
   return rst_file;
 }
 
+
+
+/*
+  This function will scan through the file and look for seqnum
+  headers, and position the file pointer in the right location to
+  start writing data for the report step given by @report_step. The
+  file is truncated, so that the filepointer will be at the (new) EOF
+  when returning.
+*/
+
+
+ecl_rst_file_type * ecl_rst_file_open_write_seek( const char * filename , int report_step) {
+  ecl_rst_file_type * rst_file = ecl_rst_file_alloc( filename  );
+  offset_type target_pos = 0;
+  bool seqnum_found = false;
+  rst_file->fortio = fortio_open_readwrite( filename , rst_file->fmt_file , ECL_ENDIAN_FLIP );
+  /*
+     If the file does not exist at all the fortio_open_readwrite()
+     will fail, we just try again - opening a new file in normal write
+     mode, and then immediately returning.
+  */
+  if (!rst_file->fortio) {
+    rst_file->fortio = fortio_open_writer( filename , rst_file->fmt_file , ECL_ENDIAN_FLIP );
+    return rst_file;
+  }
+
+  fortio_fseek( rst_file->fortio , 0 , SEEK_SET );
+  {
+    ecl_kw_type * work_kw = ecl_kw_alloc_new("WORK-KW" , 0 , ECL_INT_TYPE , NULL);
+
+    while (true) {
+      offset_type current_offset = fortio_ftell( rst_file->fortio );
+
+      if (fortio_read_at_eof(rst_file->fortio)) {
+        if (seqnum_found)
+          target_pos = current_offset;
+        break;
+      }
+
+      if (!ecl_kw_fread_header( work_kw , rst_file->fortio))
+        break;
+
+      if (ecl_kw_name_equal( work_kw , SEQNUM_KW)) {
+        ecl_kw_fread_realloc_data( work_kw , rst_file->fortio);
+        int file_step = ecl_kw_iget_int( work_kw , 0 );
+        if (file_step >= report_step) {
+          target_pos = current_offset;
+          break;
+        }
+        seqnum_found = true;
+      } else
+          ecl_kw_fskip_data( work_kw , rst_file->fortio );
+
+    }
+
+    ecl_kw_free( work_kw );
+  }
+
+  fortio_fseek( rst_file->fortio , target_pos , SEEK_SET);
+  fortio_ftruncate_current( rst_file->fortio );
+  return rst_file;
+}
 
 ecl_rst_file_type * ecl_rst_file_open_write( const char * filename ) {
   ecl_rst_file_type * rst_file = ecl_rst_file_alloc( filename  );
@@ -126,7 +189,7 @@ static ecl_kw_type * ecl_rst_file_alloc_INTEHEAD( ecl_rst_file_type * rst_file,
   ecl_kw_iset_int( intehead_kw , INTEHEAD_NZ_INDEX      , rsthead->nz);
   ecl_kw_iset_int( intehead_kw , INTEHEAD_NACTIVE_INDEX , rsthead->nactive);
   ecl_kw_iset_int( intehead_kw , INTEHEAD_PHASE_INDEX   , rsthead->phase_sum );
-  
+
   /* All well properties are hardcoded to zero. */
   {
     int NGMAXZ = 0;
@@ -144,20 +207,20 @@ static ecl_kw_type * ecl_rst_file_alloc_INTEHEAD( ecl_rst_file_type * rst_file,
     ecl_kw_iset_int( intehead_kw , INTEHEAD_NZWELZ_INDEX  , rsthead->nzwelz );
     ecl_kw_iset_int( intehead_kw , INTEHEAD_NICONZ_INDEX  , rsthead->niconz );
     ecl_kw_iset_int( intehead_kw , INTEHEAD_NIGRPZ_INDEX  , NIGRPZ );
-    
+
     {
       ecl_util_set_date_values( rsthead->sim_time , &rsthead->day , &rsthead->month , &rsthead->year );
       ecl_kw_iset_int( intehead_kw , INTEHEAD_DAY_INDEX    , rsthead->day );
       ecl_kw_iset_int( intehead_kw , INTEHEAD_MONTH_INDEX  , rsthead->month );
       ecl_kw_iset_int( intehead_kw , INTEHEAD_YEAR_INDEX   , rsthead->year );
     }
-    
-    ecl_kw_iset_int( intehead_kw , INTEHEAD_IPROG_INDEX , simulator);   
+
+    ecl_kw_iset_int( intehead_kw , INTEHEAD_IPROG_INDEX , simulator);
     ecl_kw_iset_int( intehead_kw , INTEHEAD_NSWLMX_INDEX  , NSWLMX );
     ecl_kw_iset_int( intehead_kw , INTEHEAD_NSEGMX_INDEX  , NSEGMX );
     ecl_kw_iset_int( intehead_kw , INTEHEAD_NISEGZ_INDEX  , NISEGZ );
   }
-  return intehead_kw; 
+  return intehead_kw;
 }
 
 
@@ -166,14 +229,14 @@ static ecl_kw_type * ecl_rst_file_alloc_LOGIHEAD( int simulator ) {
   bool dual_porosity          = false;
   bool radial_grid_ECLIPSE100 = false;
   bool radial_grid_ECLIPSE300 = false;
-  
+
   ecl_kw_type * logihead_kw = ecl_kw_alloc( LOGIHEAD_KW , LOGIHEAD_RESTART_SIZE , ECL_BOOL_TYPE );
-  
+
   ecl_kw_scalar_set_bool( logihead_kw , false );
-    
-  if (simulator == INTEHEAD_ECLIPSE100_VALUE) 
+
+  if (simulator == INTEHEAD_ECLIPSE100_VALUE)
     ecl_kw_iset_bool( logihead_kw , LOGIHEAD_RADIAL100_INDEX , radial_grid_ECLIPSE100);
-  else 
+  else
     ecl_kw_iset_bool( logihead_kw , LOGIHEAD_RADIAL300_INDEX , radial_grid_ECLIPSE300);
 
   ecl_kw_iset_bool( logihead_kw , LOGIHEAD_DUALP_INDEX , dual_porosity);
@@ -186,8 +249,8 @@ static ecl_kw_type * ecl_rst_file_alloc_DOUBHEAD( ecl_rst_file_type * rst_file ,
 
   ecl_kw_scalar_set_double( doubhead_kw , 0);
   ecl_kw_iset_double( doubhead_kw , DOUBHEAD_DAYS_INDEX , days );
-  
-  
+
+
   return doubhead_kw;
 }
 
@@ -224,4 +287,7 @@ void ecl_rst_file_add_kw(ecl_rst_file_type * rst_file , const ecl_kw_type * ecl_
   ecl_kw_fwrite( ecl_kw , rst_file->fortio );
 }
 
-                                 
+
+offset_type ecl_rst_file_ftell(const ecl_rst_file_type * rst_file ) {
+  return fortio_ftell( rst_file->fortio );
+}

--- a/libecl/src/fortio.c
+++ b/libecl/src/fortio.c
@@ -343,6 +343,7 @@ fortio_type * fortio_open_append(const char *filename , bool fmt_file , bool end
   } else
     return NULL;
 }
+
 /*****************************************************************/
 
 bool fortio_fclose_stream( fortio_type * fortio ) {
@@ -784,6 +785,13 @@ bool fortio_fseek( fortio_type * fortio , offset_type offset , int whence) {
 }
 
 bool fortio_ftruncate( fortio_type * fortio , offset_type size) {
+  fortio_fseek( fortio , size , SEEK_SET);
+  return util_ftruncate( fortio->stream , size);
+}
+
+
+bool fortio_ftruncate_current( fortio_type * fortio ) {
+  offset_type size = fortio_ftell( fortio );
   return util_ftruncate( fortio->stream , size);
 }
 

--- a/libecl/tests/ecl_rst_file.c
+++ b/libecl/tests/ecl_rst_file.c
@@ -1,0 +1,174 @@
+/*
+   Copyright (C) 2016  Statoil ASA, Norway.
+
+   The file 'ecl_rst_file.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <ert/util/test_util.h>
+#include <ert/util/test_work_area.h>
+
+#include <ert/ecl/ecl_kw.h>
+#include <ert/ecl/ecl_kw_magic.h>
+#include <ert/ecl/ecl_endian_flip.h>
+#include <ert/ecl/ecl_rst_file.h>
+
+
+
+void write_keyword( fortio_type * fortio , const char * kw, ecl_type_enum ecl_type ) {
+  ecl_kw_type * ecl_kw = ecl_kw_alloc( kw , 1000 , ecl_type );
+  ecl_kw_fwrite( ecl_kw , fortio );
+  ecl_kw_free( ecl_kw );
+}
+
+
+void write_seqnum( fortio_type * fortio , int report_step ) {
+  ecl_kw_type * ecl_kw = ecl_kw_alloc( SEQNUM_KW , 1 , ECL_INT_TYPE );
+  ecl_kw_iset_int( ecl_kw , 0 , report_step );
+  ecl_kw_fwrite( ecl_kw , fortio );
+  ecl_kw_free( ecl_kw );
+}
+
+
+
+void test_empty() {
+  ecl_rst_file_type * rst_file = ecl_rst_file_open_write_seek( "EMPTY.UNRST" , 0 );
+  test_assert_int_equal( ecl_rst_file_ftell( rst_file ) , 0 );
+  ecl_rst_file_close( rst_file );
+}
+
+
+void test_file( const char * src_file , const char * target_file , int report_step , offset_type expected_offset) {
+  util_copy_file( src_file , target_file );
+  {
+    ecl_rst_file_type * rst_file = ecl_rst_file_open_write_seek( target_file , report_step );
+    test_assert_true( ecl_rst_file_ftell( rst_file ) == expected_offset );
+    ecl_rst_file_close( rst_file );
+    test_assert_true( util_file_size( target_file ) == expected_offset );
+  }
+}
+
+
+
+void test_Xfile() {
+  test_work_area_type * work_area = test_work_area_alloc("rst-file");
+  {
+    fortio_type * f = fortio_open_writer( "TEST.X0010" , false , ECL_ENDIAN_FLIP);
+
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    fortio_fclose( f );
+  }
+  test_file( "TEST.X0010" , "FILE.X0010" , 10 , 0 );
+  test_work_area_free( work_area );
+}
+
+
+
+void test_UNRST0() {
+  test_work_area_type * work_area = test_work_area_alloc("rst-file");
+  offset_type pos10;
+  offset_type pos20;
+  offset_type pos_end;
+  {
+    fortio_type * f = fortio_open_writer( "TEST.UNRST" , false , ECL_ENDIAN_FLIP);
+    write_seqnum( f , 0 );
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    pos10 = fortio_ftell( f );
+    write_seqnum( f , 10 );
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    pos20 = fortio_ftell( f );
+    write_seqnum( f , 20 );
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    pos_end = fortio_ftell( f );
+    fortio_fclose( f );
+  }
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 0 , 0 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 5 , pos10 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 10 , pos10 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 15 , pos20 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 20 , pos20 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 25 , pos_end );
+  test_work_area_free( work_area );
+}
+
+
+void test_UNRST1() {
+  test_work_area_type * work_area = test_work_area_alloc("rst-file");
+  offset_type pos5;
+  offset_type pos10;
+  offset_type pos20;
+  offset_type pos_end;
+  {
+    fortio_type * f = fortio_open_writer( "TEST.UNRST" , false , ECL_ENDIAN_FLIP);
+    pos5 = fortio_ftell( f );
+    write_seqnum( f , 5 );
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    pos10 = fortio_ftell( f );
+    write_seqnum( f , 10 );
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    pos20 = fortio_ftell( f );
+    write_seqnum( f , 20 );
+    write_keyword( f , "INTEHEAD" , ECL_INT_TYPE );
+    write_keyword( f , "PRESSURE" , ECL_FLOAT_TYPE );
+    write_keyword( f , "SWAT" , ECL_FLOAT_TYPE );
+
+    pos_end = fortio_ftell( f );
+    fortio_fclose( f );
+  }
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 0 , 0 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 1 , 0 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 5 , pos5 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 10 , pos10 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 15 , pos20 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 20 , pos20 );
+  test_file( "TEST.UNRST" , "FILE.UNRST" , 25 , pos_end );
+  test_work_area_free( work_area );
+}
+
+
+
+
+
+
+
+int main(int argc , char ** argv) {
+  test_empty();
+  test_Xfile();
+  test_UNRST0();
+  test_UNRST1();
+}

--- a/libecl/tests/tests.cmake
+++ b/libecl/tests/tests.cmake
@@ -103,3 +103,7 @@ add_test( ecl_fault_block_layer ${EXECUTABLE_OUTPUT_PATH}/ecl_fault_block_layer 
 add_executable( ecl_grid_export ecl_grid_export.c )
 target_link_libraries( ecl_grid_export ecl test_util )
 add_test( ecl_grid_export ${EXECUTABLE_OUTPUT_PATH}/ecl_grid_export  )
+
+add_executable( ecl_rst_file ecl_rst_file.c )
+target_link_libraries( ecl_rst_file ecl test_util )
+add_test( ecl_rst_file ${EXECUTABLE_OUTPUT_PATH}/ecl_rst_file  )


### PR DESCRIPTION
The function ecl_rst_file_open_write_seek( ) can be used to open a
restart file in read-write mode, including a seek to the right seqnum header.