### PR TITLE
Added slicing for runpath_list

### DIFF
--- a/python/python/ert/enkf/runpath_list.py
+++ b/python/python/ert/enkf/runpath_list.py
@@ -6,39 +6,49 @@ RunpathNode = namedtuple("RunpathNode", ["realization", "iteration", "runpath", 
 
 class RunpathList(BaseCClass):
     TYPE_NAME = "runpath_list"
-    _alloc = EnkfPrototype("void* runpath_list_alloc(char*)" , bind = False)
-    _free = EnkfPrototype("void runpath_list_free(runpath_list)")
-    _add = EnkfPrototype("void runpath_list_add(runpath_list, int, int, char*, char*)")
-    _clear = EnkfPrototype("void runpath_list_clear(runpath_list)")
-    _size = EnkfPrototype("int runpath_list_size(runpath_list)")
-    _iens = EnkfPrototype("int runpath_list_iget_iens(runpath_list, int)")
-    _iteration = EnkfPrototype("int runpath_list_iget_iter(runpath_list, int)")
-    _runpath = EnkfPrototype("char* runpath_list_iget_runpath(runpath_list, int)")
-    _basename = EnkfPrototype("char* runpath_list_iget_basename(runpath_list, int)")
-    _export = EnkfPrototype("void runpath_list_fprintf(runpath_list)")
-    
+    _alloc     = EnkfPrototype("void* runpath_list_alloc(char*)" , bind = False)
+    _free      = EnkfPrototype("void  runpath_list_free(runpath_list)")
+    _add       = EnkfPrototype("void  runpath_list_add(runpath_list, int, int, char*, char*)")
+    _clear     = EnkfPrototype("void  runpath_list_clear(runpath_list)")
+    _size      = EnkfPrototype("int   runpath_list_size(runpath_list)")
+    _iens      = EnkfPrototype("int   runpath_list_iget_iens(runpath_list, int)")
+    _iteration = EnkfPrototype("int   runpath_list_iget_iter(runpath_list, int)")
+    _runpath   = EnkfPrototype("char* runpath_list_iget_runpath(runpath_list, int)")
+    _basename  = EnkfPrototype("char* runpath_list_iget_basename(runpath_list, int)")
+    _export    = EnkfPrototype("void  runpath_list_fprintf(runpath_list)")
+
     _get_export_file = EnkfPrototype("char* runpath_list_get_export_file(runpath_list)")
     _set_export_file = EnkfPrototype("void runpath_list_set_export_file(runpath_list, char*)")
-    
+
     def __init__(self, export_file):
         c_ptr = self._alloc( export_file )
-        super(RunpathList , self).__init__(c_ptr)
+        if c_ptr:
+            super(RunpathList , self).__init__(c_ptr)
+        else:
+            raise ValueError('Could not construct RunpathList with export_file "%s".' % export_file)
 
     def __len__(self):
         return self._size( )
 
     def __getitem__(self, index):
         """ @rtype: RunpathNode """
-        if not 0 <= index < len(self):
-            raise IndexError("Index not in range: 0 <= %d < %d" % (index, len(self)))
+        ls = len(self)
+        if isinstance(index, int):
+            idx = index
+            if idx < 0:
+                idx += ls
+            if not 0 <= idx < ls:
+                raise IndexError("Index not in range: 0 <= %d < %d" % (index, ls))
+            realization = self._iens(idx)
+            iteration   = self._iteration(idx)
+            runpath     = self._runpath(idx)
+            basename    = self._basename(idx)
+            return RunpathNode(realization, iteration, runpath, basename)
+        elif isinstance(index, slice):
+            return [self[i] for i in range(*index.indices(ls))]
+        raise TypeError('List indices must be integers, not %s.' % str(type(index)))
 
-        realization = self._iens(index)
-        iteration   = self._iteration(index)
-        runpath     = self._runpath(index)
-        basename    = self._basename(index)
 
-        return RunpathNode(realization, iteration, runpath, basename)
-    
     def __iter__(self):
         index = 0
         while index < len(self):
@@ -69,7 +79,8 @@ class RunpathList(BaseCClass):
     def free(self):
         self._free( )
 
+    def __repr__(self):
+        return 'RunpathList(size = %d) %s' % (len(self), self._ad_str())
 
     def export(self):
         self._export( )
-

--- a/python/tests/ert/enkf/test_runpath_list.py
+++ b/python/tests/ert/enkf/test_runpath_list.py
@@ -6,20 +6,10 @@ from ert.test import ExtendedTestCase, TestAreaContext,ErtTestContext
 from ert.enkf import RunpathList, RunpathNode
 from ert.util import BoolVector
 
-from cwrap import Prototype
-
-class _TestRunpathListPrototype(Prototype):
-    lib = ert.load('libenkf')
-
-    def __init__(self, prototype, bind=True):
-        super(_TestRunpathListPrototype, self).__init__(_TestRunpathListPrototype.lib, prototype, bind=bind)
-
 class RunpathListTest(ExtendedTestCase):
 
-    _runpath_list_alloc = _TestRunpathListPrototype("runpath_list_obj runpath_list_alloc(char*)", bind = False)
-
     def test_runpath_list(self):
-        runpath_list = self._runpath_list_alloc("")
+        runpath_list = RunpathList('')
 
         self.assertEqual(len(runpath_list), 0)
 
@@ -46,7 +36,48 @@ class RunpathListTest(ExtendedTestCase):
         self.assertEqual(len(runpath_list), 0)
 
 
-        
+    def test_collection(self):
+        """Testing len, adding, getting (idx and slice), printing, clearing."""
+        def path(idx):
+            return 'path_%d' % idx
+        def base(idx):
+            return 'base_%d' % idx
+        with TestAreaContext("runpath_list"):
+            runpath_list = RunpathList("EXPORT.txt")
+            runpath_list.add( 3 , 1 , path(3) , base(3) )
+            runpath_list.add( 1 , 1 , path(1) , base(1) )
+            runpath_list.add( 2 , 1 , path(2) , base(2) )
+            runpath_list.add( 0 , 0 , path(0) , base(0) )
+            runpath_list.add( 3 , 0 , path(3) , base(3) )
+            runpath_list.add( 1 , 0 , path(1) , base(1) )
+            runpath_list.add( 2 , 0 , path(2) , base(2) )
+            runpath_list.add( 0 , 1 , path(0) , base(0) )
+
+            self.assertEqual(8, len(runpath_list))
+            pfx = 'RunpathList(size' # the __repr__ function
+            self.assertEqual(pfx, repr(runpath_list)[:len(pfx)])
+            node2 = RunpathNode(2, 1 , path(2), base(2))
+            self.assertEqual(node2, runpath_list[2])
+
+            node3 = RunpathNode(0,0,path(0),base(0))
+            node4 = RunpathNode(3,0,path(3),base(3))
+            node5 = RunpathNode(1,0,path(1),base(1))
+            node6 = RunpathNode(2,0,path(2),base(2))
+            nodeslice = [node3, node4, node5, node6]
+            self.assertEqual(nodeslice, runpath_list[3:7])
+            self.assertEqual(node6, runpath_list[-2])
+            with self.assertRaises(TypeError):
+                runpath_list["key"]
+            with self.assertRaises(IndexError):
+                runpath_list[12]
+
+            runpath_list.clear()
+            self.assertEqual(0, len(runpath_list))
+            with self.assertRaises(IndexError):
+                runpath_list[0]
+            self.assertEqual('EXPORT.txt', runpath_list.getExportFile())
+
+
     def test_sorted_export(self):
         with TestAreaContext("runpath_list"):
             runpath_list = RunpathList("EXPORT.txt")


### PR DESCRIPTION
* removed TestPrototyping from runpath_list, use standard constructor
* added a test_collection to runpath_list test, testing slicing ++

This PR is mainly for ease of debugging failures in the `RunpathList` test suite occurring possibly because of file sync issues:  I removed the ad-hoc prototyping from RunpathList (prototyping is tested elsewhere) and instead just use the constructor.

Also added `__getitem__(self, slice)` and tests, as well as `__repr__` and test.