### PR TITLE
repr for bool_vector and enkf_node

### DIFF
--- a/python/python/ert/util/bool_vector.py
+++ b/python/python/ert/util/bool_vector.py
@@ -143,3 +143,23 @@ class BoolVector(VectorTemplate):
     def createActiveList(self):
         """ @rtype: ert.util.IntVector """
         return self._active_list(self)
+
+    def _tostr(self, arr = None):
+        if arr is None:
+            arr = self
+        return "".join(['1' if x else '0' for x in arr])
+
+    def __repr__(self):
+        """Will return BoolVector(size = 4, content = "0010") at 0x1729 and
+        if size > 10, will return content = "0001...100", i.e., |content|<=10.
+        """
+        cnt = ''
+        ls = len(self)
+        if ls <= 10:
+            cnt = self._tostr()
+        else:
+            a,b  = self[:4], self[-3:]
+            cnt  = self._tostr(a)
+            cnt += "..."
+            cnt += self._tostr(b)
+        return 'BoolVector(size = %d, content = "%s") %s' % (ls, cnt, self._ad_str())


### PR DESCRIPTION
during debugging I needed to know some states of `BoolVector` and `EnkfNode`, so I implemented `__repr__`.

They might be good to have later as well.