### PR TITLE
Some python3 initial work, and cwrap vs Python 3

### DIFF
--- a/cmake/cmake_pyc2
+++ b/cmake/cmake_pyc2
@@ -21,7 +21,7 @@ shutil.copyfile( src_file , target_file )
 shutil.copystat( src_file , target_file )
 try:
     py_compile.compile( target_file , doraise = True)
-except Exception,error:
+except Exception as error:
     sys.exit("py_compile(%s) failed:%s" % (target_file , error))
 
 

--- a/python/python/cwrap/clib.py
+++ b/python/python/cwrap/clib.py
@@ -83,7 +83,7 @@ def load( lib, so_version = None, path = None):
         try:
             dll = ctypes.CDLL(lib_file , ctypes.RTLD_GLOBAL)
             return dll
-        except Exception, exc:
+        except Exception as exc:
             error = exc
 
     error_msg = "\nFailed to load shared library:%s\n\ndlopen() error: %s\n" % (lib , error)

--- a/python/python/cwrap/metacwrap.py
+++ b/python/python/cwrap/metacwrap.py
@@ -17,7 +17,7 @@
 import re
 from types import MethodType
 
-from .prototype import registerType, Prototype
+from .prototype import Prototype
 
 
 def snakeCase(name):
@@ -43,13 +43,13 @@ class MetaCWrap(type):
         if hasattr(cls, "storageType"):
             storage_type = cls.storageType()
 
-        registerType(type_name, cls, is_return_type=is_return_type, storage_type=storage_type)
+        Prototype.registerType(type_name, cls, is_return_type=is_return_type, storage_type=storage_type)
 
         if hasattr(cls, "createCReference"):
-            registerType("%s_ref" % type_name, cls.createCReference, is_return_type=True, storage_type=storage_type)
+            Prototype.registerType("%s_ref" % type_name, cls.createCReference, is_return_type=True, storage_type=storage_type)
 
         if hasattr(cls, "createPythonObject"):
-            registerType("%s_obj" % type_name, cls.createPythonObject, is_return_type=True, storage_type=storage_type)
+            Prototype.registerType("%s_obj" % type_name, cls.createPythonObject, is_return_type=True, storage_type=storage_type)
 
 
         for key, attr in attrs.items():

--- a/python/python/cwrap/prototype.py
+++ b/python/python/cwrap/prototype.py
@@ -31,7 +31,7 @@ REGISTERED_TYPES = {}
 """:type: dict[str,TypeDefinition]"""
 
 
-def registerType(type_name, type_class_or_function, is_return_type=True, storage_type=None):
+def _registerType(type_name, type_class_or_function, is_return_type=True, storage_type=None):
     if type_name in REGISTERED_TYPES:
         raise PrototypeError("Type: '%s' already registered!" % type_name)
 
