### PR TITLE
Remove CWrapper from enkf part 3

### DIFF
--- a/libenkf/include/ert/enkf/gen_obs.h
+++ b/libenkf/include/ert/enkf/gen_obs.h
@@ -41,7 +41,7 @@ void           gen_obs_set_scalar( gen_obs_type * gen_obs , double scalar_value 
 void 	       gen_obs_attach_data_index( gen_obs_type * gen_obs , const int_vector_type * data_index );
 void 	       gen_obs_load_data_index( gen_obs_type * obs , const char * data_index_file);
 void 	       gen_obs_parse_data_index( gen_obs_type * obs , const char * data_index_string);
-
+void           gen_obs_free(gen_obs_type * gen_obs);
 
 
 

--- a/libenkf/include/ert/enkf/gen_obs.h
+++ b/libenkf/include/ert/enkf/gen_obs.h
@@ -28,6 +28,7 @@
 typedef struct gen_obs_struct gen_obs_type;
 
 gen_obs_type * gen_obs_alloc(gen_data_config_type * config , const char * obs_key , const char * , double , double , const char * , const char * , const char  * );
+gen_obs_type * gen_obs_alloc__(gen_data_config_type * data_config , const char * obs_key); // for python bindings
 void           gen_obs_user_get_with_data_index(const gen_obs_type * gen_obs , const char * index_key , double * value , double * std , bool * valid);
 
 void           gen_obs_update_std_scale(gen_obs_type * gen_obs, double std_multiplier , const active_list_type * active_list);

--- a/python/python/cwrap/basecclass.py
+++ b/python/python/cwrap/basecclass.py
@@ -44,6 +44,8 @@ class BaseCClass(object):
 
     def _address(self):
         return self.__c_pointer
+    def _ad_str(self):
+        return 'at 0x%x' % self._address()
 
     @classmethod
     def cNamespace(cls):

--- a/python/python/cwrap/basecclass.py
+++ b/python/python/cwrap/basecclass.py
@@ -113,7 +113,7 @@ class BaseCClass(object):
         if isinstance(other, BaseCClass):
             return self.__c_pointer == other.__c_pointer
         else:
-            return super(BaseCClass , self).__eq__(other)
+            return super(BaseCClass , self) == other
 
     def __hash__(self):
         # Similar to last resort comparison; this returns the hash of the

--- a/python/python/ert/enkf/active_list.py
+++ b/python/python/ert/enkf/active_list.py
@@ -14,32 +14,29 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 class ActiveList(BaseCClass):
+    TYPE_NAME = "active_list"
+
+    _alloc     = EnkfPrototype("void* active_list_alloc()", bind = False)
+    _free      = EnkfPrototype("void  active_list_free(active_list)")
+    _add_index = EnkfPrototype("void  active_list_add_index(active_list , int)")
+    _get_mode  = EnkfPrototype("active_mode_enum active_list_get_mode(active_list)")
+
     def __init__(self):
-        c_ptr = ActiveList.cNamespace().alloc()
+        c_ptr = self._alloc()
         super(ActiveList, self).__init__(c_ptr)
 
-
     def getMode(self):
-        return ActiveList.cNamespace().get_mode(self)
+        return self._get_mode()
 
     def addActiveIndex(self, index):
-        ActiveList.cNamespace().add_index(self , index)
-
+        self._add_index(index)
 
     def free(self):
-        ActiveList.cNamespace().free(self)
+        self._free()
 
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("active_list", ActiveList)
-
-
-ActiveList.cNamespace().alloc     = cwrapper.prototype("c_void_p active_list_alloc()")
-ActiveList.cNamespace().free      = cwrapper.prototype("void     active_list_free(active_list)")
-ActiveList.cNamespace().get_mode  = cwrapper.prototype("active_mode_enum active_list_get_mode(active_list)")
-ActiveList.cNamespace().add_index = cwrapper.prototype("void active_list_add_index(active_list , int)")
+    def __repr__(self):
+        return 'ActiveList(mode = %s) at 0x%x' % (str(self.getMode()), self._address())

--- a/python/python/ert/enkf/active_list.py
+++ b/python/python/ert/enkf/active_list.py
@@ -1,17 +1,17 @@
-#  Copyright (C) 2015  Statoil ASA, Norway. 
-#   
-#  The file 'active_list.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  Copyright (C) 2015  Statoil ASA, Norway.
+#
+#  The file 'active_list.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
 from cwrap import BaseCClass, CWrapper
@@ -29,7 +29,7 @@ class ActiveList(BaseCClass):
     def addActiveIndex(self, index):
         ActiveList.cNamespace().add_index(self , index)
 
-        
+
     def free(self):
         ActiveList.cNamespace().free(self)
 

--- a/python/python/ert/enkf/analysis_config.py
+++ b/python/python/ert/enkf/analysis_config.py
@@ -13,9 +13,8 @@
 #   
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
-from cwrap import BaseCClass, CWrapper
+from cwrap import BaseCClass
 from ert.enkf import EnkfPrototype
-from ert.enkf import ENKF_LIB
 from ert.enkf import AnalysisIterConfig
 from ert.analysis import AnalysisModule
 from ert.util import StringList

--- a/python/python/ert/enkf/analysis_iter_config.py
+++ b/python/python/ert/enkf/analysis_iter_config.py
@@ -13,52 +13,69 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
-
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 class AnalysisIterConfig(BaseCClass):
+    TYPE_NAME = "analysis_iter_config"
+
+    _alloc              = EnkfPrototype("void* analysis_iter_config_alloc( )", bind = False)
+    _free               = EnkfPrototype("void  analysis_iter_config_free( analysis_iter_config )")
+    _set_num_iterations = EnkfPrototype("void  analysis_iter_config_set_num_iterations(analysis_iter_config, int)")
+    _get_num_iterations = EnkfPrototype("int   analysis_iter_config_get_num_iterations(analysis_iter_config)")
+    _get_num_retries    = EnkfPrototype("int   analysis_iter_config_get_num_retries_per_iteration(analysis_iter_config)")
+    _num_iterations_set = EnkfPrototype("bool  analysis_iter_config_num_iterations_set(analysis_iter_config)")
+    _set_case_fmt       = EnkfPrototype("void  analysis_iter_config_set_case_fmt( analysis_iter_config , char* )")
+    _get_case_fmt       = EnkfPrototype("char* analysis_iter_config_get_case_fmt( analysis_iter_config)")
+    _case_fmt_set       = EnkfPrototype("bool  analysis_iter_config_case_fmt_set(analysis_iter_config)")
+
     def __init__(self):
-        c_ptr = AnalysisIterConfig.cNamespace().alloc()
+        c_ptr = self._alloc()
         super(AnalysisIterConfig , self).__init__(c_ptr)
 
     def getNumIterations(self):
         """ @rtype: int """
-        return AnalysisIterConfig.cNamespace().get_num_iterations(self)
+        return self._get_num_iterations()
+
+    def __len__(self):
+        """Returns number of iterations."""
+        return self.getNumIterations()
 
     def setNumIterations(self, num_iterations):
-        AnalysisIterConfig.cNamespace().set_num_iterations(self, num_iterations)
+        self._set_num_iterations(num_iterations)
 
     def numIterationsSet(self):
-        return AnalysisIterConfig.cNamespace().num_iterations_set(self)
+        return self._num_iterations_set()
 
     def getNumRetries(self):
         """ @rtype: int """
-        return AnalysisIterConfig.cNamespace().get_num_retries(self)
+        return self._get_num_retries()
 
     def getCaseFormat(self):
         """ @rtype: str """
-        return AnalysisIterConfig.cNamespace().get_case_fmt(self)
+        return self._get_case_fmt()
 
     def setCaseFormat(self, case_fmt):
-        AnalysisIterConfig.cNamespace().set_case_fmt(self, case_fmt)
+        self._set_case_fmt(case_fmt)
 
     def caseFormatSet(self):
-        return AnalysisIterConfig.cNamespace().case_fmt_set(self)
+        return self._case_fmt_set()
 
     def free(self):
-        AnalysisIterConfig.cNamespace().free(self)
+        self._free()
 
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("analysis_iter_config", AnalysisIterConfig)
+    def _short_case_fmt(self, maxlen=10):
+        fmt = getCaseFormat()
+        if len(fmt) <= maxlen:
+            return fmt
+        return fmt[:maxlen-2] + ".."
 
-
-AnalysisIterConfig.cNamespace().alloc = cwrapper.prototype("c_void_p analysis_iter_config_alloc( )")
-AnalysisIterConfig.cNamespace().free = cwrapper.prototype("void analysis_iter_config_free( analysis_iter_config )")
-AnalysisIterConfig.cNamespace().set_num_iterations = cwrapper.prototype("void analysis_iter_config_set_num_iterations(analysis_iter_config, int)")
-AnalysisIterConfig.cNamespace().get_num_iterations = cwrapper.prototype("int analysis_iter_config_get_num_iterations(analysis_iter_config)")
-AnalysisIterConfig.cNamespace().get_num_retries = cwrapper.prototype("int analysis_iter_config_get_num_retries_per_iteration(analysis_iter_config)")
-AnalysisIterConfig.cNamespace().num_iterations_set = cwrapper.prototype("bool analysis_iter_config_num_iterations_set(analysis_iter_config)")
-AnalysisIterConfig.cNamespace().set_case_fmt = cwrapper.prototype("void analysis_iter_config_set_case_fmt( analysis_iter_config , char* )")
-AnalysisIterConfig.cNamespace().get_case_fmt = cwrapper.prototype("char* analysis_iter_config_get_case_fmt( analysis_iter_config)")
-AnalysisIterConfig.cNamespace().case_fmt_set = cwrapper.prototype("bool analysis_iter_config_case_fmt_set(analysis_iter_config)")
+    def __repr__(self):
+        cfs = 'format = False'
+        if self.caseFormatSet():
+            cfs = 'format = True'
+        fmt  = self._short_case_fmt()
+        ret  = 'AnalysisIterConfig(iterations = %d, retries = %d, fmt = %s, %s) at 0x%x'
+        its  = len(self)
+        rets = self.getNumRetries()
+        return ret % (its, rets, fmt, cfs, self._address)

--- a/python/python/ert/enkf/config/gen_data_config.py
+++ b/python/python/ert/enkf/config/gen_data_config.py
@@ -13,84 +13,87 @@
 #   
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.enkf.enums import GenDataFileType
 
 
 class GenDataConfig(BaseCClass):
+    TYPE_NAME = "gen_data_config"
+
+    _alloc               = EnkfPrototype("void* gen_data_config_alloc_GEN_DATA_result( char* , gen_data_file_format_type)", bind = False)
+    _free                = EnkfPrototype("void  gen_data_config_free( gen_data_config )")
+    _get_output_format   = EnkfPrototype("gen_data_file_format_type gen_data_config_get_output_format(gen_data_config)")
+    _get_input_format    = EnkfPrototype("gen_data_file_format_type gen_data_config_get_input_format(gen_data_config)")
+    _get_template_file   = EnkfPrototype("char* gen_data_config_get_template_file(gen_data_config)")
+    _get_template_key    = EnkfPrototype("char* gen_data_config_get_template_key(gen_data_config)")
+    _get_initial_size    = EnkfPrototype("int   gen_data_config_get_initial_size(gen_data_config)")
+    _has_report_step     = EnkfPrototype("bool  gen_data_config_has_report_step(gen_data_config, int)")
+    _get_data_size       = EnkfPrototype("int   gen_data_config_get_data_size__(gen_data_config , int)")
+    _get_key             = EnkfPrototype("char* gen_data_config_get_key(gen_data_config)")
+    _get_active_mask     = EnkfPrototype("bool_vector_ref gen_data_config_get_active_mask(gen_data_config)")
+    _get_num_report_step = EnkfPrototype("int   gen_data_config_num_report_step(gen_data_config)")
+    _iget_report_step    = EnkfPrototype("int   gen_data_config_iget_report_step(gen_data_config, int)")
+
+
     def __init__(self, key , input_format = GenDataFileType.ASCII):
         # Can currently only create GEN_DATA instances which should be used
         # as result variables.
-        c_pointer = GenDataConfig.cNamespace().alloc( key , input_format )
+        c_pointer = self._alloc( key , input_format )
         super(GenDataConfig, self).__init__(c_pointer)
 
 
     def get_template_file(self):
-        return GenDataConfig.cNamespace().get_template_file(self)
+        return self._get_template_file()
 
     def get_template_key(self):
-        return GenDataConfig.cNamespace().get_template_key(self)
+        return self._get_template_key()
 
     def getDataSize(self , report_step):
-        data_size = GenDataConfig.cNamespace().get_data_size(self , report_step)
+        data_size = self._get_data_size(report_step)
         if data_size < 0:
             raise ValueError("No data has been loaded for %s at report step:%d " % (self.getName() , report_step))
         else:
             return data_size
             
     def getActiveMask(self):
-         return GenDataConfig.cNamespace().get_active_mask(self)
+         return self._get_active_mask()
 
     def getName(self):
-        return GenDataConfig.cNamespace().get_key(self)
-
+        return self.name()
+    def name(self):
+        return self._get_key()
 
     def get_initial_size(self):
-        return GenDataConfig.cNamespace().get_initial_size(self)
+        return self._get_initial_size()
 
     def getOutputFormat(self):
-        return GenDataConfig.cNamespace().get_output_format(self)
+        return self._get_output_format()
 
     def getInputFormat(self):
-        return GenDataConfig.cNamespace().get_input_format(self)
+        return self._get_input_format()
 
     def free(self):
-        GenDataConfig.cNamespace().free(self)
+        self._free()
+
+    def __repr__(self):
+        nm = self.name()
+        tk = self.get_template_key()
+        iz = self.get_initial_size()
+        return 'GenDataConfig(name = %s, template_key = %s, initial_size = %d) %s' % (nm, tk, iz, self._ad_str())
 
     def hasReportStep(self, report_step):
         """ @rtype: bool """
-        return GenDataConfig.cNamespace().has_report_step(self, report_step)
+        return self._has_report_step(report_step)
 
     def getNumReportStep(self):
         """ @rtype: int """
-        return GenDataConfig.cNamespace().get_num_report_step(self)
+        return self._get_num_report_step()
 
     def getReportStep(self, index):
         """ @rtype: int """
-        return GenDataConfig.cNamespace().iget_report_step(self, index)
+        return self._iget_report_step(index)
 
     def getReportSteps(self):
         """ @rtype: list of int """
         return [self.getReportStep(index) for index in range(self.getNumReportStep())]
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("gen_data_config", GenDataConfig)
-
-
-GenDataConfig.cNamespace().alloc = cwrapper.prototype("c_void_p gen_data_config_alloc_GEN_DATA_result( char* , gen_data_file_format_type)")
-GenDataConfig.cNamespace().free  = cwrapper.prototype("void gen_data_config_free( gen_data_config )")
-GenDataConfig.cNamespace().get_output_format = cwrapper.prototype("gen_data_file_format_type gen_data_config_get_output_format(gen_data_config)")
-GenDataConfig.cNamespace().get_input_format = cwrapper.prototype("gen_data_file_format_type gen_data_config_get_input_format(gen_data_config)")
-GenDataConfig.cNamespace().get_template_file = cwrapper.prototype("char* gen_data_config_get_template_file(gen_data_config)")
-GenDataConfig.cNamespace().get_template_key = cwrapper.prototype("char* gen_data_config_get_template_key(gen_data_config)")
-GenDataConfig.cNamespace().get_initial_size = cwrapper.prototype("int gen_data_config_get_initial_size(gen_data_config)")
-GenDataConfig.cNamespace().has_report_step = cwrapper.prototype("bool gen_data_config_has_report_step(gen_data_config, int)")
-GenDataConfig.cNamespace().get_data_size    = cwrapper.prototype("int gen_data_config_get_data_size__(gen_data_config , int)")
-GenDataConfig.cNamespace().get_key          = cwrapper.prototype("char* gen_data_config_get_key(gen_data_config)")
-GenDataConfig.cNamespace().get_active_mask  = cwrapper.prototype("bool_vector_ref gen_data_config_get_active_mask(gen_data_config)")
-
-GenDataConfig.cNamespace().get_num_report_step = cwrapper.prototype("int gen_data_config_num_report_step(gen_data_config)")
-GenDataConfig.cNamespace().iget_report_step    = cwrapper.prototype("int gen_data_config_iget_report_step(gen_data_config, int)")
-

--- a/python/python/ert/enkf/ecl_config.py
+++ b/python/python/ert/enkf/ecl_config.py
@@ -1,17 +1,17 @@
-#  Copyright (C) 2012  Statoil ASA, Norway. 
-#   
-#  The file 'ecl_config.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  Copyright (C) 2012  Statoil ASA, Norway.
+#
+#  The file 'ecl_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from warnings import warn
 
@@ -27,7 +27,7 @@ class EclConfig(BaseCClass):
     def __init__(self):
         c_pointer = EclConfig.cNamespace().alloc()
         super(EclConfig, self).__init__(c_pointer)
-        
+
     def free(self):
         EclConfig.cNamespace().free(self)
 
@@ -64,15 +64,15 @@ class EclConfig(BaseCClass):
 
     def set_gridfile(self, gridfile):
         EclConfig.cNamespace().set_gridfile(self, gridfile)
-    
+
     def validateGridFile(self , gridfile):
         return EclConfig.cNamespace().validate_gridfile(self, gridfile)
-        
+
     def get_grid(self):
         warning_message = "The method get_grid() is deprecated. Use getGrid() instead"
         warn(warning_message)
         return self.getGrid( )
-    
+
     def getGrid(self):
         return EclConfig.cNamespace().get_grid(self)
 
@@ -124,7 +124,7 @@ class EclConfig(BaseCClass):
     def hasRefcase(self):
         """ @rtype: bool """
         return EclConfig.cNamespace().has_refcase(self)
-        
+
     #-----------------------------------------------------------------
 
     def get_static_kw_list(self):

--- a/python/python/ert/enkf/ecl_config.py
+++ b/python/python/ert/enkf/ecl_config.py
@@ -21,11 +21,10 @@ from ert.util import StringList
 from ert.ecl import EclSum
 from ert.ecl import EclGrid
 from ert.util import UIReturn
+from ert.sched import SchedFile
 
 class EclConfig(BaseCClass):
     TYPE_NAME = "ecl_config"
-    #cwrapper.registerType("ecl_config_obj", EclConfig.createPythonObject)
-    #cwrapper.registerType("ecl_config_ref", EclConfig.createCReference)
 
     _alloc                  = EnkfPrototype("void* ecl_config_alloc( )", bind = False)
     _free                   = EnkfPrototype("void  ecl_config_free( ecl_config )")
@@ -58,8 +57,11 @@ class EclConfig(BaseCClass):
     _get_pressure_unit      = EnkfPrototype("char* ecl_config_get_pressure_unit(ecl_config)")
 
     def __init__(self):
-        c_pointer = self._alloc()
-        super(EclConfig, self).__init__(c_pointer)
+        c_ptr = self._alloc()
+        if c_ptr:
+            super(EclConfig, self).__init__(c_ptr)
+        else:
+            raise RuntimeError('Internal error: Failed constructing EclConfig!')
 
     def free(self):
         self._free()

--- a/python/python/ert/enkf/ecl_config.py
+++ b/python/python/ert/enkf/ecl_config.py
@@ -15,58 +15,91 @@
 #  for more details.
 from warnings import warn
 
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.util import StringList
 from ert.ecl import EclSum
 from ert.ecl import EclGrid
 from ert.util import UIReturn
 
-
 class EclConfig(BaseCClass):
+    TYPE_NAME = "ecl_config"
+    #cwrapper.registerType("ecl_config_obj", EclConfig.createPythonObject)
+    #cwrapper.registerType("ecl_config_ref", EclConfig.createCReference)
+
+    _alloc                  = EnkfPrototype("void* ecl_config_alloc( )", bind = False)
+    _free                   = EnkfPrototype("void  ecl_config_free( ecl_config )")
+    _get_eclbase            = EnkfPrototype("char* ecl_config_get_eclbase( ecl_config )")
+    _validate_eclbase       = EnkfPrototype("ui_return_obj ecl_config_validate_eclbase( ecl_config , char*)")
+    _set_eclbase            = EnkfPrototype("void  ecl_config_set_eclbase( ecl_config , char*)")
+    _get_data_file          = EnkfPrototype("char* ecl_config_get_data_file(ecl_config)")
+    _set_data_file          = EnkfPrototype("void  ecl_config_set_data_file(ecl_config , char*)")
+    _validate_data_file     = EnkfPrototype("ui_return_obj ecl_config_validate_data_file(ecl_config , char*)")
+    _get_gridfile           = EnkfPrototype("char* ecl_config_get_gridfile(ecl_config)")
+    _set_gridfile           = EnkfPrototype("void  ecl_config_set_grid(ecl_config, char*)")
+    _validate_gridfile      = EnkfPrototype("ui_return_obj ecl_config_validate_grid(ecl_config, char*)")
+    _get_grid               = EnkfPrototype("ecl_grid_ref ecl_config_get_grid(ecl_config)")
+    _get_schedule_file      = EnkfPrototype("char* ecl_config_get_schedule_file(ecl_config)")
+    _set_schedule_file      = EnkfPrototype("void  ecl_config_set_schedule_file(ecl_config, char*, char*)")
+    _validate_schedule_file = EnkfPrototype("ui_return_obj ecl_config_validate_schedule_file(ecl_config, char*)")
+    _get_sched_file         = EnkfPrototype("sched_file_ref ecl_config_get_sched_file(ecl_config)")
+    _get_init_section       = EnkfPrototype("char* ecl_config_get_init_section(ecl_config)")
+    _set_init_section       = EnkfPrototype("void  ecl_config_set_init_section(ecl_config, char*)")
+    _validate_init_section  = EnkfPrototype("ui_return_obj ecl_config_validate_init_section(ecl_config, char*)")
+    _get_refcase_name       = EnkfPrototype("char* ecl_config_get_refcase_name(ecl_config)")
+    _get_refcase            = EnkfPrototype("ecl_sum_ref ecl_config_get_refcase(ecl_config)")
+    _load_refcase           = EnkfPrototype("void  ecl_config_load_refcase(ecl_config, char*)")
+    _validate_refcase       = EnkfPrototype("ui_return_obj ecl_config_validate_refcase(ecl_config, char*)")
+    _has_refcase            = EnkfPrototype("bool  ecl_config_has_refcase(ecl_config)")
+    _get_static_kw_list     = EnkfPrototype("stringlist_ref ecl_config_get_static_kw_list(ecl_config)")
+    _clear_static_kw        = EnkfPrototype("void  ecl_config_clear_static_kw(ecl_config)")
+    _add_static_kw          = EnkfPrototype("void  ecl_config_add_static_kw(ecl_config, char*)")
+    _get_depth_unit         = EnkfPrototype("char* ecl_config_get_depth_unit(ecl_config)")
+    _get_pressure_unit      = EnkfPrototype("char* ecl_config_get_pressure_unit(ecl_config)")
+
     def __init__(self):
-        c_pointer = EclConfig.cNamespace().alloc()
+        c_pointer = self._alloc()
         super(EclConfig, self).__init__(c_pointer)
 
     def free(self):
-        EclConfig.cNamespace().free(self)
+        self._free()
 
     #-----------------------------------------------------------------
 
     def getEclBase(self):
         """ @rtype: str """
-        return EclConfig.cNamespace().get_eclbase(self)
+        return self._get_eclbase()
 
     def validateEclBase(self , eclbase_fmt):
-        return EclConfig.cNamespace().validate_eclbase(self , eclbase_fmt)
+        return self._validate_eclbase(eclbase_fmt)
 
     # Warning: You should probably use the EnkFMain.setEclBase() method to update the Eclipse basename format
     def setEclBase(self , eclbase):
-        EclConfig.cNamespace().set_eclbase( self , eclbase )
+        self._set_eclbase(eclbase)
 
     #-----------------------------------------------------------------
 
     def getDataFile(self):
-        return EclConfig.cNamespace().get_data_file(self)
+        return self._get_data_file()
 
     def setDataFile(self , datafile):
-        EclConfig.cNamespace().set_data_file(self , datafile)
+        self._set_data_file( datafile)
 
     def validateDataFile( self , datafile ):
         """ @rtype: UIReturn """
-        return EclConfig.cNamespace().validate_data_file( self , datafile )
+        return self._validate_data_file(  datafile )
 
     #-----------------------------------------------------------------
 
     def get_gridfile(self):
         """ @rtype: str """
-        return EclConfig.cNamespace().get_gridfile(self)
+        return self._get_gridfile()
 
     def set_gridfile(self, gridfile):
-        EclConfig.cNamespace().set_gridfile(self, gridfile)
+        self._set_gridfile(gridfile)
 
     def validateGridFile(self , gridfile):
-        return EclConfig.cNamespace().validate_gridfile(self, gridfile)
+        return self._validate_gridfile(gridfile)
 
     def get_grid(self):
         warning_message = "The method get_grid() is deprecated. Use getGrid() instead"
@@ -74,44 +107,44 @@ class EclConfig(BaseCClass):
         return self.getGrid( )
 
     def getGrid(self):
-        return EclConfig.cNamespace().get_grid(self)
+        return self._get_grid()
 
     #-----------------------------------------------------------------
 
     def getScheduleFile(self):
-        return EclConfig.cNamespace().get_schedule_file(self)
+        return self._get_schedule_file()
 
-    def setScheduleFile(self, schedule_file):
-        EclConfig.cNamespace().set_schedule_file(self, schedule_file)
+    def setScheduleFile(self, schedule_file, target_file = None):
+        self._set_schedule_file(schedule_file, target_file)
 
     def validateScheduleFile(self , schedule_file):
-        return EclConfig.cNamespace().validate_schedule_file( self , schedule_file )
+        return self._validate_schedule_file(schedule_file)
 
     def get_sched_file(self):
-        return EclConfig.cNamespace().get_sched_file(self)
+        return self._get_sched_file()
 
     #-----------------------------------------------------------------
 
     def getInitSection(self):
-        return EclConfig.cNamespace().get_init_section(self)
+        return self._get_init_section()
 
     def setInitSection(self, init_section):
-        EclConfig.cNamespace().set_init_section(self, init_section)
+        self._set_init_section(init_section)
 
     def validateInitSection(self, init_section):
-        return EclConfig.cNamespace().validate_init_section(self, init_section)
+        return self._validate_init_section(init_section)
 
     #-----------------------------------------------------------------
 
     def getRefcaseName(self):
-        return EclConfig.cNamespace().get_refcase_name(self)
+        return self._get_refcase_name()
 
     def loadRefcase(self, refcase):
-        EclConfig.cNamespace().load_refcase(self, refcase)
+        self._load_refcase(refcase)
 
     def getRefcase(self):
         """ @rtype: EclSum """
-        refcase = EclConfig.cNamespace().get_refcase( self )
+        refcase = self._get_refcase()
         if not refcase is None:
             refcase.setParent(self)
 
@@ -119,73 +152,28 @@ class EclConfig(BaseCClass):
 
 
     def validateRefcase(self, refcase):
-        return EclConfig.cNamespace().validate_refcase( self , refcase )
+        return self._validate_refcase(refcase)
 
     def hasRefcase(self):
         """ @rtype: bool """
-        return EclConfig.cNamespace().has_refcase(self)
+        return self._has_refcase()
 
     #-----------------------------------------------------------------
 
     def get_static_kw_list(self):
         """ @rtype: StringList """
-        return EclConfig.cNamespace().get_static_kw_list(self).setParent(self)
+        return self._get_static_kw_list().setParent(self)
 
     def clear_static_kw(self):
-        EclConfig.cNamespace().clear_static_kw(self)
+        self._clear_static_kw()
 
     def add_static_kw(self, kw):
-        EclConfig.cNamespace().add_static_kw(self, kw)
+        self._add_static_kw(kw)
 
     #-----------------------------------------------------------------
 
     def getDepthUnit(self):
-        return EclConfig.cNamespace().get_depth_unit(self)
+        return self._get_depth_unit()
 
     def getPressureUnit(self):
-        return EclConfig.cNamespace().get_pressure_unit(self)
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("ecl_config", EclConfig)
-cwrapper.registerType("ecl_config_obj", EclConfig.createPythonObject)
-cwrapper.registerType("ecl_config_ref", EclConfig.createCReference)
-
-
-EclConfig.cNamespace().alloc = cwrapper.prototype("c_void_p ecl_config_alloc( )")
-EclConfig.cNamespace().free = cwrapper.prototype("void ecl_config_free( ecl_config )")
-
-EclConfig.cNamespace().get_eclbase = cwrapper.prototype("char* ecl_config_get_eclbase( ecl_config )")
-EclConfig.cNamespace().validate_eclbase = cwrapper.prototype("ui_return_obj ecl_config_validate_eclbase( ecl_config , char*)")
-EclConfig.cNamespace().set_eclbase = cwrapper.prototype("void ecl_config_set_eclbase( ecl_config , char*)")
-
-EclConfig.cNamespace().get_data_file = cwrapper.prototype("char* ecl_config_get_data_file(ecl_config)")
-EclConfig.cNamespace().set_data_file = cwrapper.prototype("void ecl_config_set_data_file(ecl_config , char*)")
-EclConfig.cNamespace().validate_data_file = cwrapper.prototype("ui_return_obj ecl_config_validate_data_file(ecl_config , char*)")
-
-EclConfig.cNamespace().get_gridfile = cwrapper.prototype("char* ecl_config_get_gridfile(ecl_config)")
-EclConfig.cNamespace().set_gridfile = cwrapper.prototype("void ecl_config_set_grid(ecl_config, char*)")
-EclConfig.cNamespace().validate_gridfile = cwrapper.prototype("ui_return_obj ecl_config_validate_grid(ecl_config, char*)")
-EclConfig.cNamespace().get_grid = cwrapper.prototype("ecl_grid_ref ecl_config_get_grid(ecl_config)")  #todo: fix return type!!!
-
-EclConfig.cNamespace().get_schedule_file = cwrapper.prototype("char* ecl_config_get_schedule_file(ecl_config)")
-EclConfig.cNamespace().set_schedule_file = cwrapper.prototype("void ecl_config_set_schedule_file(ecl_config, char*)")
-EclConfig.cNamespace().validate_schedule_file = cwrapper.prototype("ui_return_obj ecl_config_validate_schedule_file(ecl_config, char*)")
-EclConfig.cNamespace().get_sched_file = cwrapper.prototype("c_void_p ecl_config_get_sched_file(ecl_config)") #todo: fix return type!!!
-
-EclConfig.cNamespace().get_init_section = cwrapper.prototype("char* ecl_config_get_init_section(ecl_config)")
-EclConfig.cNamespace().set_init_section = cwrapper.prototype("void ecl_config_set_init_section(ecl_config, char*)")
-EclConfig.cNamespace().validate_init_section = cwrapper.prototype("ui_return_obj ecl_config_validate_init_section(ecl_config, char*)")
-
-EclConfig.cNamespace().get_refcase_name = cwrapper.prototype("char* ecl_config_get_refcase_name(ecl_config)")
-EclConfig.cNamespace().get_refcase = cwrapper.prototype("ecl_sum_ref ecl_config_get_refcase(ecl_config)")   #todo: fix return type!!!
-EclConfig.cNamespace().load_refcase = cwrapper.prototype("void ecl_config_load_refcase(ecl_config, char*)")
-EclConfig.cNamespace().validate_refcase = cwrapper.prototype("ui_return_obj ecl_config_validate_refcase(ecl_config, char*)")
-EclConfig.cNamespace().has_refcase = cwrapper.prototype("bool ecl_config_has_refcase(ecl_config)")
-
-EclConfig.cNamespace().get_static_kw_list = cwrapper.prototype("stringlist_ref ecl_config_get_static_kw_list(ecl_config)")
-EclConfig.cNamespace().clear_static_kw = cwrapper.prototype("void ecl_config_clear_static_kw(ecl_config)")
-EclConfig.cNamespace().add_static_kw = cwrapper.prototype("void ecl_config_add_static_kw(ecl_config, char*)")
-
-EclConfig.cNamespace().get_depth_unit = cwrapper.prototype("char* ecl_config_get_depth_unit(ecl_config)")
-EclConfig.cNamespace().get_pressure_unit = cwrapper.prototype("char* ecl_config_get_pressure_unit(ecl_config)")
+        return self._get_pressure_unit()

--- a/python/python/ert/enkf/enkf_obs.py
+++ b/python/python/ert/enkf/enkf_obs.py
@@ -1,17 +1,17 @@
 # Copyright (C) 2012  Statoil ASA, Norway.
-#   
-#  The file 'enkf_obs.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#
+#  The file 'enkf_obs.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 import os.path
 
@@ -30,7 +30,7 @@ class EnkfObs(BaseCClass):
         c_ptr = EnkfObs.cNamespace().alloc( history , external_time_map , grid , refcase , ensemble_config )
         super(EnkfObs, self).__init__(c_ptr)
 
-        
+
     def __len__(self):
         return EnkfObs.cNamespace().get_size(self)
 
@@ -65,12 +65,12 @@ class EnkfObs(BaseCClass):
     def createLocalObsdata(self , key , add_active_steps = True):
         # Use getAllActiveLocalObsdata()
         raise NotImplementedError("Hmmm C function: enkf_obs_alloc_all_active_local_obs() removed")
-    
+
 
 
     def getAllActiveLocalObsdata(self , key = "ALL-OBS"):
         return EnkfObs.cNamespace().create_all_active_obs( self , key )
-        
+
 
 
     def getTypedKeylist(self, observation_implementation_type):
@@ -85,7 +85,7 @@ class EnkfObs(BaseCClass):
             return EnkfObs.cNamespace().obs_type( self , key)
         else:
             raise KeyError("Unknown observation key:%s" % key)
-            
+
 
     def getMatchingKeys(self , pattern , obs_type = None):
         """
@@ -101,7 +101,7 @@ class EnkfObs(BaseCClass):
             return new_key_list
         else:
             return key_list
-        
+
 
     def hasKey(self, key):
 
@@ -133,7 +133,7 @@ class EnkfObs(BaseCClass):
 
     def scaleCorrelatedStd( self , fs , local_obsdata , active_list):
         return EnkfObs.cNamespace().scale_correlated_std( self , fs , active_list , local_obsdata )
-    
+
     def localScaleStd( self , local_obsdata , scale_factor):
         return EnkfObs.cNamespace().local_scale_std( self , local_obsdata, scale_factor)
 
@@ -172,5 +172,3 @@ EnkfObs.cNamespace().get_obs_and_measure_data = cwrapper.prototype("void enkf_ob
 EnkfObs.cNamespace().create_all_active_obs       = cwrapper.prototype("local_obsdata_obj enkf_obs_alloc_all_active_local_obs( enkf_obs , char*)");
 EnkfObs.cNamespace().scale_correlated_std        = cwrapper.prototype("double  enkf_obs_scale_correlated_std( enkf_obs , enkf_fs , int_vector , local_obsdata)");
 EnkfObs.cNamespace().local_scale_std             = cwrapper.prototype("void  enkf_obs_local_scale_std( enkf_obs , local_obsdata , double)");
-
-

--- a/python/python/ert/enkf/enkf_obs.py
+++ b/python/python/ert/enkf/enkf_obs.py
@@ -15,27 +15,47 @@
 #  for more details.
 import os.path
 
-from cwrap import BaseCClass, CWrapper
+from cwrap import BaseCClass
 from ert.util import StringList, IntVector
 from ert.sched import History
 from ert.ecl import EclSum , EclGrid
-from ert.enkf import ENKF_LIB, EnkfFs, LocalObsdataNode , LocalObsdata, MeasData, ObsData
+from ert.enkf import EnkfPrototype
+from ert.enkf import EnkfFs, LocalObsdataNode , LocalObsdata, MeasData, ObsData
 from ert.enkf.enums import EnkfObservationImplementationType
 
 from ert.enkf.observations import ObsVector
 
 
 class EnkfObs(BaseCClass):
+    TYPE_NAME = "enkf_obs"
+
+    _alloc                    = EnkfPrototype("void* enkf_obs_alloc( history , time_map , ecl_grid , ecl_sum , ens_config )", bind = False)
+    _free                     = EnkfPrototype("void enkf_obs_free( enkf_obs )")
+    _get_size                 = EnkfPrototype("int enkf_obs_get_size( enkf_obs )")
+    _load                     = EnkfPrototype("bool enkf_obs_load( enkf_obs , char*)")
+    _clear                    = EnkfPrototype("void enkf_obs_clear( enkf_obs )")
+    _alloc_typed_keylist      = EnkfPrototype("stringlist_obj enkf_obs_alloc_typed_keylist(enkf_obs, enkf_obs_impl_type)")
+    _alloc_matching_keylist   = EnkfPrototype("stringlist_obj enkf_obs_alloc_matching_keylist(enkf_obs, char*)")
+    _has_key                  = EnkfPrototype("bool enkf_obs_has_key(enkf_obs, char*)")
+    _obs_type                 = EnkfPrototype("enkf_obs_impl_type enkf_obs_get_type(enkf_obs, char*)")
+    _get_vector               = EnkfPrototype("obs_vector_ref enkf_obs_get_vector(enkf_obs, char*)")
+    _iget_vector              = EnkfPrototype("obs_vector_ref enkf_obs_iget_vector(enkf_obs, int)")
+    _iget_obs_time            = EnkfPrototype("time_t enkf_obs_iget_obs_time(enkf_obs, int)")
+    _add_obs_vector           = EnkfPrototype("void enkf_obs_add_obs_vector(enkf_obs, obs_vector)")
+    _get_obs_and_measure_data = EnkfPrototype("void enkf_obs_get_obs_and_measure_data(enkf_obs, enkf_fs, local_obsdata, int_vector, meas_data, obs_data)")
+    _create_all_active_obs    = EnkfPrototype("local_obsdata_obj enkf_obs_alloc_all_active_local_obs( enkf_obs , char*)");
+    _scale_correlated_std     = EnkfPrototype("double  enkf_obs_scale_correlated_std( enkf_obs , enkf_fs ,       int_vector , local_obsdata)");
+    _local_scale_std          = EnkfPrototype("void  enkf_obs_local_scale_std( enkf_obs ,        local_obsdata , double)");
+
     def __init__(self , ensemble_config , history = None , external_time_map = None , grid = None , refcase = None ):
-        c_ptr = EnkfObs.cNamespace().alloc( history , external_time_map , grid , refcase , ensemble_config )
+        c_ptr = self._alloc( history , external_time_map , grid , refcase , ensemble_config )
         super(EnkfObs, self).__init__(c_ptr)
 
-
     def __len__(self):
-        return EnkfObs.cNamespace().get_size(self)
+        return self._get_size()
 
     def __contains__(self , key):
-        return EnkfObs.cNamespace().has_key(self, key)
+        return self._has_key(key)
 
     def __iter__(self):
         """ @rtype: ObsVector """
@@ -50,16 +70,19 @@ class EnkfObs(BaseCClass):
         """ @rtype: ObsVector """
         if isinstance(key_or_index, str):
             if self.hasKey(key_or_index):
-                return EnkfObs.cNamespace().get_vector(self, key_or_index).setParent(self)
+                return self._get_vector(key_or_index).setParent(self)
             else:
                 raise KeyError("Unknown key: %s" % key_or_index)
         elif isinstance(key_or_index, int):
-            if 0 <= key_or_index < len(self):
-                return EnkfObs.cNamespace().iget_vector(self, key_or_index).setParent(self)
+            idx = key_or_index
+            if idx < 0:
+                idx += len(self)
+            if 0 <= idx < len(self):
+                return self._iget_vector(idx).setParent(self)
             else:
-                raise IndexError("Index must be in range: 0 <= %d < %d" % (key_or_index, len(self)))
+                raise IndexError("Invalid index: %d.  Valid range is [0, %d)." % (key_or_index, len(self)))
         else:
-            raise TypeError("Key or index must be of type str or int")
+            raise TypeError("Key or index must be of type str or int, not %s." % str(type(key_or_index)))
 
 
     def createLocalObsdata(self , key , add_active_steps = True):
@@ -69,7 +92,7 @@ class EnkfObs(BaseCClass):
 
 
     def getAllActiveLocalObsdata(self , key = "ALL-OBS"):
-        return EnkfObs.cNamespace().create_all_active_obs( self , key )
+        return self._create_all_active_obs( key )
 
 
 
@@ -78,11 +101,11 @@ class EnkfObs(BaseCClass):
          @type observation_implementation_type: EnkfObservationImplementationType
          @rtype: StringList
         """
-        return EnkfObs.cNamespace().alloc_typed_keylist(self, observation_implementation_type)
+        return self._alloc_typed_keylist(observation_implementation_type)
 
     def obsType(self , key):
         if key in self:
-            return EnkfObs.cNamespace().obs_type( self , key)
+            return self._obs_type(key)
         else:
             raise KeyError("Unknown observation key:%s" % key)
 
@@ -92,7 +115,7 @@ class EnkfObs(BaseCClass):
         Will return a list of all the observation keys matching the input
         pattern. The matching is based on fnmatch().
         """
-        key_list = EnkfObs.cNamespace().alloc_matching_keylist(self, pattern)
+        key_list = self._alloc_matching_keylist(pattern)
         if obs_type:
             new_key_list = []
             for key in key_list:
@@ -104,14 +127,13 @@ class EnkfObs(BaseCClass):
 
 
     def hasKey(self, key):
-
         """ @rtype: bool """
         return key in self
 
 
     def getObservationTime(self, index):
         """ @rtype: CTime """
-        return EnkfObs.cNamespace().iget_obs_time(self, index)
+        return self._iget_obs_time(index)
 
 
     def addObservationVector(self, observation_vector):
@@ -119,7 +141,7 @@ class EnkfObs(BaseCClass):
 
         observation_vector.convertToCReference(self)
 
-        EnkfObs.cNamespace().add_obs_vector(self, observation_vector)
+        self._add_obs_vector(observation_vector)
 
     def getObservationAndMeasureData(self, fs, local_obsdata, active_list, meas_data, obs_data):
         assert isinstance(fs, EnkfFs)
@@ -128,47 +150,25 @@ class EnkfObs(BaseCClass):
         assert isinstance(meas_data, MeasData)
         assert isinstance(obs_data, ObsData)
 
-        EnkfObs.cNamespace().get_obs_and_measure_data(self, fs, local_obsdata, active_list, meas_data, obs_data)
+        self._get_obs_and_measure_data(fs, local_obsdata, active_list, meas_data, obs_data)
 
 
     def scaleCorrelatedStd( self , fs , local_obsdata , active_list):
-        return EnkfObs.cNamespace().scale_correlated_std( self , fs , active_list , local_obsdata )
+        return self._scale_correlated_std( fs , active_list , local_obsdata )
 
     def localScaleStd( self , local_obsdata , scale_factor):
-        return EnkfObs.cNamespace().local_scale_std( self , local_obsdata, scale_factor)
+        return self._local_scale_std(local_obsdata, scale_factor)
 
     def load(self , config_file):
         if not os.path.isfile( config_file ):
-            raise IOError("The observation config file:%s does not exist" % config_file)
-        return EnkfObs.cNamespace().load( self , config_file )
-
+            raise IOError('The observation config file "%s" does not exist.' % config_file)
+        return self._load( config_file )
 
     def clear(self):
-        EnkfObs.cNamespace().clear( self )
-
+        self._clear()
 
     def free(self):
-        EnkfObs.cNamespace().free(self)
+        self._free()
 
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("enkf_obs", EnkfObs)
-
-EnkfObs.cNamespace().alloc = cwrapper.prototype("c_void_p enkf_obs_alloc( history , time_map , ecl_grid , ecl_sum , ens_config )")
-EnkfObs.cNamespace().free = cwrapper.prototype("void enkf_obs_free( enkf_obs )")
-EnkfObs.cNamespace().get_size = cwrapper.prototype("int enkf_obs_get_size( enkf_obs )")
-EnkfObs.cNamespace().load = cwrapper.prototype("bool enkf_obs_load( enkf_obs , char*)")
-EnkfObs.cNamespace().clear = cwrapper.prototype("void enkf_obs_clear( enkf_obs )")
-EnkfObs.cNamespace().alloc_typed_keylist = cwrapper.prototype("stringlist_obj enkf_obs_alloc_typed_keylist(enkf_obs, enkf_obs_impl_type)")
-EnkfObs.cNamespace().alloc_matching_keylist = cwrapper.prototype("stringlist_obj enkf_obs_alloc_matching_keylist(enkf_obs, char*)")
-EnkfObs.cNamespace().has_key = cwrapper.prototype("bool enkf_obs_has_key(enkf_obs, char*)")
-EnkfObs.cNamespace().obs_type = cwrapper.prototype("enkf_obs_impl_type enkf_obs_get_type(enkf_obs, char*)")
-EnkfObs.cNamespace().get_vector = cwrapper.prototype("obs_vector_ref enkf_obs_get_vector(enkf_obs, char*)")
-EnkfObs.cNamespace().iget_vector = cwrapper.prototype("obs_vector_ref enkf_obs_iget_vector(enkf_obs, int)")
-EnkfObs.cNamespace().iget_obs_time = cwrapper.prototype("time_t enkf_obs_iget_obs_time(enkf_obs, int)")
-EnkfObs.cNamespace().add_obs_vector = cwrapper.prototype("void enkf_obs_add_obs_vector(enkf_obs, obs_vector)")
-
-EnkfObs.cNamespace().get_obs_and_measure_data = cwrapper.prototype("void enkf_obs_get_obs_and_measure_data(enkf_obs, enkf_fs, local_obsdata, int_vector, meas_data, obs_data)")
-EnkfObs.cNamespace().create_all_active_obs       = cwrapper.prototype("local_obsdata_obj enkf_obs_alloc_all_active_local_obs( enkf_obs , char*)");
-EnkfObs.cNamespace().scale_correlated_std        = cwrapper.prototype("double  enkf_obs_scale_correlated_std( enkf_obs , enkf_fs , int_vector , local_obsdata)");
-EnkfObs.cNamespace().local_scale_std             = cwrapper.prototype("void  enkf_obs_local_scale_std( enkf_obs , local_obsdata , double)");
+    def __repr__(self):
+        return 'EnkfObs(len = %d) at 0x%x' % (len(self), self._address())

--- a/python/python/ert/enkf/enums/active_mode_enum.py
+++ b/python/python/ert/enkf/enums/active_mode_enum.py
@@ -14,10 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class ActiveMode(BaseCEnum):
+    TYPE_NAME = "active_mode_enum"
     ALL_ACTIVE = None
     INACTIVE = None
     PARTLY_ACTIVE = None
@@ -26,6 +25,3 @@ class ActiveMode(BaseCEnum):
 ActiveMode.addEnum("ALL_ACTIVE", 1)
 ActiveMode.addEnum("INACTIVE", 2)
 ActiveMode.addEnum("PARTLY_ACTIVE", 3)
-
-ActiveMode.registerEnum(ENKF_LIB, "active_mode_enum")
-

--- a/python/python/ert/enkf/enums/enkf_field_file_format_enum.py
+++ b/python/python/ert/enkf/enums/enkf_field_file_format_enum.py
@@ -14,10 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class EnkfFieldFileFormatEnum(BaseCEnum):
+    TYPE_NAME = "enkf_field_file_format_enum"
     UNDEFINED_FORMAT         = None
     RMS_ROFF_FILE            = None
     ECL_KW_FILE              = None
@@ -35,5 +34,3 @@ EnkfFieldFileFormatEnum.addEnum("ECL_KW_FILE_ALL_CELLS", 4)
 EnkfFieldFileFormatEnum.addEnum("ECL_GRDECL_FILE", 5)
 EnkfFieldFileFormatEnum.addEnum("ECL_FILE", 6)
 EnkfFieldFileFormatEnum.addEnum("FILE_FORMAT_NULL", 7)
-
-EnkfFieldFileFormatEnum.registerEnum(ENKF_LIB, "enkf_field_file_format_enum")

--- a/python/python/ert/enkf/enums/enkf_fs_type_enum.py
+++ b/python/python/ert/enkf/enums/enkf_fs_type_enum.py
@@ -14,19 +14,14 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
 
 
 class EnKFFSType(BaseCEnum):
+    TYPE_NAME = "enkf_fs_type_enum"
     INVALID_DRIVER_ID = None
     PLAIN_DRIVER_ID = None
     BLOCK_FS_DRIVER_ID = None
 
-
 EnKFFSType.addEnum("INVALID_DRIVER_ID", 0)
 EnKFFSType.addEnum("PLAIN_DRIVER_ID", 1005)
 EnKFFSType.addEnum("BLOCK_FS_DRIVER_ID", 3001)
-EnKFFSType.registerEnum(ENKF_LIB, "enkf_fs_type_enum")
-
-
-

--- a/python/python/ert/enkf/enums/enkf_init_modes_enum.py
+++ b/python/python/ert/enkf/enums/enkf_init_modes_enum.py
@@ -14,8 +14,6 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class EnkfInitModeEnum(BaseCEnum):
     TYPE_NAME = "enkf_init_mode_enum"
@@ -27,7 +25,3 @@ class EnkfInitModeEnum(BaseCEnum):
 EnkfInitModeEnum.addEnum("INIT_NONE", 0)
 EnkfInitModeEnum.addEnum("INIT_CONDITIONAL", 1)
 EnkfInitModeEnum.addEnum("INIT_FORCE", 2)
-EnkfInitModeEnum.registerEnum(ENKF_LIB, "enkf_init_mode_enum")
-
-
-

--- a/python/python/ert/enkf/enums/enkf_obs_impl_type_enum.py
+++ b/python/python/ert/enkf/enums/enkf_obs_impl_type_enum.py
@@ -14,10 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class EnkfObservationImplementationType(BaseCEnum):
+    TYPE_NAME = "enkf_obs_impl_type"
     GEN_OBS = None
     SUMMARY_OBS = None
     BLOCK_OBS = None
@@ -25,8 +24,3 @@ class EnkfObservationImplementationType(BaseCEnum):
 EnkfObservationImplementationType.addEnum("GEN_OBS", 1)
 EnkfObservationImplementationType.addEnum("SUMMARY_OBS", 2)
 EnkfObservationImplementationType.addEnum("BLOCK_OBS", 3)
-
-EnkfObservationImplementationType.registerEnum(ENKF_LIB, "enkf_obs_impl_type")
-
-
-

--- a/python/python/ert/enkf/enums/enkf_run_enum.py
+++ b/python/python/ert/enkf/enums/enkf_run_enum.py
@@ -14,20 +14,16 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class EnkfRunType(BaseCEnum):
+    TYPE_NAME = "enkf_run_mode_enum"
     ENKF_ASSIMILATION = None
     ENSEMBLE_EXPERIMENT = None
     SMOOTHER_UPDATED = None
     INIT_ONLY = None
-    
+
 
 EnkfRunType.addEnum("ENKF_ASSIMILATION" , 1)
 EnkfRunType.addEnum("ENSEMBLE_EXPERIMENT" , 2)
 EnkfRunType.addEnum("SMOOTHER_UPDATE" , 4)
 EnkfRunType.addEnum("INIT_ONLY" , 8)
-
-EnkfRunType.registerEnum( ENKF_LIB , "enkf_run_mode_enum")
-

--- a/python/python/ert/enkf/enums/enkf_truncation_type.py
+++ b/python/python/ert/enkf/enums/enkf_truncation_type.py
@@ -14,10 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class EnkfTruncationType(BaseCEnum):
+    TYPE_NAME = "enkf_truncation_type_enum"
     TRUNCATE_NONE = None
     TRUNCATE_MIN  = None
     TRUNCATE_MAX  = None
@@ -25,9 +24,3 @@ class EnkfTruncationType(BaseCEnum):
 EnkfTruncationType.addEnum("TRUNCATE_NONE", 0)
 EnkfTruncationType.addEnum("TRUNCATE_MIN", 1)
 EnkfTruncationType.addEnum("TRUNCATE_MAX", 2)
-
-EnkfTruncationType.registerEnum(ENKF_LIB, "enkf_truncation_type_enum")
-
-
-
-

--- a/python/python/ert/enkf/enums/enkf_var_type_enum.py
+++ b/python/python/ert/enkf/enums/enkf_var_type_enum.py
@@ -14,8 +14,6 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class EnkfVarType(BaseCEnum):
     TYPE_NAME        = "enkf_var_type_enum"
@@ -33,7 +31,3 @@ EnkfVarType.addEnum("DYNAMIC_STATE", 2)
 EnkfVarType.addEnum("DYNAMIC_RESULT", 4)
 EnkfVarType.addEnum("STATIC_STATE", 8)
 EnkfVarType.addEnum("INDEX_STATE", 16)
-EnkfVarType.registerEnum(ENKF_LIB, "enkf_var_type_enum")
-
-
-

--- a/python/python/ert/enkf/enums/ert_impl_type_enum.py
+++ b/python/python/ert/enkf/enums/ert_impl_type_enum.py
@@ -14,7 +14,6 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
 
 
 class ErtImplType(BaseCEnum):
@@ -41,7 +40,3 @@ ErtImplType.addEnum("SUMMARY", 110)
 ErtImplType.addEnum("GEN_DATA", 113)
 ErtImplType.addEnum("SURFACE", 114)
 ErtImplType.addEnum("CONTAINER", 115)
-ErtImplType.registerEnum(ENKF_LIB, "ert_impl_type_enum")
-
-
-

--- a/python/python/ert/enkf/enums/hook_runtime_enum.py
+++ b/python/python/ert/enkf/enums/hook_runtime_enum.py
@@ -14,15 +14,12 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class HookRuntime(BaseCEnum):
+    TYPE_NAME = "hook_runtime_enum"
     PRE_SIMULATION = None
     POST_SIMULATION = None
 
 
 HookRuntime.addEnum("PRE_SIMULATION"  , 0)
 HookRuntime.addEnum("POST_SIMULATION" , 1)
-
-HookRuntime.registerEnum(ENKF_LIB, "hook_runtime_enum")

--- a/python/python/ert/enkf/enums/load_fail_type_enum.py
+++ b/python/python/ert/enkf/enums/load_fail_type_enum.py
@@ -14,10 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class LoadFailTypeEnum(BaseCEnum):
+    TYPE_NAME = "load_fail_type"
     LOAD_FAIL_SILENT = None
     LOAD_FAIL_WARN = None
     LOAD_FAIL_EXIT = None
@@ -26,7 +25,3 @@ class LoadFailTypeEnum(BaseCEnum):
 LoadFailTypeEnum.addEnum("LOAD_FAIL_SILENT", 0)
 LoadFailTypeEnum.addEnum("LOAD_FAIL_WARN", 2)
 LoadFailTypeEnum.addEnum("LOAD_FAIL_EXIT", 4)
-LoadFailTypeEnum.registerEnum(ENKF_LIB, "load_fail_type")
-
-
-

--- a/python/python/ert/enkf/enums/realization_state_enum.py
+++ b/python/python/ert/enkf/enums/realization_state_enum.py
@@ -14,10 +14,9 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCEnum
-from ert.enkf import ENKF_LIB
-
 
 class RealizationStateEnum(BaseCEnum):
+    TYPE_NAME = "realisation_state_enum"
     STATE_UNDEFINED      = None
     STATE_INITIALIZED    = None
     STATE_HAS_DATA       = None
@@ -29,7 +28,3 @@ RealizationStateEnum.addEnum("STATE_INITIALIZED", 2)
 RealizationStateEnum.addEnum("STATE_HAS_DATA", 4)
 RealizationStateEnum.addEnum("STATE_LOAD_FAILURE", 8)
 RealizationStateEnum.addEnum("STATE_PARENT_FAILURE", 16)
-RealizationStateEnum.registerEnum(ENKF_LIB, "realisation_state_enum")
-
-
-

--- a/python/python/ert/enkf/ert_template.py
+++ b/python/python/ert/enkf/ert_template.py
@@ -13,35 +13,32 @@
 #   
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
-from cwrap import CWrapper, BaseCClass
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 
 class ErtTemplate(BaseCClass):
+    TYPE_NAME = "ert_template"
+
+    _free               = EnkfPrototype("void  ert_template_free( ert_template )")
+    _get_template_file  = EnkfPrototype("char* ert_template_get_template_file(ert_template)")
+    _get_target_file    = EnkfPrototype("char* ert_template_get_target_file(ert_template)")
+    _get_args_as_string = EnkfPrototype("char* ert_template_get_args_as_string(ert_template)")
+
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
     def get_template_file(self):
         """ @rtype: str """
-        return ErtTemplate.cNamespace().get_template_file(self)
+        return self._get_template_file()
 
     def get_target_file(self):
         """ @rtype: str """
-        return ErtTemplate.cNamespace().get_target_file(self)
+        return self._get_target_file()
 
     def get_args_as_string(self):
         """ @rtype: str """
-        return ErtTemplate.cNamespace().get_args_as_string(self)
+        return self._get_args_as_string()
 
     def free(self):
-        ErtTemplate.cNamespace().free(self)
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("ert_template", ErtTemplate)
-cwrapper.registerType("ert_template_obj", ErtTemplate.createPythonObject)
-cwrapper.registerType("ert_template_ref", ErtTemplate.createCReference)
-
-ErtTemplate.cNamespace().free = cwrapper.prototype("void ert_template_free( ert_template )")
-ErtTemplate.cNamespace().get_template_file = cwrapper.prototype("char* ert_template_get_template_file(ert_template)")
-ErtTemplate.cNamespace().get_target_file = cwrapper.prototype("char* ert_template_get_target_file(ert_template)")
-ErtTemplate.cNamespace().get_args_as_string = cwrapper.prototype("char* ert_template_get_args_as_string(ert_template)")
+        self._free()

--- a/python/python/ert/enkf/ert_templates.py
+++ b/python/python/ert/enkf/ert_templates.py
@@ -13,42 +13,37 @@
 #   
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB, ErtTemplate
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype, ErtTemplate
 from ert.util import StringList
 
 
-
 class ErtTemplates(BaseCClass):
+    TYPE_NAME = "ert_templates"
+
+    _free         = EnkfPrototype("void ert_templates_free( ert_templates )")
+    _alloc_list   = EnkfPrototype("stringlist_ref ert_templates_alloc_list(ert_templates)")
+    _get_template = EnkfPrototype("ert_template_ref ert_templates_get_template(ert_templates, char*)")
+    _clear        = EnkfPrototype("void ert_templates_clear(ert_templates)")
+    _add_template = EnkfPrototype("ert_template_ref ert_templates_add_template(ert_templates, char*, char*, char*, char*)")
+
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
     def getTemplateNames(self):
         """ @rtype: StringList """
-        return ErtTemplates.cNamespace().alloc_list(self).setParent(self)
+        return self._alloc_list().setParent(self)
 
     def clear(self):
-        ErtTemplates.cNamespace().clear(self)
+        self._clear()
 
     def get_template(self, key):
         """ @rtype: ErtTemplate """
-        return ErtTemplates.cNamespace().get_template(self, key).setParent(self)
+        return self._get_template(key).setParent(self)
 
     def add_template(self, key, template_file, target_file, arg_string):
         """ @rtype: ErtTemplate """
-        return ErtTemplates.cNamespace().add_template(self, key, template_file, target_file, arg_string).setParent(self)
+        return self._add_template(key, template_file, target_file, arg_string).setParent(self)
 
     def free(self):
-        ErtTemplates.cNamespace().free(self)
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("ert_templates", ErtTemplates)
-cwrapper.registerType("ert_templates_obj", ErtTemplates.createPythonObject)
-cwrapper.registerType("ert_templates_ref", ErtTemplates.createCReference)
-
-ErtTemplates.cNamespace().free = cwrapper.prototype("void ert_templates_free( ert_templates )")
-ErtTemplates.cNamespace().alloc_list = cwrapper.prototype("stringlist_ref ert_templates_alloc_list(ert_templates)")
-ErtTemplates.cNamespace().get_template = cwrapper.prototype("ert_template_ref ert_templates_get_template(ert_templates, char*)")
-ErtTemplates.cNamespace().clear = cwrapper.prototype("void ert_templates_clear(ert_templates)")
-ErtTemplates.cNamespace().add_template = cwrapper.prototype("ert_template_ref ert_templates_add_template(ert_templates, char*, char*, char*, char*)")
+        self._free()

--- a/python/python/ert/enkf/es_update.py
+++ b/python/python/ert/enkf/es_update.py
@@ -24,16 +24,12 @@ class ESUpdate(BaseCClass):
             self.analysis_config.getModule( name )
         else:
             raise KeyError("No such module:%s " % name)
-        
+
 
     def setGlobalStdScaling(self , weight):
         self.analysis_config.setGlobalStdScaling( weight )
 
-        
-        
+
+
     def smootherUpdate( self , data_fs , target_fs):
         return self._smoother_update(data_fs , target_fs )
-
-    
-
-    

--- a/python/python/ert/enkf/es_update.py
+++ b/python/python/ert/enkf/es_update.py
@@ -1,4 +1,4 @@
-from cwrap import CWrapper, BaseCClass
+from cwrap import BaseCClass
 from ert.enkf import EnkfPrototype
 
 class ESUpdate(BaseCClass):

--- a/python/python/ert/enkf/hook_manager.py
+++ b/python/python/ert/enkf/hook_manager.py
@@ -1,28 +1,36 @@
 import os
 import sys
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 class HookManager(BaseCClass):
+    TYPE_NAME = "hook_manager"
+
+    _get_runpath_list_file = EnkfPrototype("char* hook_manager_get_runpath_list_file(hook_manager)")
+    _iget_hook_workflow    = EnkfPrototype("hook_workflow_ref hook_manager_iget_hook_workflow(hook_manager, int)")
+    _size                  = EnkfPrototype("int hook_manager_get_size(hook_manager)")
 
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
     
     def __len__(self):
         """ @rtype: int """
-        return HookManager.cNamespace().size(self)
-    
+        return self._size()
+
+    def __repr__(self):
+        return 'HookManager(len = %d) at 0x%x' % (len(self), self._address())
+
     def __getitem__(self, index):
         """ @rtype: Hook workflow """
         assert isinstance(index, int)
         if index < len(self):
-            return HookManager.cNamespace().iget_hook_workflow(self, index)
+            return self._iget_hook_workflow(index)
         else:
             raise IndexError("Invalid index")
 
     def checkRunpathListFile(self):
         """ @rtype: bool """
-        runpath_list_file = HookManager.cNamespace().get_runpath_list_file(self)
+        runpath_list_file = self._get_runpath_list_file()
 
         if not os.path.exists(runpath_list_file):
             sys.stderr.write("** Warning: the file: %s with a list of runpath directories was not found - hook workflow will probably fail.\n" % runpath_list_file)
@@ -41,11 +49,3 @@ class HookManager(BaseCClass):
             
             workflow = hook_workflow.getWorkflow()            
             workflow.run(ert_self, context=workflow_list.getContext())       
-    
-cwrapper = CWrapper(ENKF_LIB)
-
-cwrapper.registerObjectType("hook_manager", HookManager)
-
-HookManager.cNamespace().get_runpath_list_file = cwrapper.prototype("char* hook_manager_get_runpath_list_file(hook_manager)")
-HookManager.cNamespace().iget_hook_workflow    = cwrapper.prototype("hook_workflow_ref hook_manager_iget_hook_workflow(hook_manager, int)")
-HookManager.cNamespace().size                  = cwrapper.prototype("int hook_manager_get_size(hook_manager)")

--- a/python/python/ert/enkf/hook_manager.py
+++ b/python/python/ert/enkf/hook_manager.py
@@ -12,7 +12,7 @@ class HookManager(BaseCClass):
 
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
-    
+
     def __len__(self):
         """ @rtype: int """
         return self._size()
@@ -34,18 +34,18 @@ class HookManager(BaseCClass):
 
         if not os.path.exists(runpath_list_file):
             sys.stderr.write("** Warning: the file: %s with a list of runpath directories was not found - hook workflow will probably fail.\n" % runpath_list_file)
-    
+
     def getRunpathList(self):
         """ @rtype: RunpathList """
         return HookManager.cNamespace().get_runpath_list(self)
-        
+
     def runWorkflows(self , run_time , ert_self):
-        
+
         workflow_list = ert_self.getWorkflowList()
         for hook_workflow in self:
-            
+
             if (hook_workflow.getRunMode() is not run_time):
                 continue
-            
-            workflow = hook_workflow.getWorkflow()            
-            workflow.run(ert_self, context=workflow_list.getContext())       
+
+            workflow = hook_workflow.getWorkflow()
+            workflow.run(ert_self, context=workflow_list.getContext())

--- a/python/python/ert/enkf/hook_manager.py
+++ b/python/python/ert/enkf/hook_manager.py
@@ -23,10 +23,12 @@ class HookManager(BaseCClass):
     def __getitem__(self, index):
         """ @rtype: Hook workflow """
         assert isinstance(index, int)
-        if index < len(self):
+        if index < 0:
+            index += len(self)
+        if 0 <= index < len(self):
             return self._iget_hook_workflow(index)
         else:
-            raise IndexError("Invalid index")
+            raise IndexError("Invalid index.  Valid range: [0, %d)." % len(self))
 
     def checkRunpathListFile(self):
         """ @rtype: bool """
@@ -37,7 +39,7 @@ class HookManager(BaseCClass):
 
     def getRunpathList(self):
         """ @rtype: RunpathList """
-        return HookManager.cNamespace().get_runpath_list(self)
+        return self._get_runpath_list()
 
     def runWorkflows(self , run_time , ert_self):
 

--- a/python/python/ert/enkf/hook_workflow.py
+++ b/python/python/ert/enkf/hook_workflow.py
@@ -1,25 +1,20 @@
 import os
 import sys
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB, RunpathList
-
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype, RunpathList
 
 class HookWorkflow(BaseCClass):
+    TYPE_NAME = "hook_workflow"
+
+    _get_workflow = EnkfPrototype("workflow_ref hook_workflow_get_workflow(hook_workflow)")
+    _get_runmode  = EnkfPrototype("hook_runtime_enum hook_workflow_get_run_mode(hook_workflow)")
 
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
     def getWorkflow(self):
         """ @rtype: Workflow """
-        return HookWorkflow.cNamespace().get_workflow(self)
-    
+        return self._get_workflow()
+
     def getRunMode(self):
-        return HookWorkflow.cNamespace().get_runmode( self )
-
-    
-cwrapper = CWrapper(ENKF_LIB)
-
-cwrapper.registerObjectType("hook_workflow", HookWorkflow)
-
-HookWorkflow.cNamespace().get_workflow = cwrapper.prototype("workflow_ref hook_workflow_get_workflow(hook_workflow)")
-HookWorkflow.cNamespace().get_runmode  = cwrapper.prototype("hook_runtime_enum hook_workflow_get_run_mode(hook_workflow)")
+        return self._get_runmode()

--- a/python/python/ert/enkf/local_config.py
+++ b/python/python/ert/enkf/local_config.py
@@ -13,9 +13,9 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import LocalUpdateStep
+from cwrap import BaseCClass
 from ert.enkf import EnkfPrototype
+from ert.enkf import LocalUpdateStep
 from ert.enkf.local_ministep import LocalMinistep
 from ert.analysis import AnalysisModule
 

--- a/python/python/ert/enkf/local_config.py
+++ b/python/python/ert/enkf/local_config.py
@@ -1,17 +1,17 @@
-#  Copyright (C) 2012  Statoil ASA, Norway. 
-#   
-#  The file 'local_config.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  Copyright (C) 2012  Statoil ASA, Norway.
+#
+#  The file 'local_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass, CWrapper
 from ert.enkf import LocalUpdateStep
@@ -40,24 +40,21 @@ class LocalConfig(BaseCClass):
     _write_local_config_summary_file = EnkfPrototype("void local_config_summary_fprintf( local_config, char*)")
 
 
-
-
-
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
-    
+
 
     # The LocalConfig class is created as a reference to an existing
     # underlying C structure by the method
     # EnkFMain.local_config(). When the pointer to the C
     # local_config_type object has been properly wrapped we 'decorate'
     # the Python object with references to the ensemble_config ,
-    # observations and grid. 
+    # observations and grid.
     #
     # This implies that the Python object LocalConfig is richer than
     # the underlying C object local_config_type; the extra attributes
     # are only used for validation.
-    
+
     def initAttributes(self , ensemble_config , obs , grid):
         self.ensemble_config = ensemble_config
         self.obs = obs
@@ -74,7 +71,6 @@ class LocalConfig(BaseCClass):
         # The grid can be None
         return self.grid
 
-    
     def free(self):
         self._free()
 
@@ -87,20 +83,20 @@ class LocalConfig(BaseCClass):
         if analysis_module:
             assert isinstance(analysis_module, AnalysisModule)
         self._create_ministep(mini_step_key, analysis_module)
-        return self.getMinistep(mini_step_key)  
-    
+        return self.getMinistep(mini_step_key)
+
     def createObsdata(self, obsdata_key):
         """ @rtype: Obsdata """
         assert isinstance(obsdata_key, str)
         if self._has_obsdata(obsdata_key):
             raise ValueError("Tried to add existing observation key:%s " % obsdata_key)
-        
+
         self._create_obsdata(obsdata_key)
         obsdata = self.getObsdata(obsdata_key)
         obsdata.initObservations( self.__getObservations() )
         return obsdata
 
-    
+
     def copyObsdata(self, src_key, target_key):
         """ @rtype: Obsdata """
         assert isinstance(src_key, str)
@@ -109,19 +105,19 @@ class LocalConfig(BaseCClass):
         obsdata.initObservations( self.__getObservations() )
         return obsdata
 
-        
+
     def createDataset(self, dataset_key):
         """ @rtype: Dataset """
         assert isinstance(dataset_key, str)
         if self._has_dataset(dataset_key):
             raise ValueError("Tried to add existing data key:%s " % dataset_key)
-        
+
         self._create_dataset(dataset_key)
         data = self.getDataset(dataset_key)
         data.initEnsembleConfig( self.__getEnsembleConfig() )
         return data
-    
-                                 
+
+
     def copyDataset(self, src_key, target_key):
         """ @rtype: Dataset """
         assert isinstance(src_key, str)
@@ -130,7 +126,7 @@ class LocalConfig(BaseCClass):
         data.initEnsembleConfig( self.__getEnsembleConfig() )
         return data
 
-    
+
     def getUpdatestep(self):
         """ @rtype: UpdateStep """
         return self._get_updatestep()
@@ -138,31 +134,31 @@ class LocalConfig(BaseCClass):
 
     def getMinistep(self, mini_step_key):
         """ @rtype: Ministep """
-        assert isinstance(mini_step_key, str)                
-        return self._get_ministep(mini_step_key)  
-    
+        assert isinstance(mini_step_key, str)
+        return self._get_ministep(mini_step_key)
+
     def getObsdata(self, obsdata_key):
         """ @rtype: Obsdata """
-        assert isinstance(obsdata_key, str)          
+        assert isinstance(obsdata_key, str)
         return self._get_obsdata(obsdata_key)
-    
+
     def getDataset(self, dataset_key):
         """ @rtype: Dataset """
         assert isinstance(dataset_key, str)
         return self._get_dataset(dataset_key)
-    
-        
+
+
     def attachMinistep(self, update_step, mini_step):
         assert isinstance(mini_step, LocalMinistep)
         assert isinstance(update_step, LocalUpdateStep)
         self._attach_ministep(update_step, mini_step)
-        
 
-    def writeSummaryFile(self, filename):                                                                                                                          
-        """                                                                                                                                                    
-        Writes a summary of the local config object                                                                                                            
-        The summary contains the Obsset with their respective                                                                                                  
-        number of observations and the Datasets with the number of active indices                                                                              
-        """                                                                                                                                                    
-        assert isinstance(filename, str)                                                                                                                       
+
+    def writeSummaryFile(self, filename):
+        """
+        Writes a summary of the local config object
+        The summary contains the Obsset with their respective
+        number of observations and the Datasets with the number of active indices
+        """
+        assert isinstance(filename, str)
         self._write_local_config_summary_file(filename)

--- a/python/python/ert/enkf/local_dataset.py
+++ b/python/python/ert/enkf/local_dataset.py
@@ -1,8 +1,18 @@
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.ecl import EclRegion
 
 class LocalDataset(BaseCClass):
+    TYPE_NAME = "local_dataset"
+
+    _alloc       = EnkfPrototype("void* local_dataset_alloc(char*)", bind = False)
+    _size        = EnkfPrototype("void* local_dataset_get_size(local_dataset)")
+    _has_key     = EnkfPrototype("bool  local_dataset_has_key(local_dataset, char*)")
+    _free        = EnkfPrototype("void  local_dataset_free(local_dataset)")
+    _name        = EnkfPrototype("char* local_dataset_get_name(local_dataset)")
+    _add_node    = EnkfPrototype("void  local_dataset_add_node(local_dataset, char*)")
+    _del_node    = EnkfPrototype("void  local_dataset_del_node(local_dataset, char*)")
+    _active_list = EnkfPrototype("active_list_ref local_dataset_get_node_active_list(local_dataset, char*)")
 
     def __init__(self, name):
         raise NotImplementedError("Class can not be instantiated directly!")
@@ -14,32 +24,34 @@ class LocalDataset(BaseCClass):
 
     def __len__(self):
         """ @rtype: int """
-        return LocalDataset.cNamespace().size(self)
+        return self._size()
 
     def __contains__(self , key):
         """ @rtype: bool """
-        return LocalDataset.cNamespace().has_key(self, key)
+        return self._has_key(key)
 
     def __delitem__(self, key):
         assert isinstance(key, str)
         if key in self:
-            LocalDataset.cNamespace().del_node(self, key)
+            self._del_node(key)
         else:
-            raise KeyError("Unknown key:%s" % key)
+            raise KeyError('Unknown key "%s"' % key)
 
+    def name(self):
+        return self._name()
     def getName(self):
-        """ @rtype: str """
-        return LocalDataset.cNamespace().name(self)
+        """ deprecated. @rtype: str """
+        return self.name()
 
     def addNode(self, key):
         assert isinstance(key, str)
         if key in self.ensemble_config:
-            if not LocalDataset.cNamespace().has_key(self, key):
-                LocalDataset.cNamespace().add_node(self, key)
+            if not self._has_key(key):
+                self._add_node(key)
             else:
-                raise KeyError("Tried to add existing data key:%s " % key)
+                raise KeyError('Tried to add existing data key "%s".' % key)
         else:
-            raise KeyError("Tried to add data key:%s - not in ensemble" % key)
+            raise KeyError('Tried to add data key "%s" not in ensemble.' % key)
 
 
     def addNodeWithIndex(self, key, index):
@@ -65,24 +77,12 @@ class LocalDataset(BaseCClass):
     def getActiveList(self, key):
         """ @rtype: ActiveList """
         if key in self:
-            return LocalDataset.cNamespace().active_list(self , key)
+            return self._active_list(key)
         else:
-            raise KeyError("Local key:%s not recognized" % key)
-
+            raise KeyError('Local key "%s" not recognized.' % key)
 
     def free(self):
-        LocalDataset.cNamespace().free(self)
+        self._free()
 
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("local_dataset", LocalDataset)
-
-LocalDataset.cNamespace().alloc          = cwrapper.prototype("c_void_p local_dataset_alloc(char*)")
-LocalDataset.cNamespace().size           = cwrapper.prototype("c_void_p local_dataset_get_size(char*)")
-LocalDataset.cNamespace().has_key        = cwrapper.prototype("bool local_dataset_has_key(local_dataset, char*)")
-LocalDataset.cNamespace().free           = cwrapper.prototype("void local_dataset_free(local_dataset)")
-LocalDataset.cNamespace().name           = cwrapper.prototype("char* local_dataset_get_name(local_dataset)")
-LocalDataset.cNamespace().active_list    = cwrapper.prototype("active_list_ref local_dataset_get_node_active_list(local_dataset, char*)")
-LocalDataset.cNamespace().add_node       = cwrapper.prototype("void local_dataset_add_node(local_dataset, char*)")
-LocalDataset.cNamespace().del_node       = cwrapper.prototype("void local_dataset_del_node(local_dataset, char*)")
+    def __repr__(self):
+        return 'LocalDataset(name = %s, len = %d) at 0x%x' % (self.name(), len(self), self._address())

--- a/python/python/ert/enkf/local_dataset.py
+++ b/python/python/ert/enkf/local_dataset.py
@@ -11,26 +11,26 @@ class LocalDataset(BaseCClass):
     def initEnsembleConfig(self , config):
         self.ensemble_config = config
 
-    
+
     def __len__(self):
         """ @rtype: int """
         return LocalDataset.cNamespace().size(self)
-        
+
     def __contains__(self , key):
         """ @rtype: bool """
         return LocalDataset.cNamespace().has_key(self, key)
-                                 
+
     def __delitem__(self, key):
         assert isinstance(key, str)
         if key in self:
-            LocalDataset.cNamespace().del_node(self, key)  
+            LocalDataset.cNamespace().del_node(self, key)
         else:
-            raise KeyError("Unknown key:%s" % key)  
-                
+            raise KeyError("Unknown key:%s" % key)
+
     def getName(self):
         """ @rtype: str """
         return LocalDataset.cNamespace().name(self)
-    
+
     def addNode(self, key):
         assert isinstance(key, str)
         if key in self.ensemble_config:
@@ -40,35 +40,35 @@ class LocalDataset(BaseCClass):
                 raise KeyError("Tried to add existing data key:%s " % key)
         else:
             raise KeyError("Tried to add data key:%s - not in ensemble" % key)
-                       
-                
+
+
     def addNodeWithIndex(self, key, index):
         assert isinstance(key, str)
         assert isinstance(index, int)
-        
+
         self.addNode( key )
         active_list = self.getActiveList(key)
         active_list.addActiveIndex(index)
 
-        
+
     def addField(self, key, ecl_region):
         assert isinstance(key, str)
         assert isinstance(ecl_region, EclRegion)
-        
+
         self.addNode( key )
         active_list = self.getActiveList(key)
         active_region = ecl_region.getActiveList()
         for i in active_region:
             active_list.addActiveIndex(i)
 
-            
+
     def getActiveList(self, key):
         """ @rtype: ActiveList """
         if key in self:
             return LocalDataset.cNamespace().active_list(self , key)
         else:
-            raise KeyError("Local key:%s not recognized" % key)        
-    
+            raise KeyError("Local key:%s not recognized" % key)
+
 
     def free(self):
         LocalDataset.cNamespace().free(self)
@@ -86,9 +86,3 @@ LocalDataset.cNamespace().name           = cwrapper.prototype("char* local_datas
 LocalDataset.cNamespace().active_list    = cwrapper.prototype("active_list_ref local_dataset_get_node_active_list(local_dataset, char*)")
 LocalDataset.cNamespace().add_node       = cwrapper.prototype("void local_dataset_add_node(local_dataset, char*)")
 LocalDataset.cNamespace().del_node       = cwrapper.prototype("void local_dataset_del_node(local_dataset, char*)")
-
-                                                                                 
-                                                                                 
-
-
-

--- a/python/python/ert/enkf/local_ministep.py
+++ b/python/python/ert/enkf/local_ministep.py
@@ -16,33 +16,33 @@ class LocalMinistep(BaseCClass):
 
     def __len__(self):
         return LocalMinistep.cNamespace().data_size( self )
-    
+
     def __contains__(self , data_key):
         return LocalMinistep.cNamespace().has_local_data(self , data_key)
 
     def addNode(self, node):
         assert isinstance(node, LocalObsdataNode)
         LocalMinistep.cNamespace().add_node(self,node)
-        
+
     def attachObsset(self, obs_set):
         assert isinstance(obs_set, LocalObsdata)
         LocalMinistep.cNamespace().attach_obsdata(self,obs_set)
 
-    
+
     def attachDataset(self, dataset):
         assert isinstance(dataset, LocalDataset)
-        LocalMinistep.cNamespace().attach_dataset(self,dataset)  
-        
+        LocalMinistep.cNamespace().attach_dataset(self,dataset)
+
     def getLocalObsData(self):
         """ @rtype: LocalObsdata """
         return LocalMinistep.cNamespace().get_local_obs_data(self)
-    
+
     def getName(self):
         """ @rtype: str """
-        return LocalMinistep.cNamespace().name(self)         
-        
+        return LocalMinistep.cNamespace().name(self)
+
     def free(self):
-        LocalMinistep.cNamespace().free(self) 
+        LocalMinistep.cNamespace().free(self)
 
 cwrapper = CWrapper(ENKF_LIB)
 cwrapper.registerObjectType("local_ministep", LocalMinistep)
@@ -57,4 +57,3 @@ LocalMinistep.cNamespace().attach_obsdata      = cwrapper.prototype("void local_
 LocalMinistep.cNamespace().attach_dataset      = cwrapper.prototype("void local_ministep_add_dataset(local_ministep,local_dataset)")
 LocalMinistep.cNamespace().name                = cwrapper.prototype("char* local_ministep_get_name(local_ministep)")
 LocalMinistep.cNamespace().data_size           = cwrapper.prototype("int local_ministep_get_num_dataset(local_ministep)")
-

--- a/python/python/ert/enkf/local_ministep.py
+++ b/python/python/ert/enkf/local_ministep.py
@@ -1,59 +1,64 @@
 import ert.util
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB, LocalObsdata, LocalObsdataNode, LocalDataset
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype, LocalObsdata, LocalObsdataNode, LocalDataset
 
 class LocalMinistep(BaseCClass):
+    TYPE_NAME = "local_ministep"
+
+    _alloc               = EnkfPrototype("void* local_ministep_alloc(char*)", bind = False)
+    _add_node            = EnkfPrototype("void local_ministep_add_obsdata_node(local_ministep, local_obsdata_node)")
+    _get_local_obs_data  = EnkfPrototype("local_obsdata_ref local_ministep_get_obsdata(local_ministep)")
+    _get_local_data      = EnkfPrototype("local_dataset_ref local_ministep_get_dataset(local_ministep , char*)")
+    _has_local_data      = EnkfPrototype("bool              local_ministep_has_dataset(local_ministep , char*)")
+    _free                = EnkfPrototype("void local_ministep_free(local_ministep)")
+    _attach_obsdata      = EnkfPrototype("void local_ministep_add_obsdata(local_ministep, local_obsdata)")
+    _attach_dataset      = EnkfPrototype("void local_ministep_add_dataset(local_ministep, local_dataset)")
+    _name                = EnkfPrototype("char* local_ministep_get_name(local_ministep)")
+    _data_size           = EnkfPrototype("int local_ministep_get_num_dataset(local_ministep)")
 
     def __init__(self, ministep_key):
         raise NotImplementedError("Class can not be instantiated directly!")
 
     # Will used the data keys; and ignore observation keys.
     def __getitem__(self, data_key):
+        if isinstance(data_key, int):
+            raise TypeError('Keys must be strings, not int!')
         if data_key in self:
-            return LocalMinistep.cNamespace().get_local_data(self , data_key)
+            return self._get_local_data(data_key)
         else:
-            raise KeyError("No such data key: %s" % data_key)
+            raise KeyError('No such data key: "%s"' % data_key)
 
     def __len__(self):
-        return LocalMinistep.cNamespace().data_size( self )
+        return self._data_size()
 
     def __contains__(self , data_key):
-        return LocalMinistep.cNamespace().has_local_data(self , data_key)
+        return self._has_local_data(data_key)
 
     def addNode(self, node):
         assert isinstance(node, LocalObsdataNode)
-        LocalMinistep.cNamespace().add_node(self,node)
+        self._add_node(node)
 
     def attachObsset(self, obs_set):
         assert isinstance(obs_set, LocalObsdata)
-        LocalMinistep.cNamespace().attach_obsdata(self,obs_set)
+        self._attach_obsdata(obs_set)
 
 
     def attachDataset(self, dataset):
         assert isinstance(dataset, LocalDataset)
-        LocalMinistep.cNamespace().attach_dataset(self,dataset)
+        self._attach_dataset(dataset)
 
     def getLocalObsData(self):
         """ @rtype: LocalObsdata """
-        return LocalMinistep.cNamespace().get_local_obs_data(self)
+        return self._get_local_obs_data()
 
+    def name(self):
+        return self._name()
     def getName(self):
-        """ @rtype: str """
-        return LocalMinistep.cNamespace().name(self)
+        """ deprecated. @rtype: str """
+        return self.name()
 
     def free(self):
-        LocalMinistep.cNamespace().free(self)
+        self._free()
 
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("local_ministep", LocalMinistep)
-
-LocalMinistep.cNamespace().alloc               = cwrapper.prototype("c_void_p local_ministep_alloc(char*)")
-LocalMinistep.cNamespace().add_node            = cwrapper.prototype("void local_ministep_add_obsdata_node(local_ministep,local_obsdata_node)")
-LocalMinistep.cNamespace().get_local_obs_data  = cwrapper.prototype("local_obsdata_ref local_ministep_get_obsdata(local_ministep)")
-LocalMinistep.cNamespace().get_local_data      = cwrapper.prototype("local_dataset_ref local_ministep_get_dataset(local_ministep , char*)")
-LocalMinistep.cNamespace().has_local_data      = cwrapper.prototype("bool              local_ministep_has_dataset(local_ministep , char*)")
-LocalMinistep.cNamespace().free                = cwrapper.prototype("void local_ministep_free(local_ministep)")
-LocalMinistep.cNamespace().attach_obsdata      = cwrapper.prototype("void local_ministep_add_obsdata(local_ministep,local_obsdata)")
-LocalMinistep.cNamespace().attach_dataset      = cwrapper.prototype("void local_ministep_add_dataset(local_ministep,local_dataset)")
-LocalMinistep.cNamespace().name                = cwrapper.prototype("char* local_ministep_get_name(local_ministep)")
-LocalMinistep.cNamespace().data_size           = cwrapper.prototype("int local_ministep_get_num_dataset(local_ministep)")
+    def __repr__(self):
+        return 'LocalMinistep(name = %s, len = %d) at 0x%x' % (self.name(), len(self), self._address())

--- a/python/python/ert/enkf/local_obsdata.py
+++ b/python/python/ert/enkf/local_obsdata.py
@@ -1,8 +1,21 @@
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB, LocalObsdataNode
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype, LocalObsdataNode
 
 
 class LocalObsdata(BaseCClass):
+    TYPE_NAME = "local_obsdata"
+
+    _alloc       = EnkfPrototype("void* local_obsdata_alloc(char*)", bind = False)
+    _free        = EnkfPrototype("void  local_obsdata_free(local_obsdata)")
+    _size        = EnkfPrototype("int   local_obsdata_get_size(local_obsdata)")
+    _has_node    = EnkfPrototype("bool  local_obsdata_has_node(local_obsdata, char*)")
+    _add_node    = EnkfPrototype("bool  local_obsdata_add_node(local_obsdata, local_obsdata_node)")
+    _del_node    = EnkfPrototype("void  local_obsdata_del_node(local_obsdata, char*)")
+    _clear       = EnkfPrototype("void  local_dataset_clear(local_obsdata)")
+    _name        = EnkfPrototype("char* local_obsdata_get_name(local_obsdata)")
+    _iget_node   = EnkfPrototype("local_obsdata_node_ref local_obsdata_iget(local_obsdata, int)")
+    _get_node    = EnkfPrototype("local_obsdata_node_ref local_obsdata_get(local_obsdata, char*)")
+    _active_list = EnkfPrototype("active_list_ref local_obsdata_get_node_active_list(local_obsdata, char*)")
 
     def __init__(self, name , obs = None):
         # The obs instance should be a EnkFObs instance; some circular dependency problems
@@ -25,9 +38,12 @@ object as:
 
         assert isinstance(name, str)
 
-        c_pointer = LocalObsdata.cNamespace().alloc(name)
-        super(LocalObsdata, self).__init__(c_pointer)
-        self.initObservations( obs )
+        c_ptr = self._alloc(name)
+        if c_ptr:
+            super(LocalObsdata, self).__init__(c_ptr)
+            self.initObservations( obs )
+        else:
+            raise ValueError('Unable to construct LocalObsdata with name "%s" from given obs.' % name)
 
 
     def initObservations(self , obs):
@@ -35,21 +51,27 @@ object as:
 
     def __len__(self):
         """ @rtype: int """
-        return LocalObsdata.cNamespace().size(self)
+        return self._size()
 
 
     def __getitem__(self, key):
         """ @rtype: LocalObsdataNode """
         if isinstance(key , int):
-            if int < len:
-                return LocalObsdata.cNamespace().iget_node(self, key).setParent(self)
+            if key < 0:
+                key += len(self)
+            if 0 <= key < len(self):
+                node_ = self._iget_node(key)
+                node_.setParent(self)
+                return node_
             else:
-                raise IndexError("Invalid index")
+                raise IndexError('Invalid index, valid range is [0, %d)' % len(self))
         else:
             if key in self:
-                return LocalObsdata.cNamespace().get_node(self, key).setParent(self)
+                node_ = self._get_node(key)
+                node_.setParent(self)
+                return node_
             else:
-                raise KeyError("Unknown key:%s" % key)
+                raise KeyError('Unknown key "%s".' % key)
 
     def __iter__(self):
         cur = 0
@@ -60,18 +82,18 @@ object as:
     def __contains__(self, item):
         """ @rtype: bool """
         if isinstance(item, str):
-            return LocalObsdata.cNamespace().has_node(self, item)
+            return self._has_node(item)
         elif isinstance(item, LocalObsdataNode):
-            return LocalObsdata.cNamespace().has_node(self, item.getKey())
+            return self._has_node(item.getKey())
 
         return False
 
     def __delitem__(self, key):
         assert isinstance(key, str)
         if key in self:
-            LocalObsdata.cNamespace().del_node(self, key)
+            self._del_node(key)
         else:
-            raise KeyError("Unknown key:%s" % key)
+            raise KeyError('Unknown key "%s".' % key)
 
     def addNode(self, key, add_all_timesteps = True):
         """ @rtype: LocalObsdataNode """
@@ -80,7 +102,7 @@ object as:
             node = LocalObsdataNode(key , add_all_timesteps)
             if node not in self:
                 node.convertToCReference(self)
-                LocalObsdata.cNamespace().add_node(self, node)
+                self._add_node(node)
                 return node
             else:
                 raise KeyError("Tried to add existing observation key:%s " % key)
@@ -100,40 +122,27 @@ object as:
 
 
     def clear(self):
-        LocalObsdata.cNamespace().clear(self)
+        self._clear()
 
 
     def addObsVector(self , obs_vector):
         self.addNode( obs_vector.getObservationKey() )
 
-
+    def name(self):
+        return self._name()
     def getName(self):
-        """ @rtype: str """
-        return LocalObsdata.cNamespace().name(self)
+        """ deprecated. @rtype: str """
+        return self.name()
 
     def getActiveList(self, key):
         """ @rtype: ActiveList """
         if key in self:
-            return LocalObsdata.cNamespace().active_list(self , key)
+            return self._active_list(key)
         else:
-            raise KeyError("Local key:%s not recognized" % key)
+            raise KeyError('Local key "%s" not recognized.' % key)
 
     def free(self):
-        LocalObsdata.cNamespace().free(self)
+        self._free()
 
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("local_obsdata", LocalObsdata)
-
-LocalObsdata.cNamespace().alloc     = cwrapper.prototype("c_void_p local_obsdata_alloc(char*)")
-LocalObsdata.cNamespace().free      = cwrapper.prototype("void local_obsdata_free(local_obsdata)")
-LocalObsdata.cNamespace().size      = cwrapper.prototype("int local_obsdata_get_size(local_obsdata)")
-LocalObsdata.cNamespace().has_node  = cwrapper.prototype("bool local_obsdata_has_node(local_obsdata, char*)")
-LocalObsdata.cNamespace().add_node  = cwrapper.prototype("bool local_obsdata_add_node(local_obsdata, local_obsdata_node)")
-LocalObsdata.cNamespace().del_node  = cwrapper.prototype("void local_obsdata_del_node(local_obsdata, char*)")
-LocalObsdata.cNamespace().clear     = cwrapper.prototype("void local_dataset_clear(local_obsdata)")
-LocalObsdata.cNamespace().iget_node = cwrapper.prototype("local_obsdata_node_ref local_obsdata_iget(local_obsdata, int)")
-LocalObsdata.cNamespace().get_node  = cwrapper.prototype("local_obsdata_node_ref local_obsdata_get(local_obsdata, char*)")
-LocalObsdata.cNamespace().name      = cwrapper.prototype("char* local_obsdata_get_name(local_obsdata)")
-LocalObsdata.cNamespace().active_list    = cwrapper.prototype("active_list_ref local_obsdata_get_node_active_list(local_obsdata, char*)")
+    def __repr__(self):
+        return 'LocalObsdata(len = %d, name = %s) at 0x%x' % (len(self), self.name(), self._address())

--- a/python/python/ert/enkf/local_obsdata.py
+++ b/python/python/ert/enkf/local_obsdata.py
@@ -1,5 +1,5 @@
 from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB, LocalObsdataNode 
+from ert.enkf import ENKF_LIB, LocalObsdataNode
 
 
 class LocalObsdata(BaseCClass):
@@ -24,15 +24,15 @@ object as:
             raise Exception( msg )
 
         assert isinstance(name, str)
-        
+
         c_pointer = LocalObsdata.cNamespace().alloc(name)
         super(LocalObsdata, self).__init__(c_pointer)
         self.initObservations( obs )
 
-        
+
     def initObservations(self , obs):
         self.obs = obs
-        
+
     def __len__(self):
         """ @rtype: int """
         return LocalObsdata.cNamespace().size(self)
@@ -50,13 +50,13 @@ object as:
                 return LocalObsdata.cNamespace().get_node(self, key).setParent(self)
             else:
                 raise KeyError("Unknown key:%s" % key)
-        
+
     def __iter__(self):
         cur = 0
         while cur < len(self):
             yield self[cur]
             cur += 1
-                    
+
     def __contains__(self, item):
         """ @rtype: bool """
         if isinstance(item, str):
@@ -65,19 +65,19 @@ object as:
             return LocalObsdata.cNamespace().has_node(self, item.getKey())
 
         return False
-    
+
     def __delitem__(self, key):
         assert isinstance(key, str)
         if key in self:
-            LocalObsdata.cNamespace().del_node(self, key)  
+            LocalObsdata.cNamespace().del_node(self, key)
         else:
-            raise KeyError("Unknown key:%s" % key)                
-    
+            raise KeyError("Unknown key:%s" % key)
+
     def addNode(self, key, add_all_timesteps = True):
-        """ @rtype: LocalObsdataNode """           
+        """ @rtype: LocalObsdataNode """
         assert isinstance(key, str)
         if key in self.obs:
-            node = LocalObsdataNode(key , add_all_timesteps) 
+            node = LocalObsdataNode(key , add_all_timesteps)
             if node not in self:
                 node.convertToCReference(self)
                 LocalObsdata.cNamespace().add_node(self, node)
@@ -89,34 +89,34 @@ object as:
 
 
     def addNodeAndRange(self, key, step_1, step_2):
-        """ @rtype: LocalObsdataNode """        
+        """ @rtype: LocalObsdataNode """
         """ The time range will be removed in the future... """
         assert isinstance(key, str)
         assert isinstance(step_1, int)
-        assert isinstance(step_2, int)                     
+        assert isinstance(step_2, int)
         node = self.addNode( key )
         node.addRange(step_1, step_2)
         return node
 
-    
-    def clear(self):        
-        LocalObsdata.cNamespace().clear(self)        
 
-        
+    def clear(self):
+        LocalObsdata.cNamespace().clear(self)
+
+
     def addObsVector(self , obs_vector):
         self.addNode( obs_vector.getObservationKey() )
 
-        
+
     def getName(self):
         """ @rtype: str """
         return LocalObsdata.cNamespace().name(self)
-    
+
     def getActiveList(self, key):
         """ @rtype: ActiveList """
         if key in self:
             return LocalObsdata.cNamespace().active_list(self , key)
         else:
-            raise KeyError("Local key:%s not recognized" % key)      
+            raise KeyError("Local key:%s not recognized" % key)
 
     def free(self):
         LocalObsdata.cNamespace().free(self)
@@ -137,6 +137,3 @@ LocalObsdata.cNamespace().iget_node = cwrapper.prototype("local_obsdata_node_ref
 LocalObsdata.cNamespace().get_node  = cwrapper.prototype("local_obsdata_node_ref local_obsdata_get(local_obsdata, char*)")
 LocalObsdata.cNamespace().name      = cwrapper.prototype("char* local_obsdata_get_name(local_obsdata)")
 LocalObsdata.cNamespace().active_list    = cwrapper.prototype("active_list_ref local_obsdata_get_node_active_list(local_obsdata, char*)")
-
-
-

--- a/python/python/ert/enkf/local_obsdata_node.py
+++ b/python/python/ert/enkf/local_obsdata_node.py
@@ -17,7 +17,7 @@ class LocalObsdataNode(BaseCClass):
         assert isinstance(step_2, int)
         LocalObsdataNode.cNamespace().add_range(self, step_1, step_2)
 
-    
+
     def addTimeStep(self , step):
         LocalObsdataNode.cNamespace().add_step(self, step )
 
@@ -50,5 +50,3 @@ LocalObsdataNode.cNamespace().tstep_active     = cwrapper.prototype("bool local_
 LocalObsdataNode.cNamespace().get_active_list  = cwrapper.prototype("active_list_ref local_obsdata_node_get_active_list(local_obsdata_node)")
 LocalObsdataNode.cNamespace().all_timestep_active  = cwrapper.prototype("bool local_obsdata_node_all_timestep_active(local_obsdata_node)")
 LocalObsdataNode.cNamespace().set_all_timestep_active  = cwrapper.prototype("void local_obsdata_node_set_all_timestep_active(local_obsdata_node, bool)")
-
-

--- a/python/python/ert/enkf/local_obsdata_node.py
+++ b/python/python/ert/enkf/local_obsdata_node.py
@@ -1,52 +1,59 @@
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 class LocalObsdataNode(BaseCClass):
+    TYPE_NAME = "local_obsdata_node"
+
+    _alloc                   = EnkfPrototype("void* local_obsdata_node_alloc(char* , bool)", bind = False)
+    _free                    = EnkfPrototype("void  local_obsdata_node_free(local_obsdata_node)")
+    _get_key                 = EnkfPrototype("char* local_obsdata_node_get_key(local_obsdata_node)")
+    _add_range               = EnkfPrototype("void  local_obsdata_node_add_range(local_obsdata_node, int, int)")
+    _add_step                = EnkfPrototype("void  local_obsdata_node_add_tstep(local_obsdata_node, int)")
+    _tstep_active            = EnkfPrototype("bool  local_obsdata_node_tstep_active(local_obsdata_node, int)")
+    _all_timestep_active     = EnkfPrototype("bool  local_obsdata_node_all_timestep_active(local_obsdata_node)")
+    _set_all_timestep_active = EnkfPrototype("void  local_obsdata_node_set_all_timestep_active(local_obsdata_node, bool)")
+    _get_active_list         = EnkfPrototype("active_list_ref local_obsdata_node_get_active_list(local_obsdata_node)")
 
     def __init__(self, obs_key , all_timestep_active = True):
-        assert isinstance(obs_key, str)
+        if isinstance(obs_key, str):
+            c_ptr = self._alloc(obs_key , all_timestep_active)
+            if c_ptr:
+                super(LocalObsdataNode, self).__init__(c_ptr)
+            else:
+                raise ArgumentError('Unable to construct LocalObsdataNode with key = "%s".' % obs_key)
+        else:
+            raise TypeError('LocalObsdataNode needs string, not %s.' % str(type(obs_key)))
 
-        c_pointer = LocalObsdataNode.cNamespace().alloc(obs_key , all_timestep_active)
-        super(LocalObsdataNode, self).__init__(c_pointer)
-
+    def key(self):
+        return self._get_key()
     def getKey(self):
-        return LocalObsdataNode.cNamespace().get_key(self)
+        return self.key()
 
     def addRange(self, step_1, step_2):
         assert isinstance(step_1, int)
         assert isinstance(step_2, int)
-        LocalObsdataNode.cNamespace().add_range(self, step_1, step_2)
+        self._add_range(step_1, step_2)
 
 
     def addTimeStep(self , step):
-        LocalObsdataNode.cNamespace().add_step(self, step )
+        self._add_step( step )
 
 
     def free(self):
-        LocalObsdataNode.cNamespace().free(self)
+        self._free()
+
+    def __repr__(self):
+        return 'LocalObsdataNode(key = %s) %s' % (self.key(), self._ad_str())
 
     def tstepActive(self , tstep):
-        return LocalObsdataNode.cNamespace().tstep_active( self , tstep)
+        return self._tstep_active(tstep)
 
 
     def getActiveList(self):
-        return LocalObsdataNode.cNamespace().get_active_list( self )
+        return self._get_active_list()
 
     def allTimeStepActive(self):
-        return LocalObsdataNode.cNamespace().all_timestep_active( self )
+        return self._all_timestep_active()
 
     def setAllTimeStepActive(self, flag):
-        return LocalObsdataNode.cNamespace().set_all_timestep_active( self, flag )
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("local_obsdata_node", LocalObsdataNode)
-
-LocalObsdataNode.cNamespace().alloc            = cwrapper.prototype("c_void_p local_obsdata_node_alloc(char* , bool)")
-LocalObsdataNode.cNamespace().free             = cwrapper.prototype("void local_obsdata_node_free(local_obsdata_node)")
-LocalObsdataNode.cNamespace().get_key          = cwrapper.prototype("char* local_obsdata_node_get_key(local_obsdata_node)")
-LocalObsdataNode.cNamespace().add_range        = cwrapper.prototype("void local_obsdata_node_add_range(local_obsdata_node, int, int)")
-LocalObsdataNode.cNamespace().add_step         = cwrapper.prototype("void local_obsdata_node_add_tstep(local_obsdata_node, int)")
-LocalObsdataNode.cNamespace().tstep_active     = cwrapper.prototype("bool local_obsdata_node_tstep_active(local_obsdata_node, int)")
-LocalObsdataNode.cNamespace().get_active_list  = cwrapper.prototype("active_list_ref local_obsdata_node_get_active_list(local_obsdata_node)")
-LocalObsdataNode.cNamespace().all_timestep_active  = cwrapper.prototype("bool local_obsdata_node_all_timestep_active(local_obsdata_node)")
-LocalObsdataNode.cNamespace().set_all_timestep_active  = cwrapper.prototype("void local_obsdata_node_set_all_timestep_active(local_obsdata_node, bool)")
+        return self._set_all_timestep_active( flag )

--- a/python/python/ert/enkf/local_updatestep.py
+++ b/python/python/ert/enkf/local_updatestep.py
@@ -1,40 +1,43 @@
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB, LocalMinistep
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype, LocalMinistep
 
 class LocalUpdateStep(BaseCClass):
+    TYPE_NAME = "local_updatestep"
+
+    _alloc           = EnkfPrototype("void  local_updatestep_alloc(char*)", bind = False)
+    _size            = EnkfPrototype("int   local_updatestep_get_num_ministep(local_updatestep)")
+    _iget_ministep   = EnkfPrototype("local_ministep_ref local_updatestep_iget_ministep(local_updatestep, int)")
+    _free            = EnkfPrototype("void  local_updatestep_free(local_updatestep)")
+    _attach_ministep = EnkfPrototype("void  local_updatestep_add_ministep(local_updatestep, local_ministep)")
+    _name            = EnkfPrototype("char* local_updatestep_get_name(local_updatestep)")
 
     def __init__(self, updatestep_key):
         raise NotImplementedError("Class can not be instantiated directly!")
 
     def __len__(self):
         """ @rtype: int """
-        return LocalUpdateStep.cNamespace().size(self)
+        return self._size()
 
     def __getitem__(self, index):
         """ @rtype: LocalMinistep """
-        assert isinstance(index, int)
-        if index < len(self):
-            return LocalUpdateStep.cNamespace().iget_ministep(self, index)
+        if not isinstance(index, int):
+            raise TypeError('Keys must be ints, not %s' % str(type(index)))
+        if index < 0:
+            index += len(self)
+        if 0 <= index < len(self):
+            return self._iget_ministep(index)
         else:
-            raise IndexError("Invalid index")
+            raise IndexError('Invalid index, valid range: [0, %d)' % len(self))
 
     def attachMinistep(self, ministep):
         assert isinstance(ministep, LocalMinistep)
-        LocalUpdateStep.cNamespace().attach_ministep(self,ministep)
+        self._attach_ministep(ministep)
 
+    def name(self):
+        return self._name()
     def getName(self):
-        """ @rtype: str """
-        return LocalUpdateStep.cNamespace().name(self)
+        """ deprecated. @rtype: str """
+        return self.name()
 
     def free(self):
-        LocalUpdateStep.cNamespace().free(self)
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("local_updatestep", LocalUpdateStep)
-
-LocalUpdateStep.cNamespace().alloc               = cwrapper.prototype("c_void_p local_updatestep_alloc(char*)")
-LocalUpdateStep.cNamespace().size                = cwrapper.prototype("int local_updatestep_get_num_ministep(local_updatestep)")
-LocalUpdateStep.cNamespace().iget_ministep       = cwrapper.prototype("local_ministep_ref local_updatestep_iget_ministep(local_updatestep, int)")
-LocalUpdateStep.cNamespace().free                = cwrapper.prototype("void local_updatestep_free(local_updatestep)")
-LocalUpdateStep.cNamespace().attach_ministep     = cwrapper.prototype("void local_updatestep_add_ministep(local_updatestep,local_ministep)")
-LocalUpdateStep.cNamespace().name                = cwrapper.prototype("char* local_updatestep_get_name(local_updatestep)")
+        self._free(self)

--- a/python/python/ert/enkf/local_updatestep.py
+++ b/python/python/ert/enkf/local_updatestep.py
@@ -5,11 +5,11 @@ class LocalUpdateStep(BaseCClass):
 
     def __init__(self, updatestep_key):
         raise NotImplementedError("Class can not be instantiated directly!")
-    
+
     def __len__(self):
         """ @rtype: int """
         return LocalUpdateStep.cNamespace().size(self)
-    
+
     def __getitem__(self, index):
         """ @rtype: LocalMinistep """
         assert isinstance(index, int)
@@ -17,17 +17,17 @@ class LocalUpdateStep(BaseCClass):
             return LocalUpdateStep.cNamespace().iget_ministep(self, index)
         else:
             raise IndexError("Invalid index")
-        
+
     def attachMinistep(self, ministep):
         assert isinstance(ministep, LocalMinistep)
         LocalUpdateStep.cNamespace().attach_ministep(self,ministep)
-                    
+
     def getName(self):
         """ @rtype: str """
         return LocalUpdateStep.cNamespace().name(self)
-                       
+
     def free(self):
-        LocalUpdateStep.cNamespace().free(self) 
+        LocalUpdateStep.cNamespace().free(self)
 
 cwrapper = CWrapper(ENKF_LIB)
 cwrapper.registerObjectType("local_updatestep", LocalUpdateStep)
@@ -38,5 +38,3 @@ LocalUpdateStep.cNamespace().iget_ministep       = cwrapper.prototype("local_min
 LocalUpdateStep.cNamespace().free                = cwrapper.prototype("void local_updatestep_free(local_updatestep)")
 LocalUpdateStep.cNamespace().attach_ministep     = cwrapper.prototype("void local_updatestep_add_ministep(local_updatestep,local_ministep)")
 LocalUpdateStep.cNamespace().name                = cwrapper.prototype("char* local_updatestep_get_name(local_updatestep)")
-
-

--- a/python/python/ert/enkf/meas_block.py
+++ b/python/python/ert/enkf/meas_block.py
@@ -20,7 +20,7 @@ class MeasBlock(BaseCClass):
                     s += "%6.3g " % self[iobs,iens]
                 else:
                     s += "   X   "
-                    
+
             s += "]\n"
         return s
 
@@ -35,13 +35,13 @@ class MeasBlock(BaseCClass):
     def getTotalEnsSize(self):
         return MeasBlock.cNamespace().get_total_ens_size(self)
 
-        
+
     def __assert_index(self , index):
         if isinstance(index , tuple):
             iobs,iens = index
             if not 0 <= iobs < self.getObsSize():
                 raise IndexError("Invalid iobs value:%d  Valid range: [0,%d)" % (iobs , self.getObsSize()))
-                
+
             if not 0 <= iens < self.getTotalEnsSize():
                 raise IndexError("Invalid iens value:%d  Valid range: [0,%d)" % (iobs , self.getTotalEnsSize()))
 
@@ -61,7 +61,7 @@ class MeasBlock(BaseCClass):
     def __getitem__(self, index):
         iobs,iens = self.__assert_index(index)
         return MeasBlock.cNamespace().iget_value( self , iens , iobs )
-        
+
     def iensActive(self , iens):
         return MeasBlock.cNamespace().iens_active( self , iens )
 
@@ -97,8 +97,3 @@ MeasBlock.cNamespace().iset_value = cwrapper.prototype("void meas_block_iset( me
 MeasBlock.cNamespace().iget_mean = cwrapper.prototype("double meas_block_iget_ens_mean( meas_block , int )")
 MeasBlock.cNamespace().iget_std = cwrapper.prototype("double meas_block_iget_ens_std( meas_block , int )")
 MeasBlock.cNamespace().iens_active = cwrapper.prototype("bool meas_block_iens_active( meas_block , int )")
-
-
-    
-
-

--- a/python/python/ert/enkf/meas_block.py
+++ b/python/python/ert/enkf/meas_block.py
@@ -1,15 +1,30 @@
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.enkf.obs_data import ObsData
 from ert.util import Matrix, IntVector , BoolVector
 
 
 class MeasBlock(BaseCClass):
+    TYPE_NAME = "meas_block"
+
+    _alloc               = EnkfPrototype("void*  meas_block_alloc( char* , bool_vector , int)", bind = False)
+    _free                = EnkfPrototype("void   meas_block_free( meas_block )")
+    _get_active_ens_size = EnkfPrototype("int    meas_block_get_active_ens_size( meas_block )")
+    _get_total_ens_size  = EnkfPrototype("int    meas_block_get_total_ens_size( meas_block )")
+    _get_total_obs_size  = EnkfPrototype("int    meas_block_get_total_obs_size( meas_block )")
+    _iget_value          = EnkfPrototype("double meas_block_iget( meas_block , int , int)")
+    _iset_value          = EnkfPrototype("void   meas_block_iset( meas_block , int , int , double)")
+    _iget_mean           = EnkfPrototype("double meas_block_iget_ens_mean( meas_block , int )")
+    _iget_std            = EnkfPrototype("double meas_block_iget_ens_std( meas_block , int )")
+    _iens_active         = EnkfPrototype("bool   meas_block_iens_active( meas_block , int )")
 
     def __init__(self , obs_key , obs_size , ens_mask):
         assert(isinstance(ens_mask , BoolVector))
-        c_pointer = MeasBlock.cNamespace().alloc( obs_key , ens_mask , obs_size )
-        super(MeasBlock , self).__init__(c_pointer)
+        c_ptr = self._alloc( obs_key , ens_mask , obs_size )
+        if c_ptr:
+            super(MeasBlock , self).__init__(c_ptr)
+        else:
+            raise ValueError('Unable to construct MeasBlock.')
 
     def __str__(self):
         s = ""
@@ -25,15 +40,15 @@ class MeasBlock(BaseCClass):
         return s
 
     def getObsSize(self):
-        return MeasBlock.cNamespace().get_total_obs_size(self)
+        return self._get_total_obs_size()
 
 
     def getActiveEnsSize(self):
-        return MeasBlock.cNamespace().get_active_ens_size(self)
+        return self._get_active_ens_size()
 
 
     def getTotalEnsSize(self):
-        return MeasBlock.cNamespace().get_total_ens_size(self)
+        return self._get_total_ens_size()
 
 
     def __assert_index(self , index):
@@ -55,45 +70,29 @@ class MeasBlock(BaseCClass):
 
     def __setitem__(self, index, value):
         iobs , iens = self.__assert_index(index)
-        MeasBlock.cNamespace().iset_value( self , iens , iobs , value )
+        self._iset_value( iens , iobs , value )
 
 
     def __getitem__(self, index):
         iobs,iens = self.__assert_index(index)
-        return MeasBlock.cNamespace().iget_value( self , iens , iobs )
+        return self._iget_value( iens , iobs )
 
     def iensActive(self , iens):
-        return MeasBlock.cNamespace().iens_active( self , iens )
+        return self._iens_active( iens )
 
 
     def free(self):
-        MeasBlock.cNamespace().free(self)
+        self._free()
 
 
     def igetMean(self , iobs):
         if 0 <= iobs < self.getObsSize():
-            return MeasBlock.cNamespace().iget_mean(self , iobs)
+            return self._iget_mean(iobs)
         else:
             raise IndexError("Invalid observation index:%d  valid range: [0,%d)" % (iobs , self.getObsSize()))
 
     def igetStd(self , iobs):
         if 0 <= iobs < self.getObsSize():
-            return MeasBlock.cNamespace().iget_std(self , iobs)
+            return self._iget_std(iobs)
         else:
             raise IndexError("Invalid observation index:%d  valid range: [0,%d)" % (iobs , self.getObsSize()))
-
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("meas_block", MeasBlock)
-
-MeasBlock.cNamespace().alloc = cwrapper.prototype("c_void_p meas_block_alloc( char* , bool_vector , int)")
-MeasBlock.cNamespace().free = cwrapper.prototype("void meas_block_free( meas_block )")
-MeasBlock.cNamespace().get_active_ens_size = cwrapper.prototype("int meas_block_get_active_ens_size( meas_block )")
-MeasBlock.cNamespace().get_total_ens_size = cwrapper.prototype("int meas_block_get_total_ens_size( meas_block )")
-MeasBlock.cNamespace().get_total_obs_size = cwrapper.prototype("int meas_block_get_total_obs_size( meas_block )")
-MeasBlock.cNamespace().iget_value = cwrapper.prototype("double meas_block_iget( meas_block , int , int)")
-MeasBlock.cNamespace().iset_value = cwrapper.prototype("void meas_block_iset( meas_block , int , int , double)")
-MeasBlock.cNamespace().iget_mean = cwrapper.prototype("double meas_block_iget_ens_mean( meas_block , int )")
-MeasBlock.cNamespace().iget_std = cwrapper.prototype("double meas_block_iget_ens_std( meas_block , int )")
-MeasBlock.cNamespace().iens_active = cwrapper.prototype("bool meas_block_iens_active( meas_block , int )")

--- a/python/python/ert/enkf/meas_data.py
+++ b/python/python/ert/enkf/meas_data.py
@@ -1,22 +1,40 @@
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.enkf.obs_data import ObsData
 from ert.util import Matrix, IntVector
 
 
 class MeasData(BaseCClass):
+    TYPE_NAME = "meas_data"
+
+    _alloc               = EnkfPrototype("void* meas_data_alloc(bool_vector)", bind = False)
+    _free                = EnkfPrototype("void  meas_data_free(meas_data)")
+    _get_active_obs_size = EnkfPrototype("int   meas_data_get_active_obs_size(meas_data)")
+    _get_active_ens_size = EnkfPrototype("int   meas_data_get_active_ens_size( meas_data )")
+    _get_total_ens_size  = EnkfPrototype("int   meas_data_get_total_ens_size( meas_data )")
+    _get_num_blocks      = EnkfPrototype("int   meas_data_get_num_blocks( meas_data )")
+    _has_block           = EnkfPrototype("bool  meas_data_has_block( meas_data , char* )")
+    _get_block           = EnkfPrototype("meas_block_ref meas_data_get_block( meas_data , char*)")
+    _allocS              = EnkfPrototype("matrix_obj     meas_data_allocS(meas_data)")
+    _add_block           = EnkfPrototype("meas_block_ref meas_data_add_block(meas_data, char* , int , int)")
+    _iget_block          = EnkfPrototype("meas_block_ref meas_data_iget_block( meas_data , int)")
+
+    _deactivate_outliers = EnkfPrototype("void  enkf_analysis_deactivate_std_zero(obs_data, meas_data)", bind = False)
 
     def __init__(self, ens_mask):
-        c_pointer = MeasData.cNamespace().alloc(ens_mask)
-        super(MeasData, self).__init__(c_pointer)
+        c_ptr = self._alloc(ens_mask)
+        if c_ptr:
+            super(MeasData, self).__init__(c_ptr)
+        else:
+            raise ValueError('Unable to construct MeasData from given ensemble mask of type %s.' % str(type(ens_mask)))
 
     def __len__(self):
-        return MeasData.cNamespace().get_num_blocks( self )
+        return self._get_num_blocks()
 
 
     def __contains__(self , index):
         if isinstance(index , str):
-            return MeasData.cNamespace().has_block( self , index)
+            return self._has_block(index)
         else:
             raise TypeError('The in operator expects a string argument, got "%s".' % str(index))
 
@@ -24,7 +42,7 @@ class MeasData(BaseCClass):
     def __getitem__(self , index):
         if isinstance(index , str):
             if index in self:
-                return MeasData.cNamespace().get_block( self , index)
+                return self._get_block(index)
             else:
                 raise KeyError('The obs block "%s" is not recognized' % index)
         elif isinstance(index,int):
@@ -32,12 +50,17 @@ class MeasData(BaseCClass):
                 index += len(self)
 
             if 0 <= index < len(self):
-                return MeasData.cNamespace().iget_block( self , index)
+                return self._iget_block(index)
             else:
                 raise IndexError("Index out of range, should have 0 <= %d < %d." % (index, len(self)))
         else:
             raise TypeError("The index variable must string or integer")
 
+
+    def __repr__(self):
+        fmt = 'MeasData(len = %d, total ens = %d, active obs = %d, active ens = %d) at 0x%x'
+        return fmt % (len(self), self.getTotalEnsSize(),
+                      self.getActiveObsSize(), self.getActiveEnsSize(), self._address())
 
     def __str__(self):
         return '\n'.join([str(block) for block in self])
@@ -45,7 +68,7 @@ class MeasData(BaseCClass):
 
     def createS(self):
         """ @rtype: Matrix """
-        S = MeasData.cNamespace().allocS(self)
+        S = self._allocS()
         if S is None:
             raise ValueError("Failed to create S active size : [%d,%d]" % (self.getActiveEnsSize() , self.activeObsSize( )))
         return S
@@ -53,43 +76,24 @@ class MeasData(BaseCClass):
 
     def deactivateZeroStdSamples(self, obs_data):
         assert isinstance(obs_data, ObsData)
-        self.cNamespace().deactivate_outliers(obs_data, self)
+        self._deactivate_outliers(obs_data, self)
 
 
     def addBlock(self , obs_key , report_step , obs_size):
-        return MeasData.cNamespace().add_block( self , obs_key , report_step , obs_size )
+        return self._add_block( obs_key , report_step , obs_size )
 
 
     def activeObsSize(self):
-        return MeasData.cNamespace().get_active_obs_size( self )
+        return self._get_active_obs_size()
 
 
     def getActiveEnsSize(self):
-        return MeasData.cNamespace().get_active_ens_size(self)
+        return self._get_active_ens_size()
 
 
     def getTotalEnsSize(self):
-        return MeasData.cNamespace().get_total_ens_size(self)
+        return self._get_total_ens_size()
 
 
     def free(self):
-        MeasData.cNamespace().free(self)
-
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("meas_data", MeasData)
-
-MeasData.cNamespace().alloc    = cwrapper.prototype("c_void_p meas_data_alloc(bool_vector)")
-MeasData.cNamespace().free     = cwrapper.prototype("void meas_data_free(meas_data)")
-MeasData.cNamespace().get_active_obs_size = cwrapper.prototype("int meas_data_get_active_obs_size(meas_data)")
-MeasData.cNamespace().get_active_ens_size = cwrapper.prototype("int meas_data_get_active_ens_size( meas_data )")
-MeasData.cNamespace().get_total_ens_size = cwrapper.prototype("int meas_data_get_total_ens_size( meas_data )")
-MeasData.cNamespace().allocS    = cwrapper.prototype("matrix_obj meas_data_allocS(meas_data)")
-MeasData.cNamespace().add_block = cwrapper.prototype("meas_block_ref meas_data_add_block(meas_data, char* , int , int)")
-MeasData.cNamespace().get_num_blocks = cwrapper.prototype("int meas_data_get_num_blocks( meas_data )")
-MeasData.cNamespace().has_block = cwrapper.prototype("bool meas_data_has_block( meas_data , char* )")
-MeasData.cNamespace().get_block = cwrapper.prototype("meas_block_ref meas_data_get_block( meas_data , char*)")
-MeasData.cNamespace().iget_block = cwrapper.prototype("meas_block_ref meas_data_iget_block( meas_data , int)")
-
-MeasData.cNamespace().deactivate_outliers  = cwrapper.prototype("void enkf_analysis_deactivate_std_zero(obs_data, meas_data)")
+        self._free()

--- a/python/python/ert/enkf/model_config.py
+++ b/python/python/ert/enkf/model_config.py
@@ -1,17 +1,17 @@
-#  Copyright (C) 2012  Statoil ASA, Norway. 
-#   
-#  The file 'model_config.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  Copyright (C) 2012  Statoil ASA, Norway.
+#
+#  The file 'model_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import CWrapper, BaseCClass
 from ert.ecl import EclSum
@@ -25,7 +25,7 @@ class ModelConfig(BaseCClass):
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
-        
+
     def hasHistory(self):
         return ModelConfig.cNamespace().has_history(self)
 

--- a/python/python/ert/enkf/model_config.py
+++ b/python/python/ert/enkf/model_config.py
@@ -22,16 +22,37 @@ from ert.util import PathFormat
 
 
 class ModelConfig(BaseCClass):
+    TYPE_NAME = "model_config"
+
+    _free                        = EnkfPrototype("void  model_config_free( model_config )")
+    _get_forward_model           = EnkfPrototype("forward_model_ref model_config_get_forward_model(model_config)")
+    _get_max_internal_submit     = EnkfPrototype("int   model_config_get_max_internal_submit(model_config)")
+    _set_max_internal_submit     = EnkfPrototype("void  model_config_set_max_internal_submit(model_config, int)")
+    _get_case_table_file         = EnkfPrototype("char* model_config_get_case_table_file(model_config)")
+    _get_runpath_as_char         = EnkfPrototype("char* model_config_get_runpath_as_char(model_config)")
+    _select_runpath              = EnkfPrototype("bool  model_config_select_runpath(model_config, char*)")
+    _set_runpath                 = EnkfPrototype("void  model_config_set_runpath(model_config, char*)")
+    _get_enspath                 = EnkfPrototype("char* model_config_get_enspath(model_config)")
+    _get_fs_type                 = EnkfPrototype("enkf_fs_type_enum model_config_get_dbase_type(model_config)")
+    _get_history                 = EnkfPrototype("history_ref model_config_get_history(model_config)")
+    _get_history_source          = EnkfPrototype("history_source_enum model_config_get_history_source(model_config)")
+    _select_history              = EnkfPrototype("bool  model_config_select_history(model_config, history_source_enum, sched_file, ecl_sum)")
+    _has_history                 = EnkfPrototype("bool  model_config_has_history(model_config)")
+    _gen_kw_export_file          = EnkfPrototype("char* model_config_get_gen_kw_export_file(model_config)")
+    _runpath_requires_iterations = EnkfPrototype("bool  model_config_runpath_requires_iter(model_config)")
+    _get_jobname_fmt             = EnkfPrototype("char* model_config_get_jobname_fmt(model_config)")
+    _get_runpath_fmt             = EnkfPrototype("path_fmt_ref model_config_get_runpath_fmt(model_config)")
+
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
 
     def hasHistory(self):
-        return ModelConfig.cNamespace().has_history(self)
+        return self._has_history()
 
     def get_history_source(self):
         """ @rtype: HistorySourceEnum """
-        return ModelConfig.cNamespace().get_history_source(self)
+        return self._get_history_source()
 
     def set_history_source(self, history_source, sched_file, refcase):
         """
@@ -43,82 +64,57 @@ class ModelConfig(BaseCClass):
         assert isinstance(history_source, HistorySourceEnum)
         assert isinstance(sched_file, SchedFile)
         assert isinstance(refcase, EclSum)
-        return ModelConfig.cNamespace().select_history(self, history_source, sched_file, refcase)
+        return self._select_history(history_source, sched_file, refcase)
 
 
     def get_max_internal_submit(self):
         """ @rtype: int """
-        return ModelConfig.cNamespace().get_max_internal_submit(self)
+        return self._get_max_internal_submit()
 
     def set_max_internal_submit(self, max_value):
-        ModelConfig.cNamespace().get_max_internal_submit(self, max_value)
+        self._get_max_internal_submit(max_value)
 
     def getForwardModel(self):
         """ @rtype: ForwardModel """
-        return ModelConfig.cNamespace().get_forward_model(self).setParent(self)
+        return self._get_forward_model().setParent(self)
 
     def get_case_table_file(self):
         """ @rtype: str """
-        return ModelConfig.cNamespace().get_case_table_file(self)
+        return self._get_case_table_file()
 
     def getRunpathAsString(self):
         """ @rtype: str """
-        return ModelConfig.cNamespace().get_runpath_as_char(self)
+        return self._get_runpath_as_char()
 
     def selectRunpath(self, path_key):
         """ @rtype: bool """
-        return ModelConfig.cNamespace().select_runpath(self, path_key)
+        return self._select_runpath(path_key)
 
     def setRunpath(self, path_format):
-        ModelConfig.cNamespace().set_runpath(self, path_format)
+        self._set_runpath(path_format)
 
     def free(self):
-        ModelConfig.cNamespace().free(self)
+        self._free()
 
     def getFSType(self):
-        return ModelConfig.cNamespace().get_fs_type( self )
+        return self._get_fs_type()
 
     def getGenKWExportFile(self):
         """ @rtype: str """
-        return ModelConfig.cNamespace().gen_kw_export_file(self)
+        return self._gen_kw_export_file()
 
     def runpathRequiresIterations(self):
         """ @rtype: bool """
-        return ModelConfig.cNamespace().runpath_requires_iterations(self)
+        return self._runpath_requires_iterations()
 
     def getJobnameFormat(self):
         """ @rtype: str """
-        return ModelConfig.cNamespace().get_jobname_fmt(self)
+        return self._get_jobname_fmt()
 
     def getEnspath(self):
         """ @rtype: str """
-        return ModelConfig.cNamespace().get_enspath(self)
+        return self._get_enspath()
 
     def getRunpathFormat(self):
         """ @rtype: PathFormat """
-        return ModelConfig.cNamespace().get_runpath_fmt(self)
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("model_config", ModelConfig)
-
-ModelConfig.cNamespace().free = cwrapper.prototype("void model_config_free( model_config )")
-ModelConfig.cNamespace().get_forward_model = cwrapper.prototype("forward_model_ref model_config_get_forward_model(model_config)")
-ModelConfig.cNamespace().get_max_internal_submit = cwrapper.prototype("int model_config_get_max_internal_submit(model_config)")
-ModelConfig.cNamespace().set_max_internal_submit = cwrapper.prototype("void model_config_set_max_internal_submit(model_config, int)")
-ModelConfig.cNamespace().get_case_table_file = cwrapper.prototype("char* model_config_get_case_table_file(model_config)")
-ModelConfig.cNamespace().get_runpath_as_char = cwrapper.prototype("char* model_config_get_runpath_as_char(model_config)")
-ModelConfig.cNamespace().select_runpath = cwrapper.prototype("bool model_config_select_runpath(model_config, char*)")
-ModelConfig.cNamespace().set_runpath = cwrapper.prototype("void model_config_set_runpath(model_config, char*)")
-ModelConfig.cNamespace().get_fs_type = cwrapper.prototype("enkf_fs_type_enum model_config_get_dbase_type(model_config)")
-
-ModelConfig.cNamespace().get_history = cwrapper.prototype("history_ref model_config_get_history(model_config)")
-ModelConfig.cNamespace().get_history_source = cwrapper.prototype("history_source_enum model_config_get_history_source(model_config)")
-ModelConfig.cNamespace().select_history = cwrapper.prototype("bool model_config_select_history(model_config, history_source_enum, sched_file, ecl_sum)")
-ModelConfig.cNamespace().has_history = cwrapper.prototype("bool model_config_has_history(model_config)")
-ModelConfig.cNamespace().gen_kw_export_file = cwrapper.prototype("char* model_config_get_gen_kw_export_file(model_config)")
-ModelConfig.cNamespace().runpath_requires_iterations = cwrapper.prototype("bool model_config_runpath_requires_iter(model_config)")
-ModelConfig.cNamespace().get_jobname_fmt = cwrapper.prototype("char* model_config_get_jobname_fmt(model_config)")
-ModelConfig.cNamespace().get_runpath_fmt = cwrapper.prototype("path_fmt_ref model_config_get_runpath_fmt(model_config)")
-
-ModelConfig.cNamespace().get_enspath = cwrapper.prototype("char* model_config_get_enspath(model_config)")
+        return self._get_runpath_fmt()

--- a/python/python/ert/enkf/model_config.py
+++ b/python/python/ert/enkf/model_config.py
@@ -13,9 +13,9 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import CWrapper, BaseCClass
+from cwrap import BaseCClass
 from ert.ecl import EclSum
-from ert.enkf import ENKF_LIB
+from ert.enkf import EnkfPrototype
 from ert.sched import HistorySourceEnum, SchedFile
 from ert.job_queue import ForwardModel
 from ert.util import PathFormat

--- a/python/python/ert/enkf/obs_block.py
+++ b/python/python/ert/enkf/obs_block.py
@@ -1,65 +1,65 @@
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.util import Matrix
 
 
 class ObsBlock(BaseCClass):
+    TYPE_NAME = "obs_block"
+
+    _alloc       = EnkfPrototype("void*  obs_block_alloc(char*, int, matrix, bool, double)", bind = False)
+    _free        = EnkfPrototype("void   obs_block_free(obs_block)")
+    _total_size  = EnkfPrototype("int    obs_block_get_size( obs_block )")
+    _active_size = EnkfPrototype("int    obs_block_get_active_size( obs_block )")
+    _iset        = EnkfPrototype("void   obs_block_iset( obs_block , int , double , double)")
+    _iget_value  = EnkfPrototype("double obs_block_iget_value( obs_block , int)")
+    _iget_std    = EnkfPrototype("double obs_block_iget_std( obs_block , int)")
 
     def __init__(self , obs_key , obs_size , global_std_scaling=1.0):
         error_covar = None
         error_covar_owner = False
-        c_pointer = ObsBlock.cNamespace().alloc(obs_key , obs_size , error_covar , error_covar_owner, global_std_scaling)
+        c_pointer = self._alloc(obs_key , obs_size , error_covar , error_covar_owner, global_std_scaling)
         super(ObsBlock, self).__init__(c_pointer)
 
 
     def totalSize(self):
-        return ObsBlock.cNamespace().total_size(self)
+        return self._total_size()
 
     def activeSize(self):
-        return ObsBlock.cNamespace().active_size(self)
+        return self.active()
+    def active(self):
+        return self._active_size()
+    def __len__(self):
+        """Returns the total size"""
+        return self.totalSize()
 
     def __setitem__(self , index , value):
-        if isinstance(index , int):
-            if 0 <= index < self.totalSize():
-                if len(value) == 2:
-                    d = value[0]
-                    std = value[1]
+        if len(value) != 2:
+            raise TypeError("The value argument must be a two element tuple: (value , std)")
+        d, std = value
 
-                    ObsBlock.cNamespace().iset(self , index , d , std)
-                else:
-                    raise TypeError("The value argument must be a two element tuple: (value , std)")
+        if isinstance(index , int):
+            if index < 0:
+                index += len(self)
+            if 0 <= index < len(self):
+                self._iset(index, d, std)
             else:
-                raise IndexError("Invalid index:%d - valid range: [0,%d)" % (index , self.totalSize()))
+                raise IndexError("Invalid index: %d. Valid range: [0,%d)" % (index , len(self)))
         else:
-            raise TypeError("The index item must be integer")
+            raise TypeError("The index item must be integer, not %s." % str(type(index)))
 
 
     def __getitem__(self , index):
         if isinstance(index , int):
-            if 0 <= index < self.totalSize():
-                value = ObsBlock.cNamespace().iget_value(self , index)
-                std = ObsBlock.cNamespace().iget_std(self , index)
-
+            if index < 0:
+                index += len(self)
+            if 0 <= index < len(self):
+                value = self._iget_value(index)
+                std   = self._iget_std(index)
                 return (value,std)
             else:
-                raise IndexError("Invalid index:%d - valid range: [0,%d)" % (index , self.totalSize()))
+                raise IndexError("Invalid index:%d - valid range: [0,%d)" % (index , len(self)))
         else:
-            raise TypeError("The index item must be integer")
-
-
+            raise TypeError("The index item must be integer, not %s." % str(type(index)))
 
     def free(self):
-        ObsBlock.cNamespace().free(self)
-
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("obs_block", ObsBlock)
-
-ObsBlock.cNamespace().alloc = cwrapper.prototype("c_void_p obs_block_alloc(char*, int, matrix, bool, double)")
-ObsBlock.cNamespace().free  = cwrapper.prototype("void obs_block_free(obs_block)")
-ObsBlock.cNamespace().total_size  = cwrapper.prototype("int obs_block_get_size( obs_block )")
-ObsBlock.cNamespace().active_size  = cwrapper.prototype("int obs_block_get_active_size( obs_block )")
-ObsBlock.cNamespace().iset       = cwrapper.prototype("void obs_block_iset( obs_block , int , double , double)")
-ObsBlock.cNamespace().iget_value = cwrapper.prototype("double obs_block_iget_value( obs_block , int)")
-ObsBlock.cNamespace().iget_std   = cwrapper.prototype("double obs_block_iget_std( obs_block , int)")
+        self._free()

--- a/python/python/ert/enkf/obs_block.py
+++ b/python/python/ert/enkf/obs_block.py
@@ -24,7 +24,7 @@ class ObsBlock(BaseCClass):
                 if len(value) == 2:
                     d = value[0]
                     std = value[1]
-                    
+
                     ObsBlock.cNamespace().iset(self , index , d , std)
                 else:
                     raise TypeError("The value argument must be a two element tuple: (value , std)")
@@ -39,7 +39,7 @@ class ObsBlock(BaseCClass):
             if 0 <= index < self.totalSize():
                 value = ObsBlock.cNamespace().iget_value(self , index)
                 std = ObsBlock.cNamespace().iget_std(self , index)
-                
+
                 return (value,std)
             else:
                 raise IndexError("Invalid index:%d - valid range: [0,%d)" % (index , self.totalSize()))
@@ -63,5 +63,3 @@ ObsBlock.cNamespace().active_size  = cwrapper.prototype("int obs_block_get_activ
 ObsBlock.cNamespace().iset       = cwrapper.prototype("void obs_block_iset( obs_block , int , double , double)")
 ObsBlock.cNamespace().iget_value = cwrapper.prototype("double obs_block_iget_value( obs_block , int)")
 ObsBlock.cNamespace().iget_std   = cwrapper.prototype("double obs_block_iget_std( obs_block , int)")
-
-

--- a/python/python/ert/enkf/obs_block.py
+++ b/python/python/ert/enkf/obs_block.py
@@ -6,7 +6,7 @@ from ert.util import Matrix
 class ObsBlock(BaseCClass):
 
     def __init__(self , obs_key , obs_size , global_std_scaling=1.0):
-        error_covar = None 
+        error_covar = None
         error_covar_owner = False
         c_pointer = ObsBlock.cNamespace().alloc(obs_key , obs_size , error_covar , error_covar_owner, global_std_scaling)
         super(ObsBlock, self).__init__(c_pointer)

--- a/python/python/ert/enkf/obs_data.py
+++ b/python/python/ert/enkf/obs_data.py
@@ -1,29 +1,44 @@
 from types import NoneType
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.util import Matrix
 
 
 class ObsData(BaseCClass):
+    TYPE_NAME = "obs_data"
+
+    _alloc         = EnkfPrototype("void*  obs_data_alloc(double)", bind = False)
+    _free          = EnkfPrototype("void   obs_data_free(obs_data)")
+    _total_size    = EnkfPrototype("int    obs_data_get_total_size(obs_data)")
+    _scale         = EnkfPrototype("void   obs_data_scale(obs_data, matrix, matrix, matrix, matrix, matrix)")
+    _scale_matrix  = EnkfPrototype("void   obs_data_scale_matrix(obs_data, matrix)")
+    _scale_Rmatrix = EnkfPrototype("void   obs_data_scale_Rmatrix(obs_data, matrix)")
+    _iget_value    = EnkfPrototype("double obs_data_iget_value(obs_data, int)")
+    _iget_std      = EnkfPrototype("double obs_data_iget_std(obs_data, int)")
+    _add_block     = EnkfPrototype("obs_block_ref obs_data_add_block(obs_data , char* , int , matrix , bool)")
+    _allocdObs     = EnkfPrototype("matrix_obj obs_data_allocdObs(obs_data)")
+    _allocR        = EnkfPrototype("matrix_obj obs_data_allocR(obs_data)")
+    _allocD        = EnkfPrototype("matrix_obj obs_data_allocD(obs_data , matrix , matrix)")
+    _allocE        = EnkfPrototype("matrix_obj obs_data_allocE(obs_data , rng , int)")
 
     def __init__(self, global_std_scaling=1.0):
-        c_pointer = ObsData.cNamespace().alloc(global_std_scaling)
+        c_pointer = self._alloc(global_std_scaling)
         super(ObsData, self).__init__(c_pointer)
 
     def __len__(self):
         """ @rtype: int """
-        return ObsData.cNamespace().total_size(self)
+        return self._total_size()
 
     def __getitem__(self , index):
         if index < 0:
             index += len(self)
 
-        if index >= len(self):
-            raise IndexError("Invalid index:%d valid range: [0,%d)" % (index , len(self)))
+        if 0 <= index < len(self):
+            value = self._iget_value( index )
+            std = self._iget_std( index )
+            return (value,std)
 
-        value = ObsData.cNamespace().iget_value( self , index )
-        std = ObsData.cNamespace().iget_std( self , index )
-        return (value,std)
+        raise IndexError("Invalid index:%d valid range: [0,%d)" % (index , len(self)))
 
 
     def __str__(self):
@@ -32,36 +47,37 @@ class ObsData(BaseCClass):
             s += "(%g, %g)\n" % pair
         return s
 
+    def __repr__(self):
+        return 'ObsData(total_size = %d) at 0x%x' % (len(self), self._address())
 
-    
     def addBlock(self , obs_key , obs_size):
         error_covar = None 
         error_covar_owner = False
-        return ObsData.cNamespace().add_block(self , obs_key , obs_size , error_covar , error_covar_owner)
+        return self._add_block(obs_key , obs_size , error_covar , error_covar_owner)
 
 
     def createDObs(self):
         """ @rtype: Matrix """
-        return ObsData.cNamespace().allocdObs(self)
+        return self._allocdObs()
 
     def createR(self):
         """ @rtype: Matrix """
-        return ObsData.cNamespace().allocR(self)
+        return self._allocR()
 
     def createD(self , E , S):
         """ @rtype: Matrix """
-        return ObsData.cNamespace().allocD(self , E , S)
+        return self._allocD(E , S)
 
     def createE( self , rng , active_ens_size):
         """ @rtype: Matrix """
-        return ObsData.cNamespace().allocE(self , rng , active_ens_size)
+        return self._allocE(rng , active_ens_size)
 
     def scaleMatrix(self, m):
-        ObsData.cNamespace().scale_matrix(self , m )
+        self._scale_matrix( m )
 
 
     def scaleRMatrix(self, R):
-        ObsData.cNamespace().scale_Rmatrix(self , R )
+        self._scale_Rmatrix( R )
 
 
     def scale(self, S, E=None, D=None, R=None, D_obs=None):
@@ -70,31 +86,8 @@ class ObsData(BaseCClass):
         assert isinstance(D, (Matrix, NoneType))
         assert isinstance(R, (Matrix, NoneType))
         assert isinstance(D_obs, (Matrix, NoneType))
-        ObsData.cNamespace().scale(self, S, E, D, R, D_obs)
+        self._scale(S, E, D, R, D_obs)
 
 
     def free(self):
-        ObsData.cNamespace().free(self)
-
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("obs_data", ObsData)
-
-ObsData.cNamespace().alloc       = cwrapper.prototype("c_void_p obs_data_alloc(double)")
-ObsData.cNamespace().free        = cwrapper.prototype("void obs_data_free(obs_data)")
-ObsData.cNamespace().total_size  = cwrapper.prototype("int obs_data_get_total_size(obs_data)")
-ObsData.cNamespace().iget_value  = cwrapper.prototype("double obs_data_iget_value(obs_data)")
-ObsData.cNamespace().iget_std  = cwrapper.prototype("double obs_data_iget_std(obs_data)")
-ObsData.cNamespace().add_block   = cwrapper.prototype("obs_block_ref obs_data_add_block(obs_data , char* , int , matrix , bool)")
-
-ObsData.cNamespace().allocdObs   = cwrapper.prototype("matrix_obj obs_data_allocdObs(obs_data)")
-ObsData.cNamespace().allocR      = cwrapper.prototype("matrix_obj obs_data_allocR(obs_data)")
-ObsData.cNamespace().allocD      = cwrapper.prototype("matrix_obj obs_data_allocD(obs_data , matrix , matrix)")
-ObsData.cNamespace().allocE      = cwrapper.prototype("matrix_obj obs_data_allocE(obs_data , rng , int)")
-ObsData.cNamespace().scale       = cwrapper.prototype("void obs_data_scale(obs_data, matrix, matrix, matrix, matrix, matrix)")
-ObsData.cNamespace().scale_matrix = cwrapper.prototype("void obs_data_scale_matrix(obs_data, matrix)")
-ObsData.cNamespace().scale_Rmatrix = cwrapper.prototype("void obs_data_scale_Rmatrix(obs_data, matrix)")
-
-
-
+        self._free()

--- a/python/python/ert/enkf/observations/CMakeLists.txt
+++ b/python/python/ert/enkf/observations/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PYTHON_SOURCES
     __init__.py
     block_observation.py
+    block_data_config.py
     gen_observation.py
     obs_vector.py
     summary_observation.py

--- a/python/python/ert/enkf/observations/__init__.py
+++ b/python/python/ert/enkf/observations/__init__.py
@@ -1,4 +1,5 @@
 from .summary_observation import SummaryObservation
-from .block_observation import BlockObservation
 from .gen_observation import GenObservation
+from .block_data_config import BlockDataConfig
+from .block_observation import BlockObservation
 from .obs_vector import ObsVector

--- a/python/python/ert/enkf/observations/block_data_config.py
+++ b/python/python/ert/enkf/observations/block_data_config.py
@@ -1,0 +1,41 @@
+#  Copyright (C) 2016  Statoil ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+from cwrap import BaseCClass
+from ert.enkf import NodeId, FieldConfig
+from ert.enkf import EnkfPrototype
+import ctypes
+
+class BlockDataConfig(BaseCClass):
+    TYPE_NAME = "block_data_config"
+
+    def __init__(self):
+        raise NotImplementedError('Cannot instantiate BlockDataConfig!')
+
+    @classmethod
+    def from_param(cls , instance):
+        if instance is None:
+            return ctypes.c_void_p()
+        elif isinstance(instance , FieldConfig):
+            return FieldConfig.from_param( instance )
+
+        # The Container class which is used to support summary based
+        # source in the BLOCK_OBS configuration is not yet supported
+        # in Python.
+
+        #elif isinstance(instance , ContainerConfig):
+        #    return ContainerConfig.from_param( instance )
+        else:
+            raise ValueError("Currently ONLY field data is supported")

--- a/python/python/ert/enkf/observations/block_observation.py
+++ b/python/python/ert/enkf/observations/block_observation.py
@@ -13,29 +13,10 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB, NodeId, FieldConfig
+from cwrap import BaseCClass
 from ert.enkf import EnkfPrototype
-
-class BlockDataConfig(object):
-    @classmethod
-    def from_param(cls , instance):
-        if instance is None:
-            return ctypes.c_void_p()
-        elif isinstance(instance , FieldConfig):
-            return FieldConfig.from_param( instance )
-
-        # The Container class which is used to support summary based
-        # source in the BLOCK_OBS configuration is not yet supported
-        # in Python.
-
-        #elif isinstance(instance , ContainerConfig):
-        #    return ContainerConfig.from_param( instance )
-        else:
-            raise ValueError("Currently ONLY field data is supported")
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("block_data_config", BlockDataConfig)
+from ert.enkf import NodeId, FieldConfig
+from ert.enkf.observations import BlockDataConfig
 
 
 class BlockObservation(BaseCClass):

--- a/python/python/ert/enkf/observations/block_observation.py
+++ b/python/python/ert/enkf/observations/block_observation.py
@@ -15,10 +15,9 @@
 #  for more details.
 from cwrap import BaseCClass, CWrapper
 from ert.enkf import ENKF_LIB, NodeId, FieldConfig
-
+from ert.enkf import EnkfPrototype
 
 class BlockDataConfig(object):
-
     @classmethod
     def from_param(cls , instance):
         if instance is None:
@@ -35,26 +34,45 @@ class BlockDataConfig(object):
         else:
             raise ValueError("Currently ONLY field data is supported")
 
-            
+cwrapper = CWrapper(ENKF_LIB)
+cwrapper.registerType("block_data_config", BlockDataConfig)
 
 
 class BlockObservation(BaseCClass):
+    TYPE_NAME = "block_obs"
+
+    _alloc              = EnkfPrototype("void*  block_obs_alloc( char* , block_data_config , ecl_grid )", bind = False)
+    _free               = EnkfPrototype("void   block_obs_free( block_obs )")
+    _iget_i             = EnkfPrototype("int    block_obs_iget_i(block_obs, int)")
+    _iget_j             = EnkfPrototype("int    block_obs_iget_j( block_obs, int)")
+    _iget_k             = EnkfPrototype("int    block_obs_iget_k( block_obs , int)")
+    _get_size           = EnkfPrototype("int    block_obs_get_size( block_obs )")
+    _get_std            = EnkfPrototype("double block_obs_iget_std( block_obs, int )")
+    _get_std_scaling    = EnkfPrototype("double block_obs_iget_std_scaling( block_obs, int )")
+    _update_std_scaling = EnkfPrototype("void   block_obs_update_std_scale(block_obs , double , active_list)")
+    _get_value          = EnkfPrototype("double block_obs_iget_value( block_obs, int)")
+    _get_depth          = EnkfPrototype("double block_obs_iget_depth( block_obs, int)")
+    _add_field_point    = EnkfPrototype("void   block_obs_append_field_obs( block_obs, int,int,int,double,double)")
+    _add_summary_point  = EnkfPrototype("void   block_obs_append_summary_obs( block_obs, int, int, int, double, double)")
+    _iget_data          = EnkfPrototype("double block_obs_iget_data(block_obs, void*, int, node_id)")
+
+
 
     def __init__(self , obs_key , data_config , grid):
-        c_ptr = BlockObservation.cNamespace().alloc( obs_key , data_config , grid )
+        c_ptr = self._alloc( obs_key , data_config , grid )
         super(BlockObservation, self).__init__(c_ptr)
         
         
     def getCoordinate(self, index):
         """ @rtype: tuple of (int, int, int) """
-        i = BlockObservation.cNamespace().iget_i(self, index)
-        j = BlockObservation.cNamespace().iget_j(self, index)
-        k = BlockObservation.cNamespace().iget_k(self, index)
+        i = self._iget_i(index)
+        j = self._iget_j(index)
+        k = self._iget_k(index)
         return i, j, k
 
     def __len__(self):
         """ @rtype: int """
-        return BlockObservation.cNamespace().get_size(self)
+        return self._get_size()
 
     def __iter__(self):
         cur = 0
@@ -64,30 +82,30 @@ class BlockObservation(BaseCClass):
 
     def addPoint(self , i,j,k , value , std , sum_key = None):
         if sum_key is None:
-            BlockObservation.cNamespace().add_field_point(self,i,j,k,value,std)
+            self._add_field_point(i,j,k,value,std)
         else:
-            BlockObservation.cNamespace().add_summary_point(self,i,j,k,sum_key,value,std)
+            self._add_summary_point(i,j,k,sum_key,value,std)
             
 
     def getValue(self, index):
         """ @rtype: float """
-        return BlockObservation.cNamespace().get_value(self, index)
+        return self._get_value(index)
 
     def getStd(self, index):
         """ @rtype: float """
-        return BlockObservation.cNamespace().get_std(self, index)
+        return self._get_std(index)
 
     def getStdScaling(self , index):
         """ @rtype: float """
-        return BlockObservation.cNamespace().get_std_scaling(self, index)
+        return self._get_std_scaling(index)
 
     def updateStdScaling(self , factor , active_list):
-        BlockObservation.cNamespace().update_std_scaling(self, factor , active_list)
+        self._update_std_scaling(factor , active_list)
     
     
     def getDepth(self, index):
         """ @rtype: float """
-        return BlockObservation.cNamespace().get_depth(self, index)
+        return self._get_depth(index)
 
     def getData(self, state, obs_index, node_id):
         """
@@ -96,30 +114,11 @@ class BlockObservation(BaseCClass):
         @type node_id: NodeId
         @rtype: float """
 
-        return BlockObservation.cNamespace().iget_data(self, state, obs_index, node_id)
+        return self._iget_data(state, obs_index, node_id)
 
 
     def free(self):
-        BlockObservation.cNamespace().free(self)
+        self._free()
 
-##################################################################
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("block_obs", BlockObservation)
-cwrapper.registerType("block_data_config", BlockDataConfig)
-
-BlockObservation.cNamespace().alloc = cwrapper.prototype("c_void_p block_obs_alloc( char* , block_data_config , ecl_grid )")
-BlockObservation.cNamespace().free = cwrapper.prototype("void block_obs_free( block_obs )")
-BlockObservation.cNamespace().iget_i = cwrapper.prototype("int block_obs_iget_i(block_obs, int)")
-BlockObservation.cNamespace().iget_j =cwrapper.prototype("int block_obs_iget_j( block_obs, int)")
-BlockObservation.cNamespace().iget_k = cwrapper.prototype("int block_obs_iget_k( block_obs , int)")
-BlockObservation.cNamespace().get_size = cwrapper.prototype("int block_obs_get_size( block_obs )")
-BlockObservation.cNamespace().get_std = cwrapper.prototype("double block_obs_iget_std( block_obs, int )")
-BlockObservation.cNamespace().get_std_scaling = cwrapper.prototype("double block_obs_iget_std_scaling( block_obs, int )")
-BlockObservation.cNamespace().update_std_scaling = cwrapper.prototype("void block_obs_update_std_scale(block_obs , double , active_list)")
-BlockObservation.cNamespace().get_value = cwrapper.prototype("double block_obs_iget_value( block_obs, int)")
-BlockObservation.cNamespace().get_depth = cwrapper.prototype("double block_obs_iget_depth( block_obs, int)")
-BlockObservation.cNamespace().add_field_point = cwrapper.prototype("void block_obs_append_field_obs( block_obs, int,int,int,double,double)")
-BlockObservation.cNamespace().add_summary_point = cwrapper.prototype("void block_obs_append_summary_obs( block_obs, int,int,int,double,double)")
-BlockObservation.cNamespace().iget_data = cwrapper.prototype("double block_obs_iget_data(block_obs, c_void_p, int, node_id)")
-
+    def __repr__(self):
+        return 'BlockObservation(size = %d) at 0x%x' % (len(self), self._address())

--- a/python/python/ert/enkf/observations/gen_observation.py
+++ b/python/python/ert/enkf/observations/gen_observation.py
@@ -15,15 +15,29 @@
 #  for more details.
 import os.path 
 
-from cwrap import BaseCClass, CWrapper
+from cwrap import BaseCClass
 from ert.util import IntVector
-from ert.enkf import ENKF_LIB
+from ert.enkf import EnkfPrototype
 
 
 class GenObservation(BaseCClass):
+    TYPE_NAME = "gen_obs"
+
+    _alloc              = EnkfPrototype("void   gen_obs_alloc__(gen_data_config , char*)", bind = False)
+    _free               = EnkfPrototype("void   gen_obs_free(gen_obs)")
+    _load               = EnkfPrototype("void   gen_obs_load_observation(gen_obs , char*)")
+    _scalar_set         = EnkfPrototype("void   gen_obs_set_scalar(gen_obs , double , double)")
+    _get_std            = EnkfPrototype("double gen_obs_iget_std(gen_obs, int)")
+    _get_value          = EnkfPrototype("double gen_obs_iget_value(gen_obs, int)")
+    _get_std_scaling    = EnkfPrototype("double gen_obs_iget_std_scaling(gen_obs, int)")
+    _get_size           = EnkfPrototype("int    gen_obs_get_size(gen_obs)")
+    _get_data_index     = EnkfPrototype("int    gen_obs_get_obs_index(gen_obs, int)")
+    _load_data_index    = EnkfPrototype("void   gen_obs_load_data_index(gen_obs , char*)")
+    _add_data_index     = EnkfPrototype("void   gen_obs_attach_data_index(gen_obs , int_vector)")
+    _update_std_scaling = EnkfPrototype("void   gen_obs_update_std_scale(gen_obs , double , active_list)")
 
     def __init__(self , obs_key , data_config , scalar_value = None , obs_file = None , data_index = None):
-        c_pointer = GenObservation.cNamespace().alloc( data_config , obs_key )
+        c_pointer = self._alloc( data_config , obs_key )
         super(GenObservation, self).__init__(c_pointer)
 
         if scalar_value is None and obs_file is None:
@@ -36,21 +50,21 @@ class GenObservation(BaseCClass):
             if not os.path.isfile( obs_file ):
                 raise IOError("The file with observation data:%s does not exist" % obs_file )
             else:
-                GenObservation.cNamespace().load( self , obs_file )
+                self._load( obs_file )
         else:
             obs_value , obs_std = scalar_value
-            GenObservation.cNamespace().scalar_set( self , obs_value , obs_std )
+            self._scalar_set( obs_value , obs_std )
 
         if not data_index is None:
             if os.path.isfile( data_index ):
-                GenObservation.cNamespace().load_data_index( self , data_index )
+                self._load_data_index( data_index )
             else:
                 index_list = IntVector.active_list( data_index )
-                GenObservation.cNamespace().add_data_index( self , index_list )
+                self._add_data_index( index_list )
     
     
     def __len__(self):
-        return GenObservation.cNamespace().get_size(self)
+        return self._get_size()
 
     def __getitem__(self , obs_index):
         if obs_index < 0:
@@ -59,23 +73,23 @@ class GenObservation(BaseCClass):
         if 0 <= obs_index < len(self):
             return (self.getValue(obs_index) , self.getStandardDeviation(obs_index))
         else:
-            raise IndexError("Valid range: [0,%d)" % len(self))
+            raise IndexError("Invalid index.  Valid range: [0,%d)" % len(self))
 
 
     def getValue(self, obs_index):
         """ @rtype: float """
-        return GenObservation.cNamespace().get_value(self, obs_index)
+        return self._get_value(obs_index)
 
     def getStandardDeviation(self, obs_index):
         """ @rtype: float """
-        return GenObservation.cNamespace().get_std(self, obs_index)
+        return self._get_std(obs_index)
 
     def getStdScaling(self, obs_index):
         """ @rtype: float """
-        return GenObservation.cNamespace().get_std_scaling(self, obs_index)
+        return self._get_std_scaling(obs_index)
 
     def updateStdScaling(self , factor , active_list):
-        GenObservation.cNamespace().update_std_scaling(self, factor , active_list)
+        self._update_std_scaling(factor , active_list)
 
 
     def getSize(self):
@@ -87,27 +101,11 @@ class GenObservation(BaseCClass):
         return self.getDataIndex( obs_index )
         
     def getDataIndex(self, obs_index):
-        return GenObservation.cNamespace().get_data_index(self, obs_index)
+        return self._get_data_index(obs_index)
 
     def free(self):
-        GenObservation.cNamespace().free(self)
+        self._free()
 
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("gen_obs", GenObservation)
-cwrapper.registerType("gen_obs_obj", GenObservation.createPythonObject)
-cwrapper.registerType("gen_obs_ref", GenObservation.createCReference)
-
-GenObservation.cNamespace().alloc = cwrapper.prototype("c_void_p gen_obs_alloc__(gen_data_config , char*)")
-GenObservation.cNamespace().free = cwrapper.prototype("void gen_obs_free(gen_data_config)")
-GenObservation.cNamespace().load = cwrapper.prototype("void gen_obs_load_observation(gen_obs , char*)")
-GenObservation.cNamespace().scalar_set = cwrapper.prototype("void gen_obs_set_scalar(gen_obs , double , double)")
-GenObservation.cNamespace().get_value = cwrapper.prototype("double gen_obs_iget_value(summary_obs)")
-GenObservation.cNamespace().get_std_scaling = cwrapper.prototype("double gen_obs_iget_std_scaling(summary_obs)")
-GenObservation.cNamespace().get_std = cwrapper.prototype("double gen_obs_iget_std(gen_obs, int)")
-GenObservation.cNamespace().get_size = cwrapper.prototype("int gen_obs_get_size(gen_obs)")
-GenObservation.cNamespace().get_data_index = cwrapper.prototype("int gen_obs_get_obs_index(gen_obs, int)")
-GenObservation.cNamespace().load_data_index = cwrapper.prototype("void gen_obs_load_data_index(gen_obs , char*)")
-GenObservation.cNamespace().add_data_index = cwrapper.prototype("void gen_obs_attach_data_index(gen_obs , int_vector)")
-GenObservation.cNamespace().update_std_scaling = cwrapper.prototype("void gen_obs_update_std_scale(gen_obs , double , active_list)")
+    def __repr__(self):
+        si = len(self)
+        return 'GenObservation(size = %d) %s' (si, self._ad_str())

--- a/python/python/ert/enkf/observations/gen_observation.py
+++ b/python/python/ert/enkf/observations/gen_observation.py
@@ -13,17 +13,18 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-import os.path 
+import os.path
 
 from cwrap import BaseCClass
 from ert.util import IntVector
 from ert.enkf import EnkfPrototype
+from ert.enkf import GenDataConfig
 
 
 class GenObservation(BaseCClass):
     TYPE_NAME = "gen_obs"
 
-    _alloc              = EnkfPrototype("void   gen_obs_alloc__(gen_data_config , char*)", bind = False)
+    _alloc              = EnkfPrototype("void*  gen_obs_alloc__(gen_data_config , char*)", bind = False)
     _free               = EnkfPrototype("void   gen_obs_free(gen_obs)")
     _load               = EnkfPrototype("void   gen_obs_load_observation(gen_obs , char*)")
     _scalar_set         = EnkfPrototype("void   gen_obs_set_scalar(gen_obs , double , double)")

--- a/python/python/ert/enkf/observations/gen_observation.py
+++ b/python/python/ert/enkf/observations/gen_observation.py
@@ -38,8 +38,11 @@ class GenObservation(BaseCClass):
     _update_std_scaling = EnkfPrototype("void   gen_obs_update_std_scale(gen_obs , double , active_list)")
 
     def __init__(self , obs_key , data_config , scalar_value = None , obs_file = None , data_index = None):
-        c_pointer = self._alloc( data_config , obs_key )
-        super(GenObservation, self).__init__(c_pointer)
+        c_ptr = self._alloc( data_config , obs_key )
+        if c_ptr:
+            super(GenObservation, self).__init__(c_ptr)
+        else:
+            raise ValueError('Unable to construct GenObservation with given obs_key and data_config!')
 
         if scalar_value is None and obs_file is None:
             raise ValueError("Exactly one the scalar_value and obs_file arguments must be present")

--- a/python/python/ert/enkf/observations/obs_vector.py
+++ b/python/python/ert/enkf/observations/obs_vector.py
@@ -24,19 +24,19 @@ class ObsVector(BaseCClass):
     TYPE_NAME = "obs_vector"
 
     _alloc                = EnkfPrototype("void* obs_vector_alloc(enkf_obs_impl_type, char*, enkf_config_node, int)", bind = False)
-    _free                 = EnkfPrototype("void obs_vector_free( obs_vector )")
+    _free                 = EnkfPrototype("void  obs_vector_free( obs_vector )")
     _get_state_kw         = EnkfPrototype("char* obs_vector_get_state_kw( obs_vector )")
-    _get_observation_key  = EnkfPrototype("char* obs_vector_get_key( obs_vector )")
-    _iget_node            = EnkfPrototype("void obs_vector_iget_node( obs_vector, int)")
-    _get_num_active       = EnkfPrototype("int obs_vector_get_num_active( obs_vector )")
-    _iget_active          = EnkfPrototype("bool obs_vector_iget_active( obs_vector, int)")
+    _get_key              = EnkfPrototype("char* obs_vector_get_key( obs_vector )")
+    _iget_node            = EnkfPrototype("void* obs_vector_iget_node( obs_vector, int)")
+    _get_num_active       = EnkfPrototype("int   obs_vector_get_num_active( obs_vector )")
+    _iget_active          = EnkfPrototype("bool  obs_vector_iget_active( obs_vector, int)")
     _get_impl_type        = EnkfPrototype("enkf_obs_impl_type obs_vector_get_impl_type( obs_vector)")
-    _install_node         = EnkfPrototype("void obs_vector_install_node(obs_vector, int, void*)")
-    _get_next_active_step = EnkfPrototype("int obs_vector_get_next_active_step(obs_vector, int)")
-    _has_data             = EnkfPrototype("bool obs_vector_has_data(obs_vector , bool_vector , enkf_fs)")
+    _install_node         = EnkfPrototype("void  obs_vector_install_node(obs_vector, int, void*)")
+    _get_next_active_step = EnkfPrototype("int   obs_vector_get_next_active_step(obs_vector, int)")
+    _has_data             = EnkfPrototype("bool  obs_vector_has_data(obs_vector , bool_vector , enkf_fs)")
     _get_config_node      = EnkfPrototype("enkf_config_node_ref obs_vector_get_config_node(obs_vector)")
     _get_total_chi2       = EnkfPrototype("double obs_vector_total_chi2(obs_vector, enkf_fs, int)")
-    _get_obs_key          = EnkfPrototype("char* obs_vector_get_obs_key(obs_vector)")
+    _get_obs_key          = EnkfPrototype("char*  obs_vector_get_obs_key(obs_vector)")
     _get_step_list        = EnkfPrototype("int_vector_ref obs_vector_get_step_list(obs_vector)")
     _create_local_node    = EnkfPrototype("local_obsdata_node_obj obs_vector_alloc_local_node(obs_vector)")
 
@@ -61,7 +61,13 @@ class ObsVector(BaseCClass):
 
     def getObservationKey(self):
         """ @rtype: str """
-        return self._get_observation_key()
+        return self.getKey()
+
+    def getKey(self):
+        return self._get_key()
+
+    def getObsKey(self):
+        return self._get_obs_key()
 
 
     def getNode(self, index):
@@ -109,6 +115,8 @@ class ObsVector(BaseCClass):
 
     def getActiveCount(self):
         """ @rtype: int """
+        return len(self)
+    def __len__(self):
         return self._get_num_active()
 
     def isActive(self, index):
@@ -146,6 +154,13 @@ class ObsVector(BaseCClass):
 
     def free(self):
         self._free()
+
+    def __repr__(self):
+        dk = 'data_key = %s'   % self.getDataKey()
+        kk = 'key = %s'        % self.getKey()
+        ok = 'obs_key = %s'    % self.getObsKey()
+        na = 'num_active = %d' % len(self)
+        return 'ObsVector(%s, %s, %s, %s) %s' % (na, kk, ok, dk, self._ad_str())
 
     def getTotalChi2(self, fs, realization_number):
         """ @rtype: float """

--- a/python/python/ert/enkf/observations/obs_vector.py
+++ b/python/python/ert/enkf/observations/obs_vector.py
@@ -13,14 +13,33 @@
 #   
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.enkf.config import EnkfConfigNode
 from ert.enkf.enums import EnkfObservationImplementationType
 from ert.enkf.observations import BlockObservation, SummaryObservation, GenObservation
 
 
 class ObsVector(BaseCClass):
+    TYPE_NAME = "obs_vector"
+
+    _alloc                = EnkfPrototype("void* obs_vector_alloc(enkf_obs_impl_type, char*, enkf_config_node, int)", bind = False)
+    _free                 = EnkfPrototype("void obs_vector_free( obs_vector )")
+    _get_state_kw         = EnkfPrototype("char* obs_vector_get_state_kw( obs_vector )")
+    _get_observation_key  = EnkfPrototype("char* obs_vector_get_key( obs_vector )")
+    _iget_node            = EnkfPrototype("void obs_vector_iget_node( obs_vector, int)")
+    _get_num_active       = EnkfPrototype("int obs_vector_get_num_active( obs_vector )")
+    _iget_active          = EnkfPrototype("bool obs_vector_iget_active( obs_vector, int)")
+    _get_impl_type        = EnkfPrototype("enkf_obs_impl_type obs_vector_get_impl_type( obs_vector)")
+    _install_node         = EnkfPrototype("void obs_vector_install_node(obs_vector, int, void*)")
+    _get_next_active_step = EnkfPrototype("int obs_vector_get_next_active_step(obs_vector, int)")
+    _has_data             = EnkfPrototype("bool obs_vector_has_data(obs_vector , bool_vector , enkf_fs)")
+    _get_config_node      = EnkfPrototype("enkf_config_node_ref obs_vector_get_config_node(obs_vector)")
+    _get_total_chi2       = EnkfPrototype("double obs_vector_total_chi2(obs_vector, enkf_fs, int)")
+    _get_obs_key          = EnkfPrototype("char* obs_vector_get_obs_key(obs_vector)")
+    _get_step_list        = EnkfPrototype("int_vector_ref obs_vector_get_step_list(obs_vector)")
+    _create_local_node    = EnkfPrototype("local_obsdata_node_obj obs_vector_alloc_local_node(obs_vector)")
+
     def __init__(self, observation_type, observation_key, config_node, num_reports):
         """
         @type observation_type: EnkfObservationImplementationType
@@ -32,23 +51,23 @@ class ObsVector(BaseCClass):
         assert isinstance(observation_key, str)
         assert isinstance(config_node, EnkfConfigNode)
         assert isinstance(num_reports, int)
-        pointer = ObsVector.cNamespace().alloc(observation_type, observation_key, config_node, num_reports)
-        super(ObsVector, self).__init__(pointer)
+        c_ptr = self._alloc(observation_type, observation_key, config_node, num_reports)
+        super(ObsVector, self).__init__(c_ptr)
 
 
     def getDataKey(self):
         """ @rtype: str """
-        return ObsVector.cNamespace().get_state_kw(self)
+        return self._get_state_kw()
 
     def getObservationKey(self):
         """ @rtype: str """
-        return ObsVector.cNamespace().get_observation_key(self)
+        return self._get_observation_key()
 
 
     def getNode(self, index):
         """ @rtype: SummaryObservation or BlockObservation or GenObservation"""
 
-        pointer = ObsVector.cNamespace().iget_node(self, index)
+        pointer = self._iget_node(index)
 
         node_type = self.getImplementationType()
         if node_type == EnkfObservationImplementationType.SUMMARY_OBS:
@@ -74,7 +93,7 @@ class ObsVector(BaseCClass):
         """
         Will return an IntVector with the active report steps.
         """
-        return ObsVector.cNamespace().get_step_list(self)
+        return self._get_step_list()
 
     def activeStep(self):
         """Assuming the observation is only active for one report step, this
@@ -90,65 +109,44 @@ class ObsVector(BaseCClass):
 
     def getActiveCount(self):
         """ @rtype: int """
-        return ObsVector.cNamespace().get_num_active(self)
+        return self._get_num_active()
 
     def isActive(self, index):
         """ @rtype: bool """
-        return ObsVector.cNamespace().iget_active(self, index)
+        return self._iget_active(index)
 
     def getNextActiveStep(self, previous_step=-1):
         """ @rtype: int """
-        return ObsVector.cNamespace().get_next_active_step(self, previous_step)
+        return self._get_next_active_step(previous_step)
 
     def getImplementationType(self):
         """ @rtype: EnkfObservationImplementationType """
-        return ObsVector.cNamespace().get_impl_type(self)
+        return self._get_impl_type()
 
     def installNode(self, index, node):
         assert isinstance(node, SummaryObservation)
         node.convertToCReference(self)
-        ObsVector.cNamespace().install_node(self, index, node.from_param(node))
+        self._install_node(index, node.from_param(node))
 
     def getConfigNode(self):
         """ @rtype: EnkfConfigNode """
-        return ObsVector.cNamespace().get_config_node(self).setParent(self)
+        return self._get_config_node().setParent(self)
 
     
     def createLocalObs(self):
         """
         Will create a LocalObsDataNode instance with all timesteps set.
         """
-        return ObsVector.cNamespace().create_local_node( self )
+        return self._create_local_node()
 
     
     def hasData(self, active_mask, fs):
         """ @rtype: bool """
-        return ObsVector.cNamespace().has_data(self, active_mask, fs)
+        return self._has_data(active_mask, fs)
 
     def free(self):
-        ObsVector.cNamespace().free(self)
+        self._free()
 
     def getTotalChi2(self, fs, realization_number):
         """ @rtype: float """
-        return ObsVector.cNamespace().get_total_chi2(self, fs, realization_number)
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("obs_vector", ObsVector)
-
-ObsVector.cNamespace().alloc = cwrapper.prototype("c_void_p obs_vector_alloc(enkf_obs_impl_type, char*, enkf_config_node, int)")
-ObsVector.cNamespace().free = cwrapper.prototype("void obs_vector_free( obs_vector )")
-ObsVector.cNamespace().get_state_kw = cwrapper.prototype("char* obs_vector_get_state_kw( obs_vector )")
-ObsVector.cNamespace().get_observation_key = cwrapper.prototype("char* obs_vector_get_key( obs_vector )")
-ObsVector.cNamespace().iget_node = cwrapper.prototype("c_void_p obs_vector_iget_node( obs_vector, int)")
-ObsVector.cNamespace().get_num_active = cwrapper.prototype("int obs_vector_get_num_active( obs_vector )")
-ObsVector.cNamespace().iget_active = cwrapper.prototype("bool obs_vector_iget_active( obs_vector, int)")
-ObsVector.cNamespace().get_impl_type = cwrapper.prototype("enkf_obs_impl_type obs_vector_get_impl_type( obs_vector)")
-ObsVector.cNamespace().install_node = cwrapper.prototype("void obs_vector_install_node(obs_vector, int, c_void_p)")
-ObsVector.cNamespace().get_next_active_step = cwrapper.prototype("int obs_vector_get_next_active_step(obs_vector, int)")
-ObsVector.cNamespace().has_data = cwrapper.prototype("bool obs_vector_has_data(obs_vector , bool_vector , enkf_fs)")
-ObsVector.cNamespace().get_config_node = cwrapper.prototype("enkf_config_node_ref obs_vector_get_config_node(obs_vector)")
-ObsVector.cNamespace().get_total_chi2 = cwrapper.prototype("double obs_vector_total_chi2(obs_vector, enkf_fs, int)")
-ObsVector.cNamespace().get_obs_key = cwrapper.prototype("char* obs_vector_get_obs_key(obs_vector)")
-ObsVector.cNamespace().get_step_list = cwrapper.prototype("int_vector_ref obs_vector_get_step_list(obs_vector)")
-ObsVector.cNamespace().create_local_node = cwrapper.prototype("local_obsdata_node_obj obs_vector_alloc_local_node(obs_vector)")
+        return self._get_total_chi2(fs, realization_number)

--- a/python/python/ert/enkf/observations/summary_observation.py
+++ b/python/python/ert/enkf/observations/summary_observation.py
@@ -14,11 +14,22 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 
 class SummaryObservation(BaseCClass):
+    TYPE_NAME = "summary_obs"
+
+    _alloc            = EnkfPrototype("void*  summary_obs_alloc(char*, char*, double, double, char*, double)", bind = False)
+    _free             = EnkfPrototype("void   summary_obs_free(summary_obs)")
+    _get_value        = EnkfPrototype("double summary_obs_get_value(summary_obs)")
+    _get_std          = EnkfPrototype("double summary_obs_get_std(summary_obs)")
+    _get_std_scaling  = EnkfPrototype("double summary_obs_get_std_scaling(summary_obs)")
+    _get_summary_key  = EnkfPrototype("char*  summary_obs_get_summary_key(summary_obs)")
+    _update_std_scale = EnkfPrototype("void   summary_obs_update_std_scale(summary_obs , double , active_list)")
+
+
     def __init__(self, summary_key, observation_key, value, std, auto_corrf_name=None, auto_corrf_param=0.0):
         assert isinstance(summary_key, str)
         assert isinstance(observation_key, str)
@@ -29,20 +40,20 @@ class SummaryObservation(BaseCClass):
             assert isinstance(auto_corrf_name, str)
 
         assert isinstance(auto_corrf_param, float)
-        pointer = SummaryObservation.cNamespace().alloc(summary_key, observation_key, value, std, auto_corrf_name, auto_corrf_param)
-        super(SummaryObservation, self).__init__(pointer)
+        c_ptr = self._alloc(summary_key, observation_key, value, std, auto_corrf_name, auto_corrf_param)
+        super(SummaryObservation, self).__init__(c_ptr)
 
     def getValue(self):
         """ @rtype: float """
-        return SummaryObservation.cNamespace().get_value(self)
+        return self._get_value()
 
     def getStandardDeviation(self):
         """ @rtype: float """
-        return SummaryObservation.cNamespace().get_std(self)
+        return self._get_std()
 
     def getStdScaling(self , index = 0):
         """ @rtype: float """
-        return SummaryObservation.cNamespace().get_std_scaling(self)
+        return self._get_std_scaling()
 
     def __len__(self):
         return 1
@@ -50,28 +61,21 @@ class SummaryObservation(BaseCClass):
     
     def getSummaryKey(self):
         """ @rtype: str """
-        return SummaryObservation.cNamespace().get_summary_key(self)
+        return self._get_summary_key()
 
 
     def updateStdScaling(self , factor , active_list):
-        SummaryObservation.cNamespace().update_std_scale(self , factor , active_list)
+        self._update_std_scale(factor , active_list)
     
 
     def free(self):
-        SummaryObservation.cNamespace().free(self)
+        self._free()
 
-
-    
-
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("summary_obs", SummaryObservation)
-
-SummaryObservation.cNamespace().alloc = cwrapper.prototype("c_void_p summary_obs_alloc(char*, char*, double, double, char*, double)")
-SummaryObservation.cNamespace().free = cwrapper.prototype("void summary_obs_free(summary_obs)")
-SummaryObservation.cNamespace().get_value = cwrapper.prototype("double summary_obs_get_value(summary_obs)")
-SummaryObservation.cNamespace().get_std = cwrapper.prototype("double summary_obs_get_std(summary_obs)")
-SummaryObservation.cNamespace().get_std_scaling = cwrapper.prototype("double summary_obs_get_std_scaling(summary_obs)")
-SummaryObservation.cNamespace().get_summary_key = cwrapper.prototype("char* summary_obs_get_summary_key(summary_obs)")
-SummaryObservation.cNamespace().update_std_scale = cwrapper.prototype("void summary_obs_update_std_scale(summary_obs , double , active_list)")
+    def __repr__(self):
+        sk = self.getSummaryKey()
+        va = self.getValue()
+        sd = self.getStandardDeviation()
+        sc = self.getStdScaling()
+        ad = self._address()
+        fmt = 'SummaryObservation(key = %s, value = %f, std = %f, std_scaling = %f) at 0x%x'
+        return fmt % (sk, va, sd, sc, ad)

--- a/python/python/ert/enkf/plot_config.py
+++ b/python/python/ert/enkf/plot_config.py
@@ -1,17 +1,17 @@
-#  Copyright (C) 2012  Statoil ASA, Norway. 
-#   
+#  Copyright (C) 2012  Statoil ASA, Norway.
+#
 #  The file 'plot_config.py' is part of ERT - Ensemble based Reservoir Tool.
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass, CWrapper
 from ert.enkf import ENKF_LIB
@@ -40,4 +40,3 @@ cwrapper.registerType("plot_config_ref", PlotConfig.createCReference)
 PlotConfig.cNamespace().free = cwrapper.prototype("void plot_config_free( plot_config )")
 PlotConfig.cNamespace().get_path = cwrapper.prototype("char* plot_config_get_path(plot_config)")
 PlotConfig.cNamespace().set_path = cwrapper.prototype("void plot_config_set_path(plot_config, char*)")
-

--- a/python/python/ert/enkf/plot_config.py
+++ b/python/python/ert/enkf/plot_config.py
@@ -13,30 +13,27 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
-
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 class PlotConfig(BaseCClass):
+    TYPE_NAME = "plot_config"
+    #cwrapper.registerType("plot_config_obj", PlotConfig.createPythonObject)
+    #cwrapper.registerType("plot_config_ref", PlotConfig.createCReference)
+
+    _free     = EnkfPrototype("void  plot_config_free( plot_config )")
+    _get_path = EnkfPrototype("char* plot_config_get_path(plot_config)")
+    _set_path = EnkfPrototype("void  plot_config_set_path(plot_config, char*)")
+
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
 
     def getPath(self):
         """ @rtype: str """
-        return PlotConfig.cNamespace().get_path(self)
+        return self._get_path()
 
     def setPath(self, path):
-        PlotConfig.cNamespace().set_path(self, path)
+        self._set_path(path)
 
     def free(self):
-        PlotConfig.cNamespace().free(self)
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerType("plot_config", PlotConfig)
-cwrapper.registerType("plot_config_obj", PlotConfig.createPythonObject)
-cwrapper.registerType("plot_config_ref", PlotConfig.createCReference)
-
-PlotConfig.cNamespace().free = cwrapper.prototype("void plot_config_free( plot_config )")
-PlotConfig.cNamespace().get_path = cwrapper.prototype("char* plot_config_get_path(plot_config)")
-PlotConfig.cNamespace().set_path = cwrapper.prototype("void plot_config_set_path(plot_config, char*)")
+        self._free()

--- a/python/python/ert/enkf/plot_data/plot_block_data_loader.py
+++ b/python/python/ert/enkf/plot_data/plot_block_data_loader.py
@@ -9,6 +9,8 @@ class PlotBlockDataLoader(object):
         """
         @type obs_vector: ObsVector
         """
+        if obs_vector is None:
+            raise ArgumentError('Cannot construct PlotBlockDataLoader without obs_vector.  Was None.')
         super(PlotBlockDataLoader, self).__init__()
         self.__obs_vector = obs_vector
         self.__permutation_vector = None

--- a/python/python/ert/enkf/run_arg.py
+++ b/python/python/ert/enkf/run_arg.py
@@ -14,33 +14,34 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
 
-
-from cwrap import BaseCClass, CWrapper
-from ert.enkf import ENKF_LIB
-
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 
 class RunArg(BaseCClass):
+    TYPE_NAME = "run_arg"
+
+    _alloc_ENSEMBLE_EXPERIMENT = EnkfPrototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT(enkf_fs , int, int, char*)", bind = False)
+    _free                      = EnkfPrototype("void run_arg_free(run_arg)")
+    _get_queue_index           = EnkfPrototype("int  run_arg_get_queue_index(run_arg)")
+    _is_submitted              = EnkfPrototype("bool run_arg_is_submitted(run_arg)")
+
     def __init__(self):
-        raise NotImplementedError("Class can not be instantiated directly")
+        raise NotImplementedError("Cannot instantiat RunArg directly!")
 
     @classmethod
     def createEnsembleExperimentRunArg(cls, fs, iens, runpath, iter=0):
-        return RunArg.cNamespace().alloc_ENSEMBLE_EXPERIMENT(fs, iens, iter, runpath)
+        return cls._alloc_ENSEMBLE_EXPERIMENT(fs, iens, iter, runpath)
 
     def free(self):
-        RunArg.cNamespace().free(self)
+        self._free()
 
     def getQueueIndex(self):
-        return RunArg.cNamespace().get_queue_index(self)
+        return self._get_queue_index()
 
     def isSubmitted(self):
-        return RunArg.cNamespace().is_submitted(self)
+        return self._is_submitted()
 
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("run_arg", RunArg)
-
-RunArg.cNamespace().alloc_ENSEMBLE_EXPERIMENT = cwrapper.prototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT(enkf_fs , int, int, char*)")
-RunArg.cNamespace().free = cwrapper.prototype("void run_arg_free(run_arg)")
-RunArg.cNamespace().get_queue_index = cwrapper.prototype("int run_arg_get_queue_index(run_arg)")
-RunArg.cNamespace().is_submitted = cwrapper.prototype("bool run_arg_is_submitted(run_arg)")
+    def __repr__(self):
+        su = 'submitted' if self.isSubmitted() else 'not submitted'
+        qi = self.getQueueIndex()
+        return 'RunArg(queue_index = %d, %s) %s' % (qi, su, self._ad_str())

--- a/python/python/ert/enkf/summary_key_matcher.py
+++ b/python/python/ert/enkf/summary_key_matcher.py
@@ -1,44 +1,41 @@
-from cwrap import CWrapper, BaseCClass
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.util import StringList
 
 
 class SummaryKeyMatcher(BaseCClass):
+    TYPE_NAME = "summary_key_matcher"
+
+    _alloc       = EnkfPrototype("void* summary_key_matcher_alloc()", bind = False)
+    _free        = EnkfPrototype("void  summary_key_matcher_free(summary_key_matcher)")
+    _size        = EnkfPrototype("int   summary_key_matcher_get_size(summary_key_matcher)")
+    _add_key     = EnkfPrototype("void  summary_key_matcher_add_summary_key(summary_key_matcher, char*)")
+    _match_key   = EnkfPrototype("bool  summary_key_matcher_match_summary_key(summary_key_matcher, char*)")
+    _keys        = EnkfPrototype("stringlist_obj summary_key_matcher_get_keys(summary_key_matcher)")
+    _is_required = EnkfPrototype("bool  summary_key_matcher_summary_key_is_required(summary_key_matcher, char*)")
 
     def __init__(self):
-        c_ptr = SummaryKeyMatcher.cNamespace().alloc()
+        c_ptr = self._alloc()
 
         super(SummaryKeyMatcher, self).__init__(c_ptr)
 
     def addSummaryKey(self, key):
         assert isinstance(key, str)
-        return SummaryKeyMatcher.cNamespace().add_key(self, key)
+        return self._add_key(key)
 
     def __len__(self):
-        return SummaryKeyMatcher.cNamespace().size(self)
+        return self._size()
 
     def __contains__(self, key):
-        return SummaryKeyMatcher.cNamespace().match_key(self, key)
+        return self._match_key(key)
 
     def isRequired(self, key):
         """ @rtype: bool """
-        return SummaryKeyMatcher.cNamespace().is_required(self, key)
+        return self._is_required(key)
 
     def keys(self):
         """ @rtype: StringList """
-        return SummaryKeyMatcher.cNamespace().keys(self)
+        return self._keys()
 
     def free(self):
-        SummaryKeyMatcher.cNamespace().free(self)
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("summary_key_matcher", SummaryKeyMatcher)
-
-SummaryKeyMatcher.cNamespace().alloc  = cwrapper.prototype("c_void_p summary_key_matcher_alloc()")
-SummaryKeyMatcher.cNamespace().free  = cwrapper.prototype("void summary_key_matcher_free(summary_key_matcher)")
-SummaryKeyMatcher.cNamespace().size  = cwrapper.prototype("int summary_key_matcher_get_size(summary_key_matcher)")
-SummaryKeyMatcher.cNamespace().add_key  = cwrapper.prototype("void summary_key_matcher_add_summary_key(summary_key_matcher, char*)")
-SummaryKeyMatcher.cNamespace().match_key  = cwrapper.prototype("bool summary_key_matcher_match_summary_key(summary_key_matcher, char*)")
-SummaryKeyMatcher.cNamespace().keys  = cwrapper.prototype("stringlist_obj summary_key_matcher_get_keys(summary_key_matcher)")
-SummaryKeyMatcher.cNamespace().is_required  = cwrapper.prototype("bool summary_key_matcher_summary_key_is_required(summary_key_matcher, char*)")
+        self._free()

--- a/python/python/ert/enkf/summary_key_set.py
+++ b/python/python/ert/enkf/summary_key_set.py
@@ -1,54 +1,51 @@
-from cwrap import CWrapper, BaseCClass
-from ert.enkf import ENKF_LIB
+from cwrap import BaseCClass
+from ert.enkf import EnkfPrototype
 from ert.util import StringList
 
 
 class SummaryKeySet(BaseCClass):
+    TYPE_NAME = "summary_key_set"
+
+    _alloc           = EnkfPrototype("void* summary_key_set_alloc()", bind = False)
+    _alloc_from_file = EnkfPrototype("void* summary_key_set_alloc_from_file(char*, bool)", bind = False)
+    _free            = EnkfPrototype("void  summary_key_set_free(summary_key_set)")
+    _size            = EnkfPrototype("int   summary_key_set_get_size(summary_key_set)")
+    _add_key         = EnkfPrototype("bool  summary_key_set_add_summary_key(summary_key_set, char*)")
+    _has_key         = EnkfPrototype("bool  summary_key_set_has_summary_key(summary_key_set, char*)")
+    _keys            = EnkfPrototype("stringlist_obj summary_key_set_alloc_keys(summary_key_set)")
+    _is_read_only    = EnkfPrototype("bool  summary_key_set_is_read_only(summary_key_set)")
+    _fwrite          = EnkfPrototype("void  summary_key_set_fwrite(summary_key_set, char*)")
 
     def __init__(self, filename=None, read_only=False):
         if filename is None:
-            c_ptr = SummaryKeySet.cNamespace().alloc()
+            c_ptr = self._alloc()
         else:
-            c_ptr = SummaryKeySet.cNamespace().alloc_from_file(filename, read_only)
+            c_ptr = self._alloc_from_file(filename, read_only)
 
         super(SummaryKeySet, self).__init__(c_ptr)
 
     def addSummaryKey(self, key):
         assert isinstance(key, str)
-        return SummaryKeySet.cNamespace().add_key(self, key)
+        return self._add_key(key)
 
     def __len__(self):
-        return SummaryKeySet.cNamespace().size(self)
+        return self._size()
 
     def __contains__(self, key):
-        return SummaryKeySet.cNamespace().has_key(self, key)
+        return self._has_key(key)
 
     def keys(self):
         """ @rtype: StringList """
-        return SummaryKeySet.cNamespace().keys(self)
+        return self._keys()
 
     def isReadOnly(self):
         """ @rtype: bool """
-        return SummaryKeySet.cNamespace().is_read_only(self)
+        return self._is_read_only()
 
 
     def writeToFile(self, filename):
         assert isinstance(filename, str)
-        SummaryKeySet.cNamespace().fwrite(self, filename)
+        self._fwrite(filename)
 
     def free(self):
-        SummaryKeySet.cNamespace().free(self)
-
-
-cwrapper = CWrapper(ENKF_LIB)
-cwrapper.registerObjectType("summary_key_set", SummaryKeySet)
-
-SummaryKeySet.cNamespace().alloc  = cwrapper.prototype("c_void_p summary_key_set_alloc()")
-SummaryKeySet.cNamespace().alloc_from_file  = cwrapper.prototype("c_void_p summary_key_set_alloc_from_file(char*, bool)")
-SummaryKeySet.cNamespace().free  = cwrapper.prototype("void summary_key_set_free(summary_key_set)")
-SummaryKeySet.cNamespace().size  = cwrapper.prototype("int summary_key_set_get_size(summary_key_set)")
-SummaryKeySet.cNamespace().add_key  = cwrapper.prototype("bool summary_key_set_add_summary_key(summary_key_set, char*)")
-SummaryKeySet.cNamespace().has_key  = cwrapper.prototype("bool summary_key_set_has_summary_key(summary_key_set, char*)")
-SummaryKeySet.cNamespace().keys  = cwrapper.prototype("stringlist_obj summary_key_set_alloc_keys(summary_key_set)")
-SummaryKeySet.cNamespace().is_read_only  = cwrapper.prototype("bool summary_key_set_is_read_only(summary_key_set)")
-SummaryKeySet.cNamespace().fwrite  = cwrapper.prototype("void summary_key_set_fwrite(summary_key_set, char*)")
+        self._free()

--- a/python/python/ert/sched/history.py
+++ b/python/python/ert/sched/history.py
@@ -35,15 +35,21 @@ class History(BaseCClass):
         @type use_history: bool
         @rtype: HistoryType
         """
+        self._init_from = ''
+        self._init_val  = ''
         if sched_file is not None:
-            c_ptr = self._alloc_from_sched_file(refcase, use_history)
+            self._init_from = 'sched_file'
+            self._init_val  = str(sched_file)
+            c_ptr = self._alloc_from_sched_file(sched_file, use_history)
         else:
+            self._init_from = 'refcase'
+            self._init_val  = str(refcase)
             c_ptr = self._alloc_from_refcase(refcase, use_history)
         if c_ptr:
             super(History, self).__init__(c_ptr)
         else:
             if sched_file is None and refcase is None:
-                raise ValueError('Need to specify either sched_file or refcase.')
+                raise ArgumentError('Need to specify either sched_file or refcase.')
             raise ValueError('Invalid input.  Failed to create History.')
 
     @staticmethod
@@ -56,3 +62,9 @@ class History(BaseCClass):
 
     def free(self):
         self._free( self )
+
+    def __repr__(self):
+        fr = self._init_from
+        va = self._init_val
+        ad = self._ad_str()
+        return 'History(init_from = %s: %s) %s' % (fr,va,ad)

--- a/python/python/ert/sched/history.py
+++ b/python/python/ert/sched/history.py
@@ -20,8 +20,6 @@ from ert.ecl import EclSum
 
 class History(BaseCClass):
     TYPE_NAME = "history"
-    # cwrapper.registerType("history_obj", History.createPythonObject)
-    # cwrapper.registerType("history_ref", History.createCReference)
 
     _alloc_from_refcase    = SchedulePrototype("void* history_alloc_from_refcase(ecl_sum, bool)", bind = False)
     _alloc_from_sched_file = SchedulePrototype("void* history_alloc_from_sched_file(char*, sched_file)", bind = False)

--- a/python/python/ert/sched/sched_file.py
+++ b/python/python/ert/sched/sched_file.py
@@ -16,7 +16,7 @@
 import os.path
 
 from cwrap import BaseCClass
-from ert.sched import SCHED_LIB, SchedulePrototype
+from ert.sched import SchedulePrototype
 from ert.util import CTime
 
 
@@ -41,6 +41,9 @@ class SchedFile(BaseCClass):
     @property
     def length(self):
         """ @rtype: int """
+        return len(self)
+
+    def __len__(self):
         return self._length()
 
     def write(self, filename, num_dates, add_end=True):
@@ -48,3 +51,6 @@ class SchedFile(BaseCClass):
 
     def free(self):
         self._free( )
+
+    def __repr__(self):
+        return 'SchedFile(len = %d) %s' % (len(self), self._ad_str())

--- a/python/python/ert/util/ui_return.py
+++ b/python/python/ert/util/ui_return.py
@@ -21,20 +21,24 @@ from enums import UIReturnStatusEnum
 
 class UIReturn(BaseCClass):
     TYPE_NAME = "ui_return"
-    _alloc = UtilPrototype("void* ui_return_alloc( ui_return_status )" , bind = False)
-    _free = UtilPrototype("void ui_return_free(ui_return)")
-    _get_status = UtilPrototype("ui_return_status ui_return_get_status(ui_return)")
-    _get_help = UtilPrototype("char* ui_return_get_help(ui_return)")
-    _add_help = UtilPrototype("void ui_return_add_help(ui_return)")
-    _add_error = UtilPrototype("void ui_return_add_error(ui_return)")
-    _num_error = UtilPrototype("int ui_return_get_error_count(ui_return)")
-    _last_error = UtilPrototype("char* ui_return_get_last_error(ui_return)")
+
+    _alloc       = UtilPrototype("void* ui_return_alloc( ui_return_status )" , bind = False)
+    _free        = UtilPrototype("void ui_return_free(ui_return)")
+    _get_status  = UtilPrototype("ui_return_status ui_return_get_status(ui_return)")
+    _get_help    = UtilPrototype("char* ui_return_get_help(ui_return)")
+    _add_help    = UtilPrototype("void ui_return_add_help(ui_return)")
+    _add_error   = UtilPrototype("void ui_return_add_error(ui_return)")
+    _num_error   = UtilPrototype("int ui_return_get_error_count(ui_return)")
+    _last_error  = UtilPrototype("char* ui_return_get_last_error(ui_return)")
     _first_error = UtilPrototype("char* ui_return_get_first_error(ui_return)")
-    _iget_error = UtilPrototype("char* ui_return_iget_error(ui_return , int)")
-    
+    _iget_error  = UtilPrototype("char* ui_return_iget_error(ui_return ,       int)")
+
     def __init__(self , status):
         c_ptr = self._alloc(status)
-        super(UIReturn, self).__init__(c_ptr)
+        if c_ptr:
+            super(UIReturn, self).__init__(c_ptr)
+        else:
+            raise ValueError('Unable to construct UIReturn with status = %s' % str(status))
 
 
     def __nonzero__(self):
@@ -50,10 +54,12 @@ class UIReturn(BaseCClass):
 
     def __getitem__(self , index):
         if isinstance(index , int):
+            if index < 0:
+                index += len(self)
             if 0 <= index < len(self):
                 return self._iget_error( index)
             else:
-                raise IndexError
+                raise IndexError('Invalid index.  Valid range: [0, %d)' % len(self))
         else:
             raise TypeError("Lookup type must be integer")
   
@@ -99,3 +105,9 @@ class UIReturn(BaseCClass):
 
     def free(self):
         self._free()
+
+    def __repr__(self):
+        ec = len(self)
+        st = self.status()
+        ad = self._ad_str()
+        return 'UIReturn(error_count = %d, status = %s) %s' % (ec, st, ad)

--- a/python/tests/ert/enkf/test_ecl_config.py
+++ b/python/tests/ert/enkf/test_ecl_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #  Copyright (C) 2013  Statoil ASA, Norway.
 #
-#  The file 'test_analysis_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#  This file is part of ERT - Ensemble based Reservoir Tool.
 #
 #  ERT is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,7 +15,6 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-import os
 import os.path
 from ert.enkf import EclConfig
 from ert.test import ExtendedTestCase

--- a/python/tests/ert/enkf/test_enkf_obs.py
+++ b/python/tests/ert/enkf/test_enkf_obs.py
@@ -90,9 +90,12 @@ class EnKFObsTest(ExtendedTestCase):
             for v in obs:
                 self.assertTrue(isinstance(v, ObsVector))
 
-            with self.assertRaises(IndexError):
-                v = obs[-1]
+            self.assertEqual(obs[-1].getKey(),    1)
+            self.assertEqual(obs[-1].getDataKey(), 1)
+            self.assertEqual(obs[-1].getObsKey(), 1)
 
+            with self.assertRaises(IndexError):
+                v = obs[-40]
             with self.assertRaises(IndexError):
                 v = obs[40]
 

--- a/python/tests/ert/enkf/test_enkf_obs.py
+++ b/python/tests/ert/enkf/test_enkf_obs.py
@@ -90,9 +90,9 @@ class EnKFObsTest(ExtendedTestCase):
             for v in obs:
                 self.assertTrue(isinstance(v, ObsVector))
 
-            self.assertEqual(obs[-1].getKey(),    1)
-            self.assertEqual(obs[-1].getDataKey(), 1)
-            self.assertEqual(obs[-1].getObsKey(), 1)
+            self.assertEqual(obs[-1].getKey(),    'RFT_TEST')
+            self.assertEqual(obs[-1].getDataKey(),'4289383' )
+            self.assertEqual(obs[-1].getObsKey(), 'RFT_TEST')
 
             with self.assertRaises(IndexError):
                 v = obs[-40]

--- a/python/tests/ert/enkf/test_obs_block.py
+++ b/python/tests/ert/enkf/test_obs_block.py
@@ -26,7 +26,7 @@ class ObsBlockTest(ExtendedTestCase):
             block[100] = (1,1)
 
         with self.assertRaises(IndexError):
-            block[-1] = (1,1)
+            block[-100] = (1,1)
 
         with self.assertRaises(TypeError):
             block[4] = 10
@@ -40,16 +40,12 @@ class ObsBlockTest(ExtendedTestCase):
             v = block[100]
 
         with self.assertRaises(IndexError):
-            v = block[-1]
+            v = block[-100]
 
         block[0] = (10,1)
         v = block[0]
         self.assertEqual( v , (10,1))
         self.assertEqual( 1 , block.activeSize())
-        
-        
-        
-        
 
-
-
+        block[-1] = (17,19)
+        self.assertEqual( block[-1], (17,19))


### PR DESCRIPTION
Slowly cleaning up legacy wraps:
* analysis_config, hook_manager, local_config
* whitespace insanity
* local_config, local_ministep, etc
* **lots more** (see commit log)

This depends on #1323.
