### PR TITLE
Allow for user provided CMAKE_C_FLAGS on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 
 # Treat warnings as errors if not on Windows
 if (NOT ERT_WINDOWS)
-   set( CMAKE_C_FLAGS   "-std=gnu99 -Wall -Wno-unknown-pragmas ")
+   set( CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wno-unknown-pragmas ")
    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall " )
 endif()
 


### PR DESCRIPTION
This was not possible before and is e.g. needed to use flags recommended by packaging systems of Linux distributions (read: Debian).