### PR TITLE
Making sure the ertshell is creating the run path

### DIFF
--- a/python/python/ert_gui/shell/simulations.py
+++ b/python/python/ert_gui/shell/simulations.py
@@ -35,13 +35,10 @@ class Simulations(ErtShellCollection):
         now = time.time()
         print("Ensemble Experiment started at: %s" % datetime.now().isoformat(sep=" "))
 
-        print("Create the run path!")
-        iteration_count = self.ert().analysisConfig().getAnalysisIterConfig().getNumIterations()
-        active_realization_mask = BoolVector.createActiveMask("0-%d" % self.ert().getEnsembleSize())
-        # Note that 0(zero) is used and not iteration_count
-        simulation_runner.createRunPath(active_realization_mask, 0)
+        iteration_count = 0
+        active_realization_mask = BoolVector(default_value = True, initial_size = self.ert().getEnsembleSize())
+        simulation_runner.createRunPath(active_realization_mask, iteration_count)
 
-        print("Ensemble Experiment pre processing!")
         simulation_runner.runWorkflows(HookRuntime.PRE_SIMULATION)
 
         print("Start simulations!")

--- a/python/python/ert_gui/shell/simulations.py
+++ b/python/python/ert_gui/shell/simulations.py
@@ -33,9 +33,18 @@ class Simulations(ErtShellCollection):
         simulation_runner = EnkfSimulationRunner(self.ert())
 
         now = time.time()
-
         print("Ensemble Experiment started at: %s" % datetime.now().isoformat(sep=" "))
 
+        print("Create the run path!")
+        iteration_count = self.ert().analysisConfig().getAnalysisIterConfig().getNumIterations()
+        active_realization_mask = BoolVector.createActiveMask("0-%d" % self.ert().getEnsembleSize())
+        # Note that 0(zero) is used and not iteration_count
+        simulation_runner.createRunPath(active_realization_mask, 0)
+
+        print("Ensemble Experiment pre processing!")
+        simulation_runner.runWorkflows(HookRuntime.PRE_SIMULATION)
+
+        print("Start simulations!")
         num_successful_realizations = simulation_runner.runEnsembleExperiment()
 
         success = self.ert().analysisConfig().haveEnoughRealisations(num_successful_realizations, self.ert().getEnsembleSize())


### PR DESCRIPTION
The ertshell has a different entry for running the simulations than the
gert and others. Added code to create the run path and run the possibly
defined pre-simulation workflow.

The current implementation is not yet 100% neat though since it is
hardcoding the iteration number to 0 (zero). Need help! If I set the
number of iteration_count the createRunPath is creating only the last
subfolder namely iter_4 which ends up with a nice error.