### PR TITLE
added: allow building the c++ bindings using std=c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,10 @@ endif()
 
 if (MSVC)
     add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996" )
-else()
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" )
 endif()
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+find_package(CXX11Features)
 
 if (ERT_USE_OPENMP)
    find_package(OpenMP)
@@ -106,7 +106,6 @@ set( CMAKE_CXX_FLAGS_main ${CMAKE_CXX_FLAGS} )
 
 if (NOT ERT_WINDOWS)
   set( CMAKE_C_FLAGS_main "${CMAKE_C_FLAGS} -std=gnu99" )
-  set( CMAKE_CXX_FLAGS_main "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 set( ERT_EXTERNAL_UTIL_LIBS "" )

--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -1,0 +1,19 @@
+#
+# Module that checks for supported C++11 (former C++0x) features.
+#
+if(CMAKE_VERSION VERSION_LESS 3.1)
+  if(NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
+  if(NOT ERT_WINDOWS)
+    set( CMAKE_CXX_FLAGS_main "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
+else()
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+set(CXX11FEATURES_FOUND TRUE)


### PR DESCRIPTION
relies on cmake >= 3.1. for older, it falls back to the old
behavior of hardcoding c++11