### PR TITLE
Checking for graphviz (dot) before enabling dot

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -28,6 +28,15 @@ endif()
 
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
+  message(STATUS "Creating doxygen target")
+  if (DOXYGEN_DOT_FOUND)
+    message(STATUS "Found graphviz, will run doxygen with graphics")
+    set( DOXYGEN_HAVE_DOT "YES" )
+  else()
+    message(STATUS "Graphviz not found, disabling dot")
+    set( DOXYGEN_HAVE_DOT "NO" )
+  endif()
+
   configure_file(doxygen.cfg.in ${PROJECT_BINARY_DIR}/doxygen.cfg)
   add_custom_target(doxy
     COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/doxygen.cfg

--- a/docs/doxygen.cfg.in
+++ b/docs/doxygen.cfg.in
@@ -30,7 +30,7 @@ INPUT = ${PROJECT_SOURCE_DIR}/libanalysis ${PROJECT_SOURCE_DIR}/libconfig ${PROJ
 RECURSIVE         = YES
 EXCLUDE_PATTERNS  = */test/* */build/* */test-data/* */docs/* */python*/
 
-HAVE_DOT          = YES
+HAVE_DOT          = ${DOXYGEN_HAVE_DOT}
 DOT_GRAPH_MAX_NODES = 1000
 GENERATE_HTML     = YES
 CLASS_DIAGRAMS    = YES


### PR DESCRIPTION
When building `make doxy` it is assumed that the user has `graphviz (dot)` installed.

This PR rids of this assumption.  If `dot` is not found (using builtin `DOXYGEN_DOT_FOUND`), we disable `HAVE_DOT` in `doxygen.cgf`.
