### PR TITLE
Added support for top of active cells

### DIFF
--- a/python/python/ert/ecl/ecl_grid.py
+++ b/python/python/ert/ecl/ecl_grid.py
@@ -86,7 +86,8 @@ class EclGrid(BaseCClass):
     _get_depth                    = EclPrototype("double ecl_grid_get_cdepth1( ecl_grid , int )")
     _fwrite_grdecl                = EclPrototype("void   ecl_grid_grdecl_fprintf_kw( ecl_grid , ecl_kw , char* , FILE , double)") 
     _load_column                  = EclPrototype("void   ecl_grid_get_column_property( ecl_grid , ecl_kw , int , int , double_vector)")
-    _get_top                      = EclPrototype("double ecl_grid_get_top2( ecl_grid , int , int )") 
+    _get_top                      = EclPrototype("double ecl_grid_get_top2( ecl_grid , int , int )")
+    _get_top1A                    = EclPrototype("double ecl_grid_get_top1A(ecl_grid , int )")
     _get_bottom                   = EclPrototype("double ecl_grid_get_bottom2( ecl_grid , int , int )") 
     _locate_depth                 = EclPrototype("int    ecl_grid_locate_depth( ecl_grid , double , int , int )") 
     _invalid_cell                 = EclPrototype("bool   ecl_grid_cell_invalid1( ecl_grid , int)")
@@ -716,8 +717,20 @@ class EclGrid(BaseCClass):
     def top( self , i , j ):
         """
         Top of the reservoir; in the column (@i , @j).
+        Returns average depth of the four top corners.
         """
-        return self._get_top( i , j ) 
+        return self._get_top( i , j )
+
+    def top_active( self, i, j ):
+        """
+        Top of the active part of the reservoir; in the column (@i , @j).
+        Raises ValueError if (i,j) column is inactive.
+        """
+        for k in range(self.getNZ()):
+            a_idx = self.get_active_index(ijk=(i,j,k))
+            if a_idx >= 0:
+                return self._get_top1A(a_idx)
+        raise ValueError('No active cell in column (%d,%d)' % (i,j))
 
     def bottom( self , i , j ):
         """


### PR DESCRIPTION
This PR adds a feature to `ecl_grid.py`:

* added function `top_active` that returns top of the active part of the reservoir in a given column, or raises if column is inactive