### PR TITLE
Ensuring that max_runtime is enforced for WPRO

### DIFF
--- a/libjob_queue/include/ert/job_queue/queue_driver.h
+++ b/libjob_queue/include/ert/job_queue/queue_driver.h
@@ -59,8 +59,8 @@ extern "C" {
     //JOB_QUEUE_RUN_FAIL  =   512, /* The job has completed - but the queue system has detected that it has failed.         */
     //JOB_QUEUE_ALL_OK    =  1024, /* The job has loaded OK - observe that it is the calling scope which will set the status to this. */
     //JOB_QUEUE_ALL_FAIL  =  2048, /* The job has failed completely - the calling scope must set this status. */
-    JOB_QUEUE_USER_KILLED =  4096, /* The job has been killed by the user - can restart. */
-    JOB_QUEUE_USER_EXIT   =  8192, /* The whole job_queue has been exited by the user - the job can NOT be restarted. */
+    JOB_QUEUE_IS_KILLED   =  4096, /* The job has been killed, following a  JOB_QUEUE_DO_KILL*/
+    JOB_QUEUE_DO_KILL     =  8192, /* The the job should be killed, either due to user request, or automated measures - the job can NOT be restarted. */
     JOB_QUEUE_SUCCESS     = 16384,
     JOB_QUEUE_RUNNING_CALLBACK = 32768,
     JOB_QUEUE_FAILED      = 65536
@@ -74,7 +74,7 @@ extern "C" {
     user-input. It is OK to try to restart a job which is not in this
     state - basically nothing should happen.
    */
-#define JOB_QUEUE_CAN_RESTART  (JOB_QUEUE_FAILED + JOB_QUEUE_USER_KILLED  +  JOB_QUEUE_SUCCESS)
+#define JOB_QUEUE_CAN_RESTART  (JOB_QUEUE_FAILED + JOB_QUEUE_IS_KILLED  +  JOB_QUEUE_SUCCESS)
 
 
   /*
@@ -82,13 +82,13 @@ extern "C" {
     job which is not in this state, the only thing happening is that the
     function job_queue_kill_simulation() wil return false.
    */
-#define JOB_QUEUE_CAN_KILL    (JOB_QUEUE_WAITING + JOB_QUEUE_RUNNING + JOB_QUEUE_PENDING + JOB_QUEUE_SUBMITTED + JOB_QUEUE_USER_EXIT)
+#define JOB_QUEUE_CAN_KILL    (JOB_QUEUE_WAITING + JOB_QUEUE_RUNNING + JOB_QUEUE_PENDING + JOB_QUEUE_SUBMITTED + JOB_QUEUE_DO_KILL)
 
 #define JOB_QUEUE_WAITING_STATUS (JOB_QUEUE_WAITING + JOB_QUEUE_PENDING)
 
 #define JOB_QUEUE_CAN_UPDATE_STATUS (JOB_QUEUE_RUNNING + JOB_QUEUE_PENDING + JOB_QUEUE_SUBMITTED)
 
-#define JOB_QUEUE_COMPLETE_STATUS (JOB_QUEUE_USER_EXIT + JOB_QUEUE_SUCCESS + JOB_QUEUE_FAILED)
+#define JOB_QUEUE_COMPLETE_STATUS (JOB_QUEUE_IS_KILLED + JOB_QUEUE_SUCCESS + JOB_QUEUE_FAILED)
 
 
   typedef struct queue_driver_struct queue_driver_type;

--- a/libjob_queue/src/job_node.c
+++ b/libjob_queue/src/job_node.c
@@ -571,8 +571,8 @@ bool job_queue_node_kill( job_queue_node_type * node , job_queue_status_type * s
         queue_driver_free_job( driver , node->job_data );
         node->job_data = NULL;
       }
-      job_queue_status_transition(status, current_status, JOB_QUEUE_USER_KILLED);
-      job_queue_node_set_status( node , JOB_QUEUE_USER_KILLED);
+      job_queue_status_transition(status, current_status, JOB_QUEUE_IS_KILLED);
+      job_queue_node_set_status( node , JOB_QUEUE_IS_KILLED);
       result = true;
     }
   }

