### PR TITLE
Fix bug in load case manually

### DIFF
--- a/python/python/ert_gui/ertwidgets/models/valuemodel.py
+++ b/python/python/ert_gui/ertwidgets/models/valuemodel.py
@@ -15,3 +15,6 @@ class ValueModel(QObject):
     def setValue(self, value):
         self._value = value
         self.valueChanged.emit(value)
+
+    def __repr__(self):
+        return 'ValueModel(QObject)(value = "%s")' % self._value

--- a/python/python/ert_gui/tools/load_results/load_results_panel.py
+++ b/python/python/ert_gui/tools/load_results/load_results_panel.py
@@ -83,9 +83,11 @@ class LoadResultsPanel(QWidget):
         realizations = self._active_realizations_model.getActiveRealizationsMask()
         iteration = self._iterations_model.getValue()
         try:
+            if iteration is None:
+                iteration = ''
             iteration = int(iteration)
         except ValueError as e:
-            print(e)
+            print('Expected a (whole) number in iteration field, got "%s". Error message: %s.'  % (iteration, e))
             return False
         LoadResultsModel.loadResults(selected_case, realizations, iteration)
         return True

--- a/python/python/ert_gui/tools/load_results/load_results_panel.py
+++ b/python/python/ert_gui/tools/load_results/load_results_panel.py
@@ -81,9 +81,14 @@ class LoadResultsPanel(QWidget):
         all_cases = self._case_model.getAllItems()
         selected_case  = all_cases[self._case_combo.currentIndex()]
         realizations = self._active_realizations_model.getActiveRealizationsMask()
-        iteration = self._iterations_model.getActiveIteration()
-
+        iteration = self._iterations_model.getValue()
+        try:
+            iteration = int(iteration)
+        except ValueError as e:
+            print(e)
+            return False
         LoadResultsModel.loadResults(selected_case, realizations, iteration)
+        return True
 
     def setCurrectCase(self):
         current_case = getCurrentCaseName()


### PR DESCRIPTION
`ValueModel` has no attribute `getActiveIteration`, must use `getValue()`.

`getValue()` is a string, so we try to cast to int.

_internal: ERT-1134_