### PR TITLE
Remove bogus space in python shebang.

### DIFF
--- a/python/tests/core/ecl/test_ecl_sum.py
+++ b/python/tests/core/ecl/test_ecl_sum.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 #  Copyright (C) 2014  Statoil ASA, Norway.
 #   
 #  The file 'test_ecl_sum.py' is part of ERT - Ensemble based Reservoir Tool.

--- a/python/tests/core/ecl/test_ecl_sum_vector.py
+++ b/python/tests/core/ecl/test_ecl_sum_vector.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 #  Copyright (C) 2013  Statoil ASA, Norway. 
 #   
 #  The file 'test_ecl_sum_vector.py' is part of ERT - Ensemble based Reservoir Tool. 


### PR DESCRIPTION
There was a space between the # and the !.