@@ -39,28 +39,28 @@ def registerType(type_name, type_class_or_function, is_return_type=True, storage
 
     # print("Registered: %s for class: %s" % (type_name, repr(type_class_or_function)))
 
-registerType("void", None)
-registerType("void*", ctypes.c_void_p)
-registerType("uint", ctypes.c_uint)
-registerType("uint*", ctypes.POINTER(ctypes.c_uint))
-registerType("int", ctypes.c_int)
-registerType("int*", ctypes.POINTER(ctypes.c_int))
-registerType("int64", ctypes.c_int64)
-registerType("int64*", ctypes.POINTER(ctypes.c_int64))
-registerType("size_t", ctypes.c_size_t)
-registerType("size_t*", ctypes.POINTER(ctypes.c_size_t))
-registerType("bool", ctypes.c_bool)
-registerType("bool*", ctypes.POINTER(ctypes.c_bool))
-registerType("long", ctypes.c_long)
-registerType("long*", ctypes.POINTER(ctypes.c_long))
-registerType("char", ctypes.c_char)
-registerType("char*", ctypes.c_char_p)
-registerType("char**", ctypes.POINTER(ctypes.c_char_p))
-registerType("float", ctypes.c_float)
-registerType("float*", ctypes.POINTER(ctypes.c_float))
-registerType("double", ctypes.c_double)
-registerType("double*", ctypes.POINTER(ctypes.c_double))
-registerType("py_object", ctypes.py_object)
+_registerType("void", None)
+_registerType("void*", ctypes.c_void_p)
+_registerType("uint", ctypes.c_uint)
+_registerType("uint*", ctypes.POINTER(ctypes.c_uint))
+_registerType("int", ctypes.c_int)
+_registerType("int*", ctypes.POINTER(ctypes.c_int))
+_registerType("int64", ctypes.c_int64)
+_registerType("int64*", ctypes.POINTER(ctypes.c_int64))
+_registerType("size_t", ctypes.c_size_t)
+_registerType("size_t*", ctypes.POINTER(ctypes.c_size_t))
+_registerType("bool", ctypes.c_bool)
+_registerType("bool*", ctypes.POINTER(ctypes.c_bool))
+_registerType("long", ctypes.c_long)
+_registerType("long*", ctypes.POINTER(ctypes.c_long))
+_registerType("char", ctypes.c_char)
+_registerType("char*", ctypes.c_char_p)
+_registerType("char**", ctypes.POINTER(ctypes.c_char_p))
+_registerType("float", ctypes.c_float)
+_registerType("float*", ctypes.POINTER(ctypes.c_float))
+_registerType("double", ctypes.c_double)
+_registerType("double*", ctypes.POINTER(ctypes.c_double))
+_registerType("py_object", ctypes.py_object)
 
 PROTOTYPE_PATTERN = "(?P<return>[a-zA-Z][a-zA-Z0-9_*]*) +(?P<function>[a-zA-Z]\w*) *[(](?P<arguments>[a-zA-Z0-9_*, ]*)[)]"
 
@@ -160,4 +160,7 @@ class Prototype(object):
 
     @classmethod
     def registerType(cls, type_name, type_class_or_function, is_return_type=True, storage_type=None):
-        registerType(type_name, type_class_or_function, is_return_type=is_return_type, storage_type=storage_type)
+        _registerType(type_name,
+                      type_class_or_function,
+                      is_return_type = is_return_type,
+                      storage_type   = storage_type)

--- a/python/python/ert/enkf/node_id.py
+++ b/python/python/ert/enkf/node_id.py
@@ -1,5 +1,5 @@
 from ctypes import Structure, c_int
-from cwrap.prototype import registerType
+from cwrap import Prototype
 
 class NodeId(Structure):
     """
@@ -15,4 +15,4 @@ class NodeId(Structure):
         """
         super(NodeId, self).__init__(report_step, realization_number)
 
-registerType( "node_id" , NodeId )
+Prototype.registerType( "node_id" , NodeId )

--- a/python/python/ert_gui/ertwidgets/analysismodulevariablespanel.py
+++ b/python/python/ert_gui/ertwidgets/analysismodulevariablespanel.py
@@ -79,7 +79,7 @@ class AnalysisModuleVariablesPanel(QWidget):
             sorted_list.__delitem__(pos + 1)
 
         for item in sorted_list:
-            if item <> "#":
+            if item != "#":
                 result.append(item)
 
         return result

--- a/python/tests/core/cwrap/test_metawrap.py
+++ b/python/tests/core/cwrap/test_metawrap.py
@@ -4,7 +4,6 @@ from types import StringType, IntType
 import ert
 from cwrap import BaseCClass, Prototype, PrototypeError
 from ert.test import ExtendedTestCase
-import cwrap.clib as clib
 
 
 # Local copies so that the real ones don't get changed
@@ -22,11 +21,11 @@ class StringList(BaseCClass):
     TYPE_NAME = "test_stringlist"
 
     __len__ = BoundTestUtilPrototype("int stringlist_get_size(test_stringlist)")
-    free = BoundTestUtilPrototype("void stringlist_free(test_stringlist)")
+    free    = BoundTestUtilPrototype("void stringlist_free(test_stringlist)")
 
-    _alloc = TestUtilPrototype("void* stringlist_alloc_new()")
-    _iget = TestUtilPrototype("char* stringlist_iget(test_stringlist, int)")
-    _append = TestUtilPrototype("void stringlist_append_copy(test_stringlist, char*)")
+    _alloc  = TestUtilPrototype("void* stringlist_alloc_new()", bind = False)
+    _iget   = TestUtilPrototype("char* stringlist_iget(test_stringlist, int)")
+    _append = TestUtilPrototype("void  stringlist_append_copy(test_stringlist, char*)")
 
     def __init__(self, initial=None):
         c_ptr = self._alloc()

--- a/python/tests/core/ecl/test_ecl_sum.py
+++ b/python/tests/core/ecl/test_ecl_sum.py
@@ -48,7 +48,7 @@ class EclSumTest(ExtendedTestCase):
         with self.assertRaises(KeyError):
             ecl_sum_vector.addKeyword("MISSING")
 
-        dtime = datetime.datetime( 2002 , 01 , 01 , 0 , 0 , 0 )
+        dtime = datetime.datetime( 2002 , 1 , 1 , 0 , 0 , 0 )
         with TestAreaContext("EclSum/csv_dump"):
             test_file_name = self.createTestPath("dump.csv")
             outputH = open(test_file_name , "w")

--- a/python/tests/import_tester.py
+++ b/python/tests/import_tester.py
@@ -7,7 +7,11 @@ class ImportTester(object):
     @staticmethod
     def testImport(module):
         try:
-            # print(module)
+            if '__pycache__' in str(module):
+                # python 3 hack
+                return True
+            else:
+                print('Importing module %s.' % str(module))
             __import__(module)
             return True
         except ImportError:


### PR DESCRIPTION
1. python3 fixes
** fix `except Exception, err`
** remove use of spaceship operator `<>`
** make import test python 3 compatible; do not import `__pycache__`
1. renamed `registerType` to `_registerType`, do not use outside `cwrap` module!
1. removed tests from `cwrap` of functionality covered in `test_metacwrap`