--- a/libjob_queue/src/job_queue_status.c
+++ b/libjob_queue/src/job_queue_status.c
@@ -38,8 +38,8 @@ static const int status_index[] = {  JOB_QUEUE_NOT_ACTIVE ,  // Initial, allocat
                                      JOB_QUEUE_RUNNING    ,  // Job is executing                                                           - controlled by queue_driver
                                      JOB_QUEUE_DONE       ,  // Job is done (successful or not), temporary state                            - controlled/returned by by queue_driver
                                      JOB_QUEUE_EXIT       ,  // Job is done, with exit status != 0, temporary state                        - controlled/returned by by queue_driver
-                                     JOB_QUEUE_USER_EXIT  ,  // User / queue system has requested killing of job                           - controlled by job_queue / external scope
-                                     JOB_QUEUE_USER_KILLED,  // Job has been killed, due to JOB_QUEUE_USER_EXIT, FINAL STATE               - controlled by job_queue
+                                     JOB_QUEUE_DO_KILL  ,  // User / queue system has requested killing of job                           - controlled by job_queue / external scope
+                                     JOB_QUEUE_IS_KILLED,  // Job has been killed, due to JOB_QUEUE_DO_KILL, FINAL STATE               - controlled by job_queue
                                      JOB_QUEUE_SUCCESS    ,  // All good, comes after JOB_QUEUE_DONE, with additional checks, FINAL STATE  - controlled by job_queue
                                      JOB_QUEUE_RUNNING_CALLBACK, // Temporary state, while running requested callbacks after an ended job  - controlled by job_queue
                                      JOB_QUEUE_FAILED };     // Job has failed, no more retries, FINAL STATE
@@ -51,8 +51,8 @@ static const char* status_name[] = { "JOB_QUEUE_NOT_ACTIVE" ,
                                      "JOB_QUEUE_RUNNING"    ,
                                      "JOB_QUEUE_DONE"       ,
                                      "JOB_QUEUE_EXIT"       ,
-                                     "JOB_QUEUE_USER_KILLED" ,
-                                     "JOB_QUEUE_USER_EXIT"   ,
+                                     "JOB_QUEUE_IS_KILLED" ,
+                                     "JOB_QUEUE_DO_KILL"   ,
                                      "JOB_QUEUE_SUCCESS"    ,
                                      "JOB_QUEUE_RUNNING_CALLBACK",
                                      "JOB_QUEUE_FAILED" };

--- a/libjob_queue/tests/job_queue_stress_test.c
+++ b/libjob_queue/tests/job_queue_stress_test.c
@@ -202,7 +202,7 @@ void * status_job__( void * arg ) {
           bool status_true = (status == JOB_QUEUE_RUNNING) || (status == JOB_QUEUE_SUBMITTED || (status == JOB_QUEUE_RUNNING_CALLBACK) || (status == JOB_QUEUE_DONE));
           if (!status_true) {
             if (user_exit)
-              status_true = (status == JOB_QUEUE_USER_EXIT) || (status == JOB_QUEUE_USER_KILLED || (status == JOB_QUEUE_RUNNING_CALLBACK));
+              status_true = (status == JOB_QUEUE_DO_KILL) || (status == JOB_QUEUE_IS_KILLED || (status == JOB_QUEUE_RUNNING_CALLBACK));
           }
           if (!status_true)
             fprintf(stderr," Invalid status:%d for job:%d \n",status , job->queue_index );
@@ -210,7 +210,7 @@ void * status_job__( void * arg ) {
         }
       }
       status = job_queue_iget_job_status(queue, job->queue_index);
