### PR TITLE
Python3 compatibility and types (Scheduled for 2.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
     - conda update -q conda
     # Useful for debugging any issues with conda
     - conda info -a
-    - conda install pyqt=4 scipy=0.16.1 numpy pandas matplotlib
+    - conda install pyqt=4 scipy=0.16.1 numpy pandas matplotlib future
 
 env:
   global:

--- a/python/python/cwrap/basecclass.py
+++ b/python/python/cwrap/basecclass.py
@@ -22,9 +22,8 @@ import six
 import ctypes
 from .metacwrap import MetaCWrap
 
-#@six.add_metaclass(MetaCWrap) # For Python2/3 compatibility
+@six.add_metaclass(MetaCWrap)
 class BaseCClass(object):
-    __metaclass__ = MetaCWrap
     namespaces = {}
 
     def __init__(self, c_pointer, parent=None, is_reference=False):

--- a/python/python/cwrap/basecclass.py
+++ b/python/python/cwrap/basecclass.py
@@ -14,16 +14,21 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+import six
+
 import ctypes
 from .metacwrap import MetaCWrap
 
+#@six.add_metaclass(MetaCWrap) # For Python2/3 compatibility
 class BaseCClass(object):
     __metaclass__ = MetaCWrap
-
     namespaces = {}
 
     def __init__(self, c_pointer, parent=None, is_reference=False):
-        if c_pointer == 0 or c_pointer is None:
+        if not c_pointer:
             raise ValueError("Must have a valid (not null) pointer value!")
 
         if c_pointer < 0:
@@ -46,13 +51,6 @@ class BaseCClass(object):
 
     def _ad_str(self):
         return 'at 0x%x' % self._address()
-
-    @classmethod
-    def cNamespace(cls):
-        """ @rtype: CNamespace """
-        if cls not in BaseCClass.namespaces:
-            BaseCClass.namespaces[cls] = CNamespace(cls.__name__)
-        return BaseCClass.namespaces[cls]
 
     @classmethod
     def from_param(cls, c_class_object):
@@ -136,7 +134,7 @@ class BaseCClass(object):
             if not self.__is_reference:
                 # Important to check the c_pointer; in the case of failed object creation
                 # we can have a Python object with c_pointer == None.
-                if self.__c_pointer > 0:
+                if self.__c_pointer:
                     self.free()
 
     def _invalidateCPointer(self):

--- a/python/python/cwrap/basecenum.py
+++ b/python/python/cwrap/basecenum.py
@@ -21,9 +21,8 @@ import six
 import ctypes
 from .metacwrap import MetaCWrap
 
-# @six.add_metaclass(MetaCWrap) # For Python2/3 compatibility
+@six.add_metaclass(MetaCWrap)
 class BaseCEnum(object):
-    __metaclass__ = MetaCWrap
     enum_namespace = {}
 
     def __init__(self, *args, **kwargs):

--- a/python/python/cwrap/basecenum.py
+++ b/python/python/cwrap/basecenum.py
@@ -14,10 +14,14 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import six
+
 import ctypes
 from .metacwrap import MetaCWrap
 
-
+# @six.add_metaclass(MetaCWrap) # For Python2/3 compatibility
 class BaseCEnum(object):
     __metaclass__ = MetaCWrap
     enum_namespace = {}
@@ -48,6 +52,7 @@ class BaseCEnum(object):
 
     @classmethod
     def addEnum(cls, name, value):
+        name = str(name)
         if not isinstance(value, int):
             raise ValueError("Value must be an integer!")
 

--- a/python/python/cwrap/basecvalue.py
+++ b/python/python/cwrap/basecvalue.py
@@ -14,13 +14,20 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from ctypes import pointer, c_long, c_int, c_bool, c_float, c_double, c_byte, \
-    c_short, c_char, c_ubyte, c_ushort, c_uint, c_ulong
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+import six
+
+from ctypes import (pointer, c_long, c_int, c_bool, c_float, c_double, c_byte,
+                    c_short, c_char, c_ubyte, c_ushort, c_uint, c_ulong)
 
 from .metacwrap import MetaCWrap
 
+# @six.add_metaclass(MetaCWrap) # For Python2/3 compatibility
 class BaseCValue(object):
     __metaclass__ = MetaCWrap
+
     DATA_TYPE = None
     LEGAL_TYPES = [c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint, c_long, c_ulong, c_bool, c_char, c_float, c_double]
 

--- a/python/python/cwrap/basecvalue.py
+++ b/python/python/cwrap/basecvalue.py
@@ -24,10 +24,8 @@ from ctypes import (pointer, c_long, c_int, c_bool, c_float, c_double, c_byte,
 
 from .metacwrap import MetaCWrap
 
-# @six.add_metaclass(MetaCWrap) # For Python2/3 compatibility
+@six.add_metaclass(MetaCWrap)
 class BaseCValue(object):
-    __metaclass__ = MetaCWrap
-
     DATA_TYPE = None
     LEGAL_TYPES = [c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint, c_long, c_ulong, c_bool, c_char, c_float, c_double]
 

--- a/python/python/cwrap/cfile.py
+++ b/python/python/cwrap/cfile.py
@@ -15,7 +15,8 @@
 #  for more details.
 
 import ctypes
-from .prototype import Prototype
+import six
+from .prototype import Prototype, PrototypeError
 from .basecclass import BaseCClass
 
 class CFILE(BaseCClass):

--- a/python/python/cwrap/metacwrap.py
+++ b/python/python/cwrap/metacwrap.py
@@ -14,6 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+import six
+
 import re
 from types import MethodType
 
@@ -59,4 +63,5 @@ class MetaCWrap(type):
 
                 if attr.shouldBeBound():
                     method = MethodType(attr, None, cls)
+                    #method = six.create_bound_method(attr, cls)
                     setattr(cls, key, method)

--- a/python/python/ert/ecl/ecl_3dkw.py
+++ b/python/python/ert/ecl/ecl_3dkw.py
@@ -14,8 +14,10 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details. 
 
-from __future__ import print_function
-from ecl_kw import EclKW
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+from .ecl_kw import EclKW
 
 class Ecl3DKW(EclKW):
     """

--- a/python/python/ert/ecl/ecl_file_view.py
+++ b/python/python/ert/ecl/ecl_file_view.py
@@ -1,4 +1,5 @@
-import types
+from __future__ import absolute_import, division, print_function, unicode_literals
+from six import string_types
 from cwrap import BaseCClass
 from ert.ecl import EclPrototype, EclKW
 from ert.util import CTime
@@ -64,7 +65,7 @@ class EclFileView(BaseCClass):
                ....
         """
 
-        if isinstance( index , types.IntType):
+        if isinstance( index , int):
             if index < 0 or index >= len(self):
                 raise IndexError
             else:
@@ -78,7 +79,9 @@ class EclFileView(BaseCClass):
                 kw_list.append( self[i] )
             return kw_list
         else:
-            if isinstance( index , types.StringType):
+            if isinstance( index , bytes):
+                index = index.decode('ascii')
+            if isinstance( index , string_types):
                 if index in self:
                     kw_index = index
                     kw_list = []

--- a/python/python/ert/ecl/ecl_file_view.py
+++ b/python/python/ert/ecl/ecl_file_view.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from six import string_types
 from cwrap import BaseCClass
-from ert.ecl import EclPrototype, EclKW
+from ert.ecl import EclPrototype
 from ert.util import CTime
 
 class EclFileView(BaseCClass):
@@ -24,7 +24,8 @@ class EclFileView(BaseCClass):
         return self._iget_kw( index ).setParent( parent = self )
 
 
-    
+    def __repr__(self):
+        return 'EclFileView(size = %d) %s' % (len(self), self._ad_str())
 
     def iget_named_kw(self, kw_name , index):
         if not kw_name in self:

--- a/python/python/ert/ecl/ecl_kw.py
+++ b/python/python/ert/ecl/ecl_kw.py
@@ -37,8 +37,10 @@ files. This module also has (some) support for working with GRDECL
 The ecl_kw.py implementation wraps the ecl_kw.c implementation from
 the libecl library.
 """
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import ctypes
-import types
 import warnings
 
 import  numpy
@@ -496,7 +498,7 @@ class EclKW(BaseCClass):
         """
         Function to support index based assignment: kw[index] = value
         """
-        if isinstance( index , types.IntType):
+        if isinstance( index , int):
             length = len(self)
             if index < 0:
                 # Will only wrap backwards once

--- a/python/python/ert/ecl/ecl_rft.py
+++ b/python/python/ert/ecl/ecl_rft.py
@@ -17,7 +17,8 @@
 Module for loading ECLIPSE RFT files.
 """
 
-import types
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import warnings
 from cwrap import BaseCClass
 from ert.ecl import EclRFTCell, EclPLTCell, EclPrototype
@@ -164,7 +165,7 @@ class EclRFT(BaseCClass):
 
 
     def assert_cell_index( self , index ):
-        if isinstance( index , types.IntType):
+        if isinstance( index , int):
             length = self.__len__()
             if index < 0 or index >= length:
                 raise IndexError

--- a/python/python/ert/enkf/obs_data.py
+++ b/python/python/ert/enkf/obs_data.py
@@ -1,4 +1,22 @@
-from types import NoneType
+#  Copyright (C) 2016  Statoil ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
 from cwrap import BaseCClass
 from ert.enkf import EnkfPrototype
 from ert.util import Matrix
@@ -82,10 +100,9 @@ class ObsData(BaseCClass):
 
     def scale(self, S, E=None, D=None, R=None, D_obs=None):
         assert isinstance(S, Matrix)
-        assert isinstance(E, (Matrix, NoneType))
-        assert isinstance(D, (Matrix, NoneType))
-        assert isinstance(R, (Matrix, NoneType))
-        assert isinstance(D_obs, (Matrix, NoneType))
+        for X in (E,D,R,D_obs):
+            if X is not None:
+                assert isinstance(X, Matrix)
         self._scale(S, E, D, R, D_obs)
 
 

--- a/python/python/ert/job_queue/queue.py
+++ b/python/python/ert/job_queue/queue.py
@@ -24,7 +24,7 @@ import sys
 import time
 import ctypes
 
-from cwrap import BaseCClass,BaseCEnum
+from cwrap import BaseCClass
 
 from ert.job_queue import QueuePrototype
 from ert.job_queue import Job, JobStatusType

--- a/python/python/ert/job_queue/queue.py
+++ b/python/python/ert/job_queue/queue.py
@@ -17,8 +17,10 @@
 Module implementing a queue for managing external jobs.
 
 """
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
-from types import StringType, IntType
 import time
 import ctypes
 

--- a/python/python/ert/rms/rms.py
+++ b/python/python/ert/rms/rms.py
@@ -1,1 +1,1 @@
-import librms
+from .librms import *

--- a/python/python/ert/server/ertrpcclient.py
+++ b/python/python/ert/server/ertrpcclient.py
@@ -1,5 +1,8 @@
 import socket
-from xmlrpclib import ServerProxy, Fault
+try:
+    from xmlrpclib import ServerProxy, Fault
+except ImportError:
+    from xmlrpc.client import ServerProxy, Fault
 
 FAULT_CODES = {1: UserWarning,
                2: KeyError,

--- a/python/python/ert/server/ertrpcserver.py
+++ b/python/python/ert/server/ertrpcserver.py
@@ -33,8 +33,7 @@ class Session:
         self.batch_number = 0
         self.lock = Lock()
 
-
-INVERSE_FAULT_CODES = {value:key for key, value in FAULT_CODES.iteritems()}
+INVERSE_FAULT_CODES = {value:key for key, value in FAULT_CODES.items()}
 
 def createFault(error, message):
     error_code = INVERSE_FAULT_CODES[error]
@@ -183,7 +182,7 @@ class ErtRPCServer(SimpleXMLRPCServer):
                 data_node.load(self._getInitializationCase(), init_id)
                 data_node.save(target_fs, run_id)
 
-        for key, value in keywords.iteritems():
+        for key, value in keywords.items():
             config_node = ens_config[kw]
             data_node = EnkfNode( config_node )
 
@@ -295,7 +294,7 @@ class ErtRPCServer(SimpleXMLRPCServer):
             raise createFault(UserWarning, "The CustomKW with group name: '%s' already exist!" % group_name)
 
         converted_definition = {}
-        for key, value in storage_definition.iteritems():
+        for key, value in storage_definition.items():
             if value == "str":
                 converted_definition[key] = str
             elif value == "float":

--- a/python/python/ert/server/ertrpcserver.py
+++ b/python/python/ert/server/ertrpcserver.py
@@ -1,7 +1,13 @@
 import os
-from SimpleXMLRPCServer import SimpleXMLRPCServer
 from threading import Lock
-from xmlrpclib import Fault
+
+try:
+    from SimpleXMLRPCServer import SimpleXMLRPCServer
+    from xmlrpclib import Fault
+except ImportError:
+    from xmlrpc.server import SimpleXMLRPCServer
+    from xmlrpc.client import Fault
+
 
 from ert import Version
 from ert.enkf import EnKFMain, NodeId

--- a/python/python/ert/util/__init__.py
+++ b/python/python/ert/util/__init__.py
@@ -36,6 +36,9 @@ The modules included in the util package are:
    
 """
 
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
 import ert
 from cwrap import Prototype
 

--- a/python/python/ert/util/profiler.py
+++ b/python/python/ert/util/profiler.py
@@ -1,4 +1,10 @@
-import StringIO
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 import cProfile
 import pstats
 import sys
@@ -18,7 +24,7 @@ class Profiler(object):
     def stopProfiler(cls, sort_method="cumulative"):
         if cls.__profiler is not None:
             cls.__profiler.disable()
-            stream = StringIO.StringIO()
+            stream = StringIO()
             stats_printer = pstats.Stats(cls.__profiler, stream=stream).sort_stats(sort_method)
             stats_printer.print_stats()
             cls.__profiler = None

--- a/python/python/ert/util/stringlist.py
+++ b/python/python/ert/util/stringlist.py
@@ -213,6 +213,12 @@ class StringList(BaseCClass):
         buffer += "]"
         return buffer
 
+    def __repr__(self):
+        return 'StringList(size = %d) %s' % (len(self), self._ad_str())
+
+    def empty(self):
+        """Returns true if and only if list is empty."""
+        return len(self) == 0
 
     def pop(self):
         """
@@ -220,10 +226,10 @@ class StringList(BaseCClass):
         
         Will raise IndexError if list is empty.
         """
-        if len(self):
+        if not self.empty():
             return self._pop()
         else:
-            raise IndexError("pop() failed - the list is empty")
+            raise IndexError("List empty.  Cannot call pop().")
 
 
     def append(self, s):
@@ -231,11 +237,13 @@ class StringList(BaseCClass):
         Appends a new string @s to list. If the input argument is not a
         string the string representation will be appended.
         """
-        if isinstance(s, str):
+        if isinstance(s, bytes):
+            s.decode('ascii')
+        if isinstance(s, string_types):
             self._append(s)
         else:
             self._append(str(s))
-            
+
 
     @property
     def strings(self):
@@ -255,10 +263,10 @@ class StringList(BaseCClass):
         """
         Will return the last element in list. Raise IndexError if empty.
         """
-        if len(self) > 0:
+        if not self.empty():
             return self._last()
         else:
-            raise IndexError("The list is empty")
+            raise IndexError("List empty.  No such element last().")
 
 
     def sort(self, cmp_flag=0):
@@ -288,13 +296,13 @@ class StringList(BaseCClass):
 
 
     def front(self):
-        if len(self) > 0:
+        if not self.empty():
             return self._front()
         else:
-            raise IndexError
+            raise IndexError('List empty.  No such element front().')
 
     def back(self):
-        if len(self) > 0:
+        if not self.empty():
             return self._back()
         else:
-            raise IndexError
+            raise IndexError('List empty.  No such element back().')

--- a/python/python/ert/util/ui_return.py
+++ b/python/python/ert/util/ui_return.py
@@ -14,10 +14,13 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
 #  for more details.
 
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
 from cwrap import BaseCClass
 from ert.util import UtilPrototype
-from enums import UIReturnStatusEnum
-    
+from .enums import UIReturnStatusEnum
+
 
 class UIReturn(BaseCClass):
     TYPE_NAME = "ui_return"

--- a/python/python/ert/util/vector_template.py
+++ b/python/python/ert/util/vector_template.py
@@ -40,8 +40,9 @@ The C-level has implementations for several fundamental types like
 float and size_t not currently implemented in the Python version.
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import  sys
-from    types import IntType, SliceType
 
 from cwrap import CFILE, BaseCClass
 from ert.util import UtilPrototype
@@ -178,14 +179,14 @@ class VectorTemplate(BaseCClass):
         """
 
         s = ""
-        lines = len(self) / width
+        lines = len(self) // width
         if not fmt:
             fmt = self.default_format + " "
 
         if max_lines is None or lines <= max_lines:
             s += self.str_data(width, 0, len(self), fmt)
         else:
-            s1 = width * max_lines / 2
+            s1 = width * max_lines // 2
             s += self.str_data(width, 0, s1, fmt)
             s += "   ....   \n"
             s += self.str_data(width, len(self) - s1, len(self), fmt)
@@ -203,7 +204,7 @@ class VectorTemplate(BaseCClass):
         """
         Implements read [] operator - @index can be slice instance.
         """
-        if isinstance(index, IntType):
+        if isinstance(index, int):
             length = len(self)
             idx = index
             if idx < 0:
@@ -213,7 +214,7 @@ class VectorTemplate(BaseCClass):
                 return self._iget(idx)
             else:
                 raise IndexError('Index must be in range %d <= %d < %d.' % (0, index, length))
-        elif isinstance(index, SliceType):
+        elif isinstance(index, slice):
             return self.strided_copy(index)
         else:
             raise TypeError("Index should be integer or slice type.")
@@ -223,7 +224,7 @@ class VectorTemplate(BaseCClass):
         Implements write [] operator - @index must be integer or slice.
         """
         ls = len(self)
-        if isinstance(index, IntType):
+        if isinstance(index, int):
             idx = index
             if idx < 0:
                 idx += ls
@@ -232,7 +233,7 @@ class VectorTemplate(BaseCClass):
             for i in range(*index.indices(ls)):
                 self[i] = value
         else:
-            raise TypeError("Index should be integer type, not %s." % type(index))
+            raise TypeError("Index should be integer type")
 
     ##################################################################
     # Mathematical operations:

--- a/python/tests/core/util/test_string_list.py
+++ b/python/tests/core/util/test_string_list.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 try:
     from unittest2 import TestCase
 except ImportError:

--- a/python/tests/core/util/test_string_list.py
+++ b/python/tests/core/util/test_string_list.py
@@ -85,7 +85,9 @@ class StringListTest(TestCase):
         self.assertFalse(s1 == ["A","B","D"])
         self.assertFalse(s1 == ["A","B","C" , "D"])
 
-        
+        pfx = 'StringList(size' # __repr__
+        self.assertEqual(pfx, repr(s2)[:len(pfx)])
+
     def test_append_not_string(self):
         s = StringList()
         s.append(10)

--- a/python/tests/cwrap/test_metawrap.py
+++ b/python/tests/cwrap/test_metawrap.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from six import string_types
 import ctypes
-from types import StringType, IntType
 
 import ert
 from cwrap import BaseCClass, Prototype, PrototypeError
@@ -33,13 +34,15 @@ class StringList(BaseCClass):
 
         if initial:
             for s in initial:
-                if isinstance(s, StringType):
+                if isinstance(s, bytes):
+                    s.decode('ascii')
+                if isinstance(s, string_types):
                     self.append(s)
                 else:
                     raise TypeError("Item: %s not a string" % s)
 
     def __getitem__(self, index):
-        if isinstance(index, IntType):
+        if isinstance(index, int):
             length = len(self)
             if index < 0:
                 index += length
@@ -51,7 +54,9 @@ class StringList(BaseCClass):
             raise TypeError("Index should be integer type")
 
     def append(self, string):
-        if isinstance(string, StringType):
+        if isinstance(string, bytes):
+            s.decode('ascii')
+        if isinstance(string, string_types):
             self._append(self, string)
         else:
             self._append(self, str(string))
@@ -109,10 +114,10 @@ class MetaWrapTest(ExtendedTestCase):
             char_ptr = ctypes.c_char_p(c_ptr)
             python_string = char_ptr.value
             TestUtilPrototype.lib.free(c_ptr)
-            return python_string
+            return python_string.decode('ascii')
 
         Prototype.registerType("string_obj", stringObj)
 
         dateStamp  = TestUtilPrototype("string_obj util_alloc_date_stamp_utc()")
         date_stamp = dateStamp()
-        self.assertIsInstance(date_stamp, str)
+        self.assertIsInstance(date_stamp, string_types)

--- a/python/tests/gui/ertshell/ert_shell_test_context.py
+++ b/python/tests/gui/ertshell/ert_shell_test_context.py
@@ -1,4 +1,7 @@
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import os
 import sys
 from ert.test import TestAreaContext


### PR DESCRIPTION
We use `six.string_types` instead of `str` and `types.StringType`.  This is python2/3 compatible.

We also use `@six.metaclass` over `__metaclass__`, python2/3 compatible.