### PR TITLE
implemented missing function hook_manager_get_runpath_list

### DIFF
--- a/python/python/ert/enkf/hook_manager.py
+++ b/python/python/ert/enkf/hook_manager.py
@@ -7,6 +7,7 @@ class HookManager(BaseCClass):
     TYPE_NAME = "hook_manager"
 
     _get_runpath_list_file = EnkfPrototype("char* hook_manager_get_runpath_list_file(hook_manager)")
+    _get_runpath_list      = EnkfPrototype("runpath_list_ref  hook_manager_get_runpath_list(hook_manager)")
     _iget_hook_workflow    = EnkfPrototype("hook_workflow_ref hook_manager_iget_hook_workflow(hook_manager, int)")
     _size                  = EnkfPrototype("int hook_manager_get_size(hook_manager)")
 
@@ -18,7 +19,7 @@ class HookManager(BaseCClass):
         return self._size()
 
     def __repr__(self):
-        return 'HookManager(len = %d) at 0x%x' % (len(self), self._address())
+        return 'HookManager(size = %d) %s' % (len(self), self._ad_str())
 
     def __getitem__(self, index):
         """ @rtype: Hook workflow """

--- a/python/tests/ert/enkf/test_enkf_obs.py
+++ b/python/tests/ert/enkf/test_enkf_obs.py
@@ -188,8 +188,29 @@ class EnKFObsTest(ExtendedTestCase):
         self.assertEqual( len(obs) , 35 )
         self.assertTrue( "RFT2" in obs )
 
+    def test_hookmanager_runpathlist(self):
+        with ErtTestContext("obs_test", self.config_file) as test_context:
+            ert = test_context.getErt()
+            pfx = 'EnKFMain('
+            self.assertEqual(repr(ert)[:len(pfx)], pfx)
 
-        
+            hm = ert.getHookManager()
+            pfx = 'HookManager(size = '
+            self.assertEqual(repr(hm)[:len(pfx)], pfx)
+
+            rpl = hm.getRunpathList()
+            pfx = 'RunpathList(size = '
+            self.assertEqual(repr(rpl)[:len(pfx)], pfx)
+
+            ef = rpl.getExportFile()
+            self.assertTrue('.ert_runpath_list' in ef)
+            nf = 'myExportCamel'
+            rpl.setExportFile('myExportCamel')
+            ef = rpl.getExportFile()
+            self.assertTrue(nf in ef)
+
+
+
     def test_ert_obs_reload(self):
         with ErtTestContext("obs_test_reload", self.config_file) as test_context:
             ert = test_context.getErt()


### PR DESCRIPTION
Implemented the missing prototype
```python
_get_runpath_list = EnkfPrototype("runpath_list_ref hook_manager_get_runpath_list(hook_manager)")
```

Added tests for HookManager and RunpathList from EnkfMain.