### PR TITLE
Sum vector issues

### DIFF
--- a/python/python/ert/ecl/ecl_sum.py
+++ b/python/python/ert/ecl/ecl_sum.py
@@ -430,6 +430,9 @@ class EclSum(BaseCClass):
         if not key in self:
             raise KeyError("The summary key:%s was not recognized" % key)
 
+    def __iter__(self):
+        return iter(self.keys())
+
     def __getitem__(self , key):
         """
         Implements [] operator - @key should be a summary key.
@@ -1197,12 +1200,11 @@ class EclSum(BaseCClass):
            EclSum("NORNE_ATW2013.UNSMRY", [1997-11-06 00:00:00, 2006-12-01 00:00:00], keys = 3781) at 0x1609e20
         """
         name = self._nicename()
-        if name:
-            name = '"%s", ' % name
         s_time   = self.getStartTime()
         e_time   = self.getEndTime()
         num_keys = len(self.keys())
-        return 'EclSum(%s[%s, %s], keys = %d) at 0x%x' % (name, s_time, e_time, num_keys, self._address())
+        content = 'name = "%s", time = [%s, %s], keys = %d' % (name, s_time, e_time, num_keys)
+        return self._create_repr(content)
 
     def dumpCSVLine(self, time, keywords, pfile):
         """

--- a/python/python/ert/ecl/ecl_sum_vector.py
+++ b/python/python/ert/ecl/ecl_sum_vector.py
@@ -40,7 +40,7 @@ class EclSumVector(object):
         return "<Summary vector: %s>" % self.key
 
     def __repr__(self):
-        return 'EclSumVector(size = %d, unit = %s)' % (len(self), self.unit)
+        return 'EclSumVector(key = %s, size = %d, unit = %s)' % (self.key, len(self), self.unit)
 
     @property
     def unit( self ):

--- a/python/python/ert/ecl/ecl_sum_vector.py
+++ b/python/python/ert/ecl/ecl_sum_vector.py
@@ -39,13 +39,15 @@ class EclSumVector(object):
     def __str__(self):
         return "<Summary vector: %s>" % self.key
 
+    def __repr__(self):
+        return 'EclSumVector(size = %d, unit = %s)' % (len(self), self.unit)
 
     @property
     def unit( self ):
         """
         The unit of this vector.
         """
-        return self.parent.get_unit(self.key)
+        return self.parent.unit(self.key)
 
     def assert_values( self ):
         """

--- a/python/python/ert/util/time_vector.py
+++ b/python/python/ert/util/time_vector.py
@@ -25,7 +25,7 @@ class TimeVector(VectorTemplate):
 
     _alloc               = UtilPrototype("void*   time_t_vector_alloc(int, time_t )" , bind = False)
     _alloc_copy          = UtilPrototype("time_t_vector_obj time_t_vector_alloc_copy(time_t_vector )")
-    _strided_copy        = UtilPrototype("time_t_vector_obj time_t_vector_alloc_strided_copy(time_t_vector , time_t , time_t , time_t)")
+    _strided_copy        = UtilPrototype("time_t_vector_obj time_t_vector_alloc_strided_copy(time_t_vector , int , int , int)")
     _free                = UtilPrototype("void   time_t_vector_free( time_t_vector )")
     _iget                = UtilPrototype("time_t   time_t_vector_iget( time_t_vector , int )")
     _safe_iget           = UtilPrototype("time_t   time_t_vector_safe_iget( time_t_vector , int )")

--- a/python/python/ert/util/vector_template.py
+++ b/python/python/ert/util/vector_template.py
@@ -489,6 +489,9 @@ class VectorTemplate(BaseCClass):
     def free(self):
         self._free()
 
+    def __repr__(self):
+        return self._create_repr('size = %d' % len(self))
+
     def permute(self, permutation_vector):
         """
         Reorders this vector based on the indexes in permutation_vector.

--- a/python/tests/core/ecl/test_ecl_sum_vector.py
+++ b/python/tests/core/ecl/test_ecl_sum_vector.py
@@ -38,3 +38,14 @@ class EclSumVectorTest(ExtendedTestCase):
             vector = EclSumVector(self.ecl_sum, "FOPT", True)
             assert len(w) == 1
             assert issubclass(w[-1].category, DeprecationWarning)
+
+    def test_basic(self):
+        self.assertEqual(512, len(self.ecl_sum.keys()))
+        pfx = 'EclSum(name'
+        self.assertEqual(pfx, repr(self.ecl_sum)[:len(pfx)])
+        it = iter(self.ecl_sum)
+        t = self.ecl_sum[it.next()] # EclSumVector
+        self.assertEqual(63, len(t))
+        self.assertEqual('BARSA', t.unit)
+        pfx = 'EclSumVector(key = '
+        self.assertEqual(pfx, repr(t)[:len(pfx)])

--- a/python/tests/core/util/test_vectors.py
+++ b/python/tests/core/util/test_vectors.py
@@ -29,7 +29,38 @@ from ert.util import DoubleVector, IntVector, BoolVector, TimeVector, CTime, Per
 class UtilTest(TestCase):
     def setUp(self):
         pass
-        
+
+    def dotest_slicing(self, vec):
+        self.assertEqual(10, len(vec))
+        self.assertEqual(vec[-1], vec[9])
+        self.assertEqual(8, len(vec[:8]))
+        self.assertEqual(9, len(vec[1:]))
+        self.assertEqual(3, len(vec[1:8:3]))
+        odds = vec[1::2]
+        self.assertEqual(4, len(vec[1:8:2]))
+        for i in range(4):
+            self.assertEqual(vec[2*i + 1], odds[i])
+
+    def test_slicing(self):
+        dv = DoubleVector(initial_size=10)
+        for i in range(10):
+            dv[i] = 1.0 / (1+i)
+        self.dotest_slicing(dv)
+        iv = IntVector(initial_size=10)
+        for i in range(10):
+            iv[i] = i**3
+        self.dotest_slicing(iv)
+        bv = BoolVector(initial_size=10)
+        for i in range(0,10,3):
+            bv[i] = True
+        self.dotest_slicing(bv)
+        tv = TimeVector(initial_size=10)
+        for i in range(10):
+            tv[i] = CTime(datetime.datetime(2016, 12, i+3, 0, 0, 0))
+        self.dotest_slicing(tv)
+
+
+
     def test_double_vector(self):
         v = DoubleVector()
 


### PR DESCRIPTION
Added `__iter__` for `EclSum` (iterate over keys so we can `get_values(keys)`).  Implement `__repr__` for `EclSumVector` and `VectorTemplate`.

But _most importantly_ this fixes two bugs:

* The first commit fixes getting `unit` from `EclSumVector`.
* The second commit fixes `TimeVector` slicing.

The third commit adds testing for `Double`, `Int`, `Bool`, and `Time`-`Vector`.