### PR TITLE
LSF checks for nonempty exclude_hosts and stringlist join returns ""

### DIFF
--- a/libert_util/src/stringlist.c
+++ b/libert_util/src/stringlist.c
@@ -559,7 +559,7 @@ bool stringlist_equal(const stringlist_type * s1 , const stringlist_type *s2) {
 
 char * stringlist_alloc_joined_substring( const stringlist_type * s , int start_index , int end_index , const char * sep ) {
   if (start_index >= stringlist_get_size( s ))
-    return NULL;
+    return util_alloc_string_copy("");
   {
     char * string = NULL;
     int i;

--- a/libert_util/tests/ert_util_stringlist_test.c
+++ b/libert_util/tests/ert_util_stringlist_test.c
@@ -60,14 +60,8 @@ void test_join() {
   {
     // empty join
     const char* empty_join = stringlist_alloc_joined_string(s, "!!!");
-    if (empty_join == NULL) {
-      printf("%s failure, empty join returned NULL, expected \"\".\n", __func__);
-      exit(1);
-    }
-    if (strcmp("", empty_join) != 0) {
-      printf("%s failure, empty join: expected \"\", was: \"%s\"\n", __func__, empty_join);
-      exit(1);
-    }
+    test_assert_not_NULL(empty_join);
+    test_assert_string_equal("", empty_join);
   }
 
   stringlist_append_ref( s , elt0 );

--- a/libert_util/tests/ert_util_stringlist_test.c
+++ b/libert_util/tests/ert_util_stringlist_test.c
@@ -56,6 +56,20 @@ void test_join() {
   const char * elt5 = "FFF";
 
   stringlist_type * s = stringlist_alloc_new();
+
+  {
+    // empty join
+    const char* empty_join = stringlist_alloc_joined_string(s, "!!!");
+    if (empty_join == NULL) {
+      printf("%s failure, empty join returned NULL, expected \"\".\n", __func__);
+      exit(1);
+    }
+    if (strcmp("", empty_join) != 0) {
+      printf("%s failure, empty join: expected \"\", was: \"%s\"\n", __func__, empty_join);
+      exit(1);
+    }
+  }
+
   stringlist_append_ref( s , elt0 );
   stringlist_append_ref( s , elt1 );
   stringlist_append_ref( s , elt2 );

--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -357,23 +357,26 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
 
     char * excludes_string = NULL;
     char * req = "";
+    char * resreq = NULL;
 
-    if (driver->resource_request != NULL) {
-      char * resreq = util_alloc_string_copy(driver->resource_request);
-      if (stringlist_get_size(select_list) > 0) {
+    if (stringlist_get_size(select_list) > 0) {
+      excludes_string = stringlist_alloc_joined_string(select_list, " && ");
+      if (driver->resource_request != NULL) {
+        resreq = util_alloc_string_copy(driver->resource_request);
         util_string_tr(resreq, ']', ' '); // remove "]" from "select[A && B]
         excludes_string = stringlist_alloc_joined_string(select_list, " && ");
         req = util_alloc_sprintf("%s && %s]", resreq, excludes_string);
       } else {
-        req = util_alloc_sprintf("%s", resreq);
-      }
-      util_free(resreq);
-    } else {
-      if (stringlist_get_size(select_list) > 0) {
-        excludes_string = stringlist_alloc_joined_string(select_list, " && ");
         req = util_alloc_sprintf("select[%s]", excludes_string);
       }
+    } else {
+      if (driver->resource_request != NULL) {
+        resreq = util_alloc_string_copy(driver->resource_request);
+        req = util_alloc_sprintf("%s", resreq);
+      }
     }
+    if (resreq)
+      free(resreq);
 
     if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL)
       quoted_resource_request = util_alloc_sprintf("\"%s\"", req);

--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -348,7 +348,7 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
 
   {
     stringlist_type * select_list = stringlist_alloc_new();
-    if (driver->exclude_hosts != NULL && stringlist_get_size(driver->exclude_hosts) > 0) {
+    if (stringlist_get_size(driver->exclude_hosts) > 0) {
       for (int i = 0; i < stringlist_get_size(driver->exclude_hosts); i++) {
         char * exclude_host = util_alloc_sprintf("hname!='%s'", stringlist_iget(driver->exclude_hosts, i));
         stringlist_append_owned_ref(select_list, exclude_host);
@@ -361,7 +361,7 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
     if (driver->resource_request != NULL) {
       char * resreq = util_alloc_string_copy(driver->resource_request);
       if (stringlist_get_size(select_list) > 0) {
-        util_string_tr(resreq, ']', ' ');
+        util_string_tr(resreq, ']', ' '); // remove "]" from "select[A && B]
         excludes_string = stringlist_alloc_joined_string(select_list, " && ");
         req = util_alloc_sprintf("%s && %s]", resreq, excludes_string);
       } else {
@@ -380,9 +380,9 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
     else
       quoted_resource_request = util_alloc_string_copy(req);
 
-    util_free(req);
+    free(req);
     if (excludes_string)
-      util_free(excludes_string);
+      free(excludes_string);
     stringlist_free(select_list);
   }
 

--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -347,35 +347,43 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
   */
 
   {
-    stringlist_type * excludes = stringlist_alloc_new();
-    char * select = NULL;
-    if (driver->exclude_hosts != NULL) {
+    stringlist_type * select_list = stringlist_alloc_new();
+    if (driver->exclude_hosts != NULL && stringlist_get_size(driver->exclude_hosts) > 0) {
       for (int i = 0; i < stringlist_get_size(driver->exclude_hosts); i++) {
         char * exclude_host = util_alloc_sprintf("hname!='%s'", stringlist_iget(driver->exclude_hosts, i));
-        stringlist_append_owned_ref(excludes, exclude_host);
+        stringlist_append_owned_ref(select_list, exclude_host);
       }
-      const char * excludes_string = stringlist_alloc_joined_string(excludes, " && ");
-      select = util_alloc_sprintf("select[%s]", excludes_string);
     }
 
-    stringlist_type * qrr = stringlist_alloc_new();
-    if (select) {
-      stringlist_append_copy(qrr, select);
-      util_free(select);
+    char * excludes_string = NULL;
+    char * req = "";
+
+    if (driver->resource_request != NULL) {
+      char * resreq = util_alloc_string_copy(driver->resource_request);
+      if (stringlist_get_size(select_list) > 0) {
+        util_string_tr(resreq, ']', ' ');
+        excludes_string = stringlist_alloc_joined_string(select_list, " && ");
+        req = util_alloc_sprintf("%s && %s]", resreq, excludes_string);
+      } else {
+        req = util_alloc_sprintf("%s", resreq);
+      }
+      util_free(resreq);
+    } else {
+      if (stringlist_get_size(select_list) > 0) {
+        excludes_string = stringlist_alloc_joined_string(select_list, " && ");
+        req = util_alloc_sprintf("select[%s]", excludes_string);
+      }
     }
-
-    if (driver->resource_request != NULL)
-      stringlist_append_copy(qrr, driver->resource_request);
-
-    const char* req = stringlist_alloc_joined_string(qrr, " ");
 
     if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL)
       quoted_resource_request = util_alloc_sprintf("\"%s\"", req);
     else
       quoted_resource_request = util_alloc_string_copy(req);
 
-    stringlist_free( qrr );
-    stringlist_free( excludes );
+    util_free(req);
+    if (excludes_string)
+      util_free(excludes_string);
+    stringlist_free(select_list);
   }
 
   if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL)


### PR DESCRIPTION
This PR contains two changes:

* LSF driver checks that we have excluded hosts before applying `select[%s]` flag
* `stringlist_alloc_joined_string` (and `...substring`) now returns `""` on an empty list, and never `NULL`

This should fix #1273