-      if ((status == JOB_QUEUE_SUCCESS) || (status == JOB_QUEUE_USER_KILLED))
+      if ((status == JOB_QUEUE_SUCCESS) || (status == JOB_QUEUE_IS_KILLED))
         break;
     } else {
       if (!job_queue_accept_jobs(queue))

--- a/libjob_queue/tests/job_status_test.c
+++ b/libjob_queue/tests/job_status_test.c
@@ -30,7 +30,7 @@
 
 void call_get_status( void * arg ) {
   job_queue_status_type * job_status = job_queue_status_safe_cast( arg );
-  job_queue_status_get_count( job_status , JOB_QUEUE_DONE + JOB_QUEUE_USER_EXIT);
+  job_queue_status_get_count( job_status , JOB_QUEUE_DONE + JOB_QUEUE_DO_KILL);
 }
 
 
@@ -53,7 +53,7 @@ void * add_sim( void * arg ) {
 
 void * user_exit( void * arg ) {
    job_queue_status_type * job_status = job_queue_status_safe_cast( arg );
-   job_queue_status_transition( job_status , JOB_QUEUE_WAITING  , JOB_QUEUE_USER_EXIT);
+   job_queue_status_transition( job_status , JOB_QUEUE_WAITING  , JOB_QUEUE_DO_KILL);
    return NULL;
 }
 
@@ -111,7 +111,7 @@ void test_update() {
     pthread_join( thread_list[i] , NULL );
 
   test_assert_int_equal( 2*N - num_done_threads - num_exit_threads , job_queue_status_get_count( status , JOB_QUEUE_WAITING ));
-  test_assert_int_equal( num_exit_threads , job_queue_status_get_count( status , JOB_QUEUE_USER_EXIT ));
+  test_assert_int_equal( num_exit_threads , job_queue_status_get_count( status , JOB_QUEUE_DO_KILL ));
   test_assert_int_equal( num_done_threads , job_queue_status_get_count( status , JOB_QUEUE_DONE ));
 
   test_assert_int_equal( 2*N , job_queue_status_get_total_count( status ));

--- a/python/python/ert/job_queue/job_queue_manager.py
+++ b/python/python/ert/job_queue/job_queue_manager.py
@@ -32,9 +32,12 @@ class JobQueueManager(BaseCClass):
     _is_running      = QueuePrototype("bool job_queue_manager_is_running( job_queue_manager )")
     _job_complete    = QueuePrototype("bool job_queue_manager_job_complete( job_queue_manager , int)")
     _job_running     = QueuePrototype("bool job_queue_manager_job_running( job_queue_manager , int)")
-    _job_failed      = QueuePrototype("bool job_queue_manager_job_failed( job_queue_manager , int)")
+    
+    # Note, even if all realizations have finished, they need not all be failed or successes. 
+    # That is how Ert report things. They can be "killed", which is neither success nor failure.
+    _job_failed      = QueuePrototype("bool job_queue_manager_job_failed( job_queue_manager , int)") 
     _job_waiting     = QueuePrototype("bool job_queue_manager_job_waiting( job_queue_manager , int)")
-    _job_success     = QueuePrototype("bool job_queue_manager_job_success( job_queue_manager , int)")
+    _job_success     = QueuePrototype("bool job_queue_manager_job_success( job_queue_manager , int)") 
 
     # The return type of the job_queue_manager_iget_job_status should
     # really be the enum job_status_type_enum, but I just did not

--- a/python/python/ert/job_queue/job_status_type_enum.py
+++ b/python/python/ert/job_queue/job_status_type_enum.py
@@ -25,8 +25,8 @@ class JobStatusType(BaseCEnum):
     JOB_QUEUE_RUNNING = None        # The job is running
     JOB_QUEUE_DONE = None           # The job is done - but we have not yet checked if the target file is produced */
     JOB_QUEUE_EXIT = None           # The job has exited - check attempts to determine if we retry or go to complete_fail   */
-    JOB_QUEUE_USER_KILLED = None    # The job has been killed by the user - can restart. */
-    JOB_QUEUE_USER_EXIT = None      # The whole job_queue has been exited by the user - the job can NOT be restarted. */
+    JOB_QUEUE_IS_KILLED = None         # The job has been killed, following a  JOB_QUEUE_DO_KILL - can restart. */
+    JOB_QUEUE_DO_KILL = None       # The the job should be killed, either due to user request, or automated measures - the job can NOT be restarted.. */
     JOB_QUEUE_SUCCESS = None
     JOB_QUEUE_RUNNING_CALLBACK = None
     JOB_QUEUE_FAILED = None
@@ -38,8 +38,8 @@ JobStatusType.addEnum("JOB_QUEUE_PENDING", 16)
 JobStatusType.addEnum("JOB_QUEUE_RUNNING", 32)
 JobStatusType.addEnum("JOB_QUEUE_DONE", 64)
 JobStatusType.addEnum("JOB_QUEUE_EXIT", 128)
-JobStatusType.addEnum("JOB_QUEUE_USER_KILLED", 4096)
-JobStatusType.addEnum("JOB_QUEUE_USER_EXIT", 8192)
+JobStatusType.addEnum("JOB_QUEUE_IS_KILLED", 4096)
+JobStatusType.addEnum("JOB_QUEUE_DO_KILL", 8192)
 JobStatusType.addEnum("JOB_QUEUE_SUCCESS", 16384)
 JobStatusType.addEnum("JOB_QUEUE_RUNNING_CALLBACK", 32768)
 JobStatusType.addEnum("JOB_QUEUE_FAILED", 65536)

--- a/python/python/ert/job_queue/queue.py
+++ b/python/python/ert/job_queue/queue.py
@@ -28,12 +28,6 @@ from ert.job_queue import QueuePrototype
 from ert.job_queue import Job, JobStatusType
 
 
-
-
-
-
-
-
 class JobQueue(BaseCClass):
     # If the queue is created with size == 0 that means that it will
     # just grow as needed; for the queue layer to know when to exit
@@ -44,33 +38,35 @@ class JobQueue(BaseCClass):
     # queue with a finite value for size, in that case it is not
     # necessary to explitly inform the queue layer when all jobs have
     # been submitted.
-    TYPE_NAME        = "job_queue"
-    _alloc           = QueuePrototype("void* job_queue_alloc( int , char* , char* , char* )" , bind = False)
-    _start_user_exit = QueuePrototype("bool job_queue_start_user_exit( job_queue )")
-    _get_user_exit   = QueuePrototype("bool job_queue_get_user_exit( job_queue )")
-    _free            = QueuePrototype("void job_queue_free( job_queue )")
-    _set_max_running = QueuePrototype("void job_queue_set_max_running( job_queue , int)")
-    _get_max_running = QueuePrototype("int  job_queue_get_max_running( job_queue )")
-    _set_driver      = QueuePrototype("void job_queue_set_driver( job_queue , void* )")
-    _add_job         = QueuePrototype("int  job_queue_add_job( job_queue , char* , void* , void* , void* , void* , int , char* , char* , int , char**)")
-    _kill_job        = QueuePrototype("bool job_queue_kill_job( job_queue , int )")
-    _start_queue     = QueuePrototype("void job_queue_run_jobs( job_queue , int , bool)")
-    _run_jobs        = QueuePrototype("void job_queue_run_jobs_threaded(job_queue , int , bool)")
-    _sim_start       = QueuePrototype("time_t job_queue_iget_sim_start( job_queue , int)")
-    _iget_driver_data= QueuePrototype("void* job_queue_iget_driver_data( job_queue , int)")
+    TYPE_NAME             = "job_queue"
+    _alloc                = QueuePrototype("void* job_queue_alloc( int , char* , char* , char* )" , bind      = False)
+    _start_user_exit      = QueuePrototype("bool job_queue_start_user_exit( job_queue )")
+    _get_user_exit        = QueuePrototype("bool job_queue_get_user_exit( job_queue )")
+    _free                 = QueuePrototype("void job_queue_free( job_queue )")
+    _set_max_running      = QueuePrototype("void job_queue_set_max_running( job_queue , int)")
+    _get_max_running      = QueuePrototype("int  job_queue_get_max_running( job_queue )")
+    _set_max_job_duration = QueuePrototype("void job_queue_set_max_job_duration( job_queue , int)")
+    _get_max_job_duration = QueuePrototype("int  job_queue_get_max_job_duration( job_queue )")
+    _set_driver           = QueuePrototype("void job_queue_set_driver( job_queue , void* )")
+    _add_job              = QueuePrototype("int  job_queue_add_job( job_queue , char* , void* , void* , void* , void* , int , char* , char* , int , char**)")
+    _kill_job             = QueuePrototype("bool job_queue_kill_job( job_queue , int )")
+    _start_queue          = QueuePrototype("void job_queue_run_jobs( job_queue , int , bool)")
+    _run_jobs             = QueuePrototype("void job_queue_run_jobs_threaded(job_queue , int , bool)")
+    _sim_start            = QueuePrototype("time_t job_queue_iget_sim_start( job_queue , int)")
+    _iget_driver_data     = QueuePrototype("void* job_queue_iget_driver_data( job_queue , int)")
     
-    _num_running     = QueuePrototype("int  job_queue_get_num_running( job_queue )")
-    _num_complete    = QueuePrototype("int  job_queue_get_num_complete( job_queue )")
-    _num_waiting     = QueuePrototype("int  job_queue_get_num_waiting( job_queue )")
-    _num_pending     = QueuePrototype("int  job_queue_get_num_pending( job_queue )")
+    _num_running          = QueuePrototype("int  job_queue_get_num_running( job_queue )")
+    _num_complete         = QueuePrototype("int  job_queue_get_num_complete( job_queue )")
+    _num_waiting          = QueuePrototype("int  job_queue_get_num_waiting( job_queue )")
+    _num_pending          = QueuePrototype("int  job_queue_get_num_pending( job_queue )")
 
-    _is_running      = QueuePrototype("bool job_queue_is_running( job_queue )")
-    _submit_complete = QueuePrototype("void job_queue_submit_complete( job_queue )")
-    _iget_sim_start  = QueuePrototype("time_t job_queue_iget_sim_start( job_queue , int)")
-    _get_active_size = QueuePrototype("int  job_queue_get_active_size( job_queue )")
-    _get_pause       = QueuePrototype("bool job_queue_get_pause(job_queue)")
-    _set_pause_on    = QueuePrototype("void job_queue_set_pause_on(job_queue)")
-    _set_pause_off   = QueuePrototype("void job_queue_set_pause_off(job_queue)")
+    _is_running           = QueuePrototype("bool job_queue_is_running( job_queue )")
+    _submit_complete      = QueuePrototype("void job_queue_submit_complete( job_queue )")
+    _iget_sim_start       = QueuePrototype("time_t job_queue_iget_sim_start( job_queue , int)")
+    _get_active_size      = QueuePrototype("int  job_queue_get_active_size( job_queue )")
+    _get_pause            = QueuePrototype("bool job_queue_get_pause(job_queue)")
+    _set_pause_on         = QueuePrototype("void job_queue_set_pause_on(job_queue)")
+    _set_pause_off        = QueuePrototype("void job_queue_set_pause_off(job_queue)")
 
     # The return type of the job_queue_iget_job_status should really
     # be the enum job_status_type_enum, but I just did not manage to
@@ -209,6 +205,12 @@ class JobQueue(BaseCClass):
 
     def set_max_running( self, max_running ):
         self.driver.set_max_running(max_running)
+
+    def get_max_job_duration(self):
+        return self._get_max_job_duration()
+
+    def set_max_job_duration(self, max_duration):
+        self._set_max_job_duration(max_duration)
 
     def killAllJobs(self):
         # The queue will not set the user_exit flag before the

--- a/python/python/ert/server/simulation_context.py
+++ b/python/python/ert/server/simulation_context.py
@@ -10,8 +10,12 @@ class SimulationContext(object):
         self._ert = ert
         """ :type: ert.enkf.EnKFMain """
         self._size = size
+        
+        max_runtime = ert.analysisConfig().get_max_runtime()
+        job_queue = ert.siteConfig().getJobQueue()
+        job_queue.set_max_job_duration(max_runtime)
 
-        self._queue_manager = JobQueueManager(ert.siteConfig().getJobQueue())
+        self._queue_manager = JobQueueManager(job_queue)
         self._queue_manager.startQueue(size, verbose=verbose)
         self._run_args = {}
         """ :type: dict[int, RunArg] """
@@ -63,8 +67,8 @@ class SimulationContext(object):
 
 
     def didRealizationFail(self, iens):
-        queue_index = self._run_args[iens].getQueueIndex()
-        return self._queue_manager.didJobFail(queue_index)
+	# For the purposes of this class, a failure should be anything (killed job, etc) that is not an explicit success.
+        return not self.didRealizationSucceed(iens)
 
 
     def isRealizationQueued(self, iens):

--- a/python/python/ert_gui/simulation/models/simulations_tracker.py
+++ b/python/python/ert_gui/simulation/models/simulations_tracker.py
@@ -55,7 +55,7 @@ class SimulationsTracker(object):
         running_state = SimulationStateStatus("Running", JobStatusType.JOB_QUEUE_RUNNING | JobStatusType.JOB_QUEUE_EXIT | JobStatusType.JOB_QUEUE_RUNNING_CALLBACK, SimulationStateStatus.COLOR_RUNNING)
 
         # Failed also includes simulations which have been killed by the MAX_RUNTIME system.
-        failed_state = SimulationStateStatus("Failed", JobStatusType.JOB_QUEUE_USER_KILLED | JobStatusType.JOB_QUEUE_USER_EXIT | JobStatusType.JOB_QUEUE_FAILED, SimulationStateStatus.COLOR_FAILED)
+        failed_state = SimulationStateStatus("Failed", JobStatusType.JOB_QUEUE_IS_KILLED | JobStatusType.JOB_QUEUE_DO_KILL | JobStatusType.JOB_QUEUE_FAILED, SimulationStateStatus.COLOR_FAILED)
         done_state = SimulationStateStatus("Finished", JobStatusType.JOB_QUEUE_DONE | JobStatusType.JOB_QUEUE_SUCCESS, SimulationStateStatus.COLOR_FINISHED)
 
         self.states = [waiting_state, pending_state, running_state, failed_state, done_state]


### PR DESCRIPTION
Added some refactoring of the names of the job statuses in queue_driver.h

The main changes, a bit hidden in this renaming forest:
1) Added {get|set}_max_job_duration in queue.py
2) In simulation_context.py, fetch the "max_runtime" from config, and call the set_max_job_duration method.
3) Change didRealizationFail in simulation_context to return !didRealizationSucceed. This is done because the wpro / seba program tries to read results for all jobs that are not failed. Alternatively, one could change wpro/seba to rather call didRealizationSucceed.
4) In job_queue.c, there is a REAL change in the JOB_QUEUE_COMPLETE_STATUS mask, because it used to include JOB_QUEUE_USER_EXIT (now JOB_QUEUE_DO_KILL) - but this is not a final state, JOB_QUEUE_USER_KILLED is (now JOB_QUEUE_IS_KILLED).

Maybe refactoring and code change is a bad idea. I can split it in two commits if that is better...