### PR TITLE
Minor travis changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ env:
 before_script:
   - mkdir build
   - cd build
-  - cmake -DPYTHON_INSTALL_PREFIX=python -DBUILD_ERT=ON -DERT_BUILD_GUI=ON -DBUILD_TESTS=ON -DBUILD_APPLICATIONS=ON -DUSE_RUNPATH=ON -DBUILD_PYTHON=ON -DERT_USE_OPENMP=ON -DERT_DOC=OFF -DERT_BUILD_CXX=ON ..
+  - cmake -DBUILD_ERT=ON -DERT_BUILD_GUI=ON -DBUILD_TESTS=ON -DBUILD_APPLICATIONS=ON -DBUILD_PYTHON=ON -DERT_USE_OPENMP=ON -DERT_DOC=OFF -DERT_BUILD_CXX=ON ..
 
-script: make && ctest --output-on-failure
+script:
+  - make
+  - ctest --output-on-failure


### PR DESCRIPTION
1. by separating `make && ctest` into two steps, we obtain better readability and stats from travis
2. removed cmake flag `-DPYTHON_INSTALL_PREFIX=python` to get closer to out-of-the-box build

If we _really need_ to set the `-DPYTHON_INSTALL_PREFIX=python` that should be the default value.

The closer we are to the happy-path in travis, the closer the travis testing gets to user experience (not that I know anything about ~~testing~~ ~~user experience~~ ~~travis~~).