### PR TITLE
update rh6 packaging

### DIFF
--- a/redhat/ert.ecl.spec
+++ b/redhat/ert.ecl.spec
@@ -15,7 +15,7 @@ Source0:        https://github.com/OPM/%{name}/archive/release/%{version}/%{tag}
 BuildRequires:  lapack-devel zlib-devel iputils
 BuildRequires:  gcc
 %{?!el6:BuildRequires: python-devel numpy}
-%{?el6:BuildRequires:  cmake28 devtoolset-2}
+%{?el6:BuildRequires:  cmake28 devtoolset-3-toolchain}
 %{?!el6:BuildRequires:  cmake}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       libert.ecl1 = %{version}
@@ -70,8 +70,8 @@ This package contains the development and header files for ert.ecl
 %setup -q -n ert-release-%{version}-%{tag}
 
 %build
-%{?el6:scl enable devtoolset-2 bash}
-DESTDIR=${RPM_BUILD_ROOT} %{?el6:cmake28} %{?!el6:cmake} -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=%{?el6:Debug}%{?!el6:Release} -DCMAKE_INSTALL_PREFIX=%{_prefix} -DBUILD_ECL_SUMMARY=1 %{?el6:-DBUILD_PYTHON=0} %{?el6:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gcc -DCMAKE_Fortran_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gfortran}
+%{?el6:scl enable devtoolset-3 bash}
+DESTDIR=${RPM_BUILD_ROOT} %{?el6:cmake28} %{?!el6:cmake} -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DBUILD_ECL_SUMMARY=1 %{?el6:-DBUILD_PYTHON=0} %{?el6:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/gcc -DCMAKE_Fortran_COMPILER=/opt/rh/devtoolset-3/root/usr/bin/gfortran}
 make
 
 %install


### PR DESCRIPTION
compiling (newer) ert trips a bug in the devtoolset-2 toolchain. the compiler
emits assembly not understood by the assembler (devtoolset-2 uses
the default system assembler). instead of fighting this by doing a debug build (was a temporary measure), simply upgrade toolchain.