### PR TITLE
Fix diagnostics

### DIFF
--- a/libecl/include/ert/ecl/ecl_coarse_cell.h
+++ b/libecl/include/ert/ecl/ecl_coarse_cell.h
@@ -27,7 +27,7 @@ extern "C" {
   typedef struct ecl_coarse_cell_struct    ecl_coarse_cell_type;
 
   bool                   ecl_coarse_cell_equal( const ecl_coarse_cell_type * coarse_cell1 , const ecl_coarse_cell_type * coarse_cell2);
-  ecl_coarse_cell_type * ecl_coarse_cell_alloc( );
+  ecl_coarse_cell_type * ecl_coarse_cell_alloc( void );
   void                   ecl_coarse_cell_update( ecl_coarse_cell_type * coarse_cell , int i , int j , int k , int global_index );
   void                   ecl_coarse_cell_free( ecl_coarse_cell_type * coarse_cell );
   void                   ecl_coarse_cell_free__( void * arg );

--- a/libecl/include/ert/ecl/ecl_file_kw.h
+++ b/libecl/include/ert/ecl/ecl_file_kw.h
@@ -33,7 +33,7 @@ extern "C" {
 typedef struct ecl_file_kw_struct ecl_file_kw_type;
 typedef struct inv_map_struct inv_map_type;
 
-  inv_map_type     * inv_map_alloc();
+  inv_map_type     * inv_map_alloc(void);
   ecl_file_kw_type * inv_map_get_file_kw( inv_map_type * inv_map , const ecl_kw_type * ecl_kw );
   void               inv_map_free( inv_map_type * map );
 

--- a/libecl/include/ert/ecl/ecl_kw.h
+++ b/libecl/include/ert/ecl/ecl_kw.h
@@ -58,7 +58,7 @@ extern "C" {
   ecl_type_enum  ecl_kw_get_type(const ecl_kw_type *);
   const char   * ecl_kw_get_header8(const ecl_kw_type *);
   const char   * ecl_kw_get_header(const ecl_kw_type * ecl_kw );
-  ecl_kw_type  * ecl_kw_alloc_empty();
+  ecl_kw_type  * ecl_kw_alloc_empty(void);
   bool           ecl_kw_fread_header(ecl_kw_type *, fortio_type *);
   void           ecl_kw_set_header_name(ecl_kw_type * , const char * );
   void           ecl_kw_set_header(ecl_kw_type  * , const char * , int , const char *);

--- a/libecl/include/ert/ecl/ecl_rsthead.h
+++ b/libecl/include/ert/ecl/ecl_rsthead.h
@@ -83,7 +83,7 @@ extern "C" {
   void                ecl_rsthead_free( ecl_rsthead_type * rsthead );
   ecl_rsthead_type  * ecl_rsthead_alloc_from_kw( int report_step , const ecl_kw_type * intehead_kw , const ecl_kw_type * doubhead_kw , const ecl_kw_type * logihead_kw );
   ecl_rsthead_type  * ecl_rsthead_alloc( const ecl_file_view_type * rst_file , int report_step);
-  ecl_rsthead_type  * ecl_rsthead_alloc_empty();
+  ecl_rsthead_type  * ecl_rsthead_alloc_empty(void);
   time_t              ecl_rsthead_date( const ecl_kw_type * intehead_kw );
   void                ecl_rsthead_fprintf( const ecl_rsthead_type * header , FILE * stream);
   void                ecl_rsthead_fprintf_struct( const ecl_rsthead_type * header , FILE * stream);

--- a/libecl_well/include/ert/ecl_well/well_branch_collection.h
+++ b/libecl_well/include/ert/ecl_well/well_branch_collection.h
@@ -33,7 +33,7 @@ extern "C" {
 
   typedef struct well_branch_collection_struct well_branch_collection_type;
 
-  well_branch_collection_type * well_branch_collection_alloc();
+  well_branch_collection_type * well_branch_collection_alloc(void);
   void                          well_branch_collection_free( well_branch_collection_type * branches );
   void                          well_branch_collection_free__( void * arg );
   bool                          well_branch_collection_has_branch( const well_branch_collection_type * branches , int branch_id);

--- a/libecl_well/include/ert/ecl_well/well_conn_collection.h
+++ b/libecl_well/include/ert/ecl_well/well_conn_collection.h
@@ -33,7 +33,7 @@ extern "C" {
 
   typedef struct well_conn_collection_struct well_conn_collection_type;
 
-  well_conn_collection_type * well_conn_collection_alloc();
+  well_conn_collection_type * well_conn_collection_alloc(void);
   void                        well_conn_collection_free( well_conn_collection_type * wellcc );
   void                        well_conn_collection_free__( void * arg );
   int                         well_conn_collection_get_size( const well_conn_collection_type * wellcc );

--- a/libecl_well/include/ert/ecl_well/well_segment_collection.h
+++ b/libecl_well/include/ert/ecl_well/well_segment_collection.h
@@ -36,7 +36,7 @@ extern "C" {
 
   typedef struct well_segment_collection_struct well_segment_collection_type;
 
-  well_segment_collection_type * well_segment_collection_alloc();
+  well_segment_collection_type * well_segment_collection_alloc(void);
   void                           well_segment_collection_free(well_segment_collection_type * segment_collection );
   int                            well_segment_collection_get_size( const well_segment_collection_type * segment_collection );
   void                           well_segment_collection_add( well_segment_collection_type * segment_collection , well_segment_type * segment);

--- a/libecl_well/src/well_segment_collection.c
+++ b/libecl_well/src/well_segment_collection.c
@@ -39,7 +39,7 @@ struct well_segment_collection_struct {
 
 
 
-well_segment_collection_type * well_segment_collection_alloc() {
+well_segment_collection_type * well_segment_collection_alloc(void) {
   well_segment_collection_type * segment_collection = util_malloc( sizeof * segment_collection );
 
   segment_collection->__segment_storage = vector_alloc_new();

--- a/libert_util/include/ert/util/hash.h
+++ b/libert_util/include/ert/util/hash.h
@@ -37,8 +37,8 @@ UTIL_SAFE_CAST_HEADER_CONST(hash);
 
 void              hash_lock  (hash_type * );
 void              hash_unlock(hash_type * );
-hash_type       * hash_alloc();
-hash_type       * hash_alloc_unlocked();
+hash_type       * hash_alloc(void);
+hash_type       * hash_alloc_unlocked(void);
 void              hash_iter_complete(hash_type * );
 void              hash_free(hash_type *);
 void              hash_free__(void *);

--- a/libert_util/include/ert/util/stringlist.h
+++ b/libert_util/include/ert/util/stringlist.h
@@ -40,7 +40,7 @@ typedef int  ( string_cmp_ftype)  (const void * , const void *);
   stringlist_type * stringlist_alloc_deep_copy_with_offset(const stringlist_type * src , int offset);
   stringlist_type * stringlist_alloc_deep_copy( const stringlist_type * src ); 
 
-  stringlist_type * stringlist_alloc_new();
+  stringlist_type * stringlist_alloc_new(void);
   void              stringlist_free__(void * );
   void              stringlist_free(stringlist_type *);
   void              stringlist_clear(stringlist_type * );

--- a/libert_util/include/ert/util/type_macros.h
+++ b/libert_util/include/ert/util/type_macros.h
@@ -49,7 +49,7 @@ bool type ## _is_instance( const void * __arg ) {          \
    if (__arg == NULL)                                      \
       return false;                                        \
    else {                                                  \
-      const type ## _type * arg = (type ## _type *) __arg; \
+      const type ## _type * arg =                   __arg; \
       if ( arg->__type_id == TYPE_ID)                      \
          return true;                                      \
       else                                                 \

--- a/libert_util/include/ert/util/util.h
+++ b/libert_util/include/ert/util/util.h
@@ -101,7 +101,7 @@ typedef enum {left_pad   = 0,
   //#define UTIL_CXX_MALLOC(var , num_elm) (typeof (var)) util_malloc( (num_elm) * sizeof var)
 
   void         util_bitmask_on(int *  , int );
-  char       * util_get_timezone();
+  char       * util_get_timezone(void);
   time_t       util_make_datetime_utc(int , int , int , int , int , int );
   void         util_fprintf_date_utc(time_t  , FILE * );
   time_t       util_make_date_utc(int , int , int);
@@ -119,7 +119,7 @@ typedef enum {left_pad   = 0,
   bool         util_file_older( const char * file , time_t t0);
 
   char       * util_alloc_date_string_utc( time_t t );
-  char       * util_alloc_date_stamp_utc( );
+  char       * util_alloc_date_stamp_utc( void );
 
   double       util_pow10(double x);
   bool         util_char_in(char c, int , const char *);
@@ -134,7 +134,7 @@ typedef enum {left_pad   = 0,
   bool         util_sscanf_date_utc(const char * , time_t *);
   bool         util_sscanf_isodate(const char * , time_t *);
   bool         util_sscanf_percent(const char * string, double * value);
-  char       * util_alloc_stdin_line();
+  char       * util_alloc_stdin_line(void);
   char       * util_realloc_stdin_line(char * );
   bool         util_is_executable(const char * );
   bool         util_entry_exists( const char * entry );
@@ -174,7 +174,7 @@ typedef enum {left_pad   = 0,
   bool         util_ftruncate(FILE * stream , long size);
 
   void         util_usleep( unsigned long micro_seconds );
-  void         util_yield();
+  void         util_yield(void);
   char       * util_blocking_alloc_stdin_line(unsigned long );
 
   int          util_roundf( float x );
@@ -288,12 +288,12 @@ typedef enum {left_pad   = 0,
 
   void     util_fread_from_buffer(void *  , size_t  , size_t , char ** );
 
-  unsigned int util_clock_seed( );
+  unsigned int util_clock_seed( void );
   void         util_fread_dev_random(int , char * );
   void         util_fread_dev_urandom(int , char * );
   bool         util_string_isspace(const char * s);
 
-  char *  util_alloc_dump_filename();
+  char *  util_alloc_dump_filename(void);
   void    util_exit(const char * fmt , ...);
   void    util_install_signals(void);
   void    util_update_signals(void);
@@ -379,7 +379,7 @@ typedef enum {left_pad   = 0,
   int      util_fnmatch( const char * pattern , const char * string );
   void     util_time_utc( time_t * t , struct tm * ts );
 
-  char      ** util_alloc_PATH_list();
+  char      ** util_alloc_PATH_list(void);
   char       * util_alloc_PATH_executable(const char * executable );
   char       * util_isscanf_alloc_envvar( const char * string , int env_index );
   void         util_setenv( const char * variable , const char * value);
@@ -493,7 +493,7 @@ const char * util_enum_iget( int index , int size , const util_enum_element_type
 void    util_abort__(const char * file , const char * function , int line , const char * fmt , ...);
 void    util_abort_signal(int );
 void    util_abort_append_version_info(const char * );
-void    util_abort_free_version_info();
+void    util_abort_free_version_info(void);
 void    util_abort_set_executable( const char * argv0 );
 
 

--- a/libert_util/include/ert/util/vector.h
+++ b/libert_util/include/ert/util/vector.h
@@ -32,7 +32,7 @@ extern "C" {
   typedef struct vector_struct vector_type;
 
 
-  vector_type * vector_alloc_new();
+  vector_type * vector_alloc_new(void);
   void          vector_grow_NULL( vector_type * vector , int new_size );
   vector_type * vector_alloc_NULL_initialized( int size );
 


### PR DESCRIPTION
This change-set fixes a few diagnostic messages that I got following PR #1300.  It is mostly adding explicit `void` keywords to declarations of functions that do not take arguments.

Commit 5d6eb7f is potentially contentious.  The commit assumes that the macro in question (i.e., `UTIL_IS_INSTANCE_FUNCTION`) will only ever be processed by a C compiler and that we can rely on `void*` being implicitly convertible to all other (object) pointer types.  If the macro is supposed to be usable in a C++ context, then the body of the macro must be different.