### PR TITLE
Minor field config refactor, added type FieldExportEnum

### DIFF
--- a/libecl/include/ert/ecl/ecl_kw.h
+++ b/libecl/include/ert/ecl/ecl_kw.h
@@ -125,7 +125,6 @@ extern "C" {
   void           ecl_kw_fskip_header( fortio_type * fortio);
 
 
-  bool ecl_kw_is_grdecl_file(FILE * );
   bool ecl_kw_is_kw_file(fortio_type * fortio);
 
   int        ecl_kw_element_sum_int( const ecl_kw_type * ecl_kw );

--- a/libecl/src/ecl_kw.c
+++ b/libecl/src/ecl_kw.c
@@ -2518,41 +2518,6 @@ bool ecl_kw_is_kw_file(fortio_type * fortio) {
 }
 
 
-
-
-
-bool ecl_kw_is_grdecl_file(FILE * stream) {
-  const long int init_pos = util_ftell(stream);
-  bool grdecl_file;
-  bool at_eof = false;
-  util_fskip_chars(stream ,  " \r\n\t"  , &at_eof);  /* Skipping intial space */
-  util_fskip_cchars(stream , " \r\n\t"  , &at_eof);  /* Skipping PORO/PERMX/... */
-  if (at_eof)
-    grdecl_file = false;
-  else {
-    grdecl_file = true;
-    {
-      int c;
-      do {
-        c = fgetc(stream);
-        if (c == '\r' || c == '\n')
-          break;
-        else {
-          if (c != ' ') {
-            grdecl_file = false;
-            break;
-          }
-        }
-      } while (c == ' ');
-    }
-  }
-  util_fseek(stream , init_pos , SEEK_SET);
-  return grdecl_file;
-}
-
-
-
-
 #define KW_MAX_MIN(type)                                       \
 {                                                              \
   type * data = ecl_kw_get_data_ref(ecl_kw);                   \

--- a/libenkf/include/ert/enkf/field_config.h
+++ b/libenkf/include/ert/enkf/field_config.h
@@ -51,7 +51,8 @@ extern "C" {
 typedef enum {
   ECLIPSE_RESTART   = 1,
   ECLIPSE_PARAMETER = 2,
-  GENERAL           = 3
+  GENERAL           = 3,
+  UNKNOWN_FIELD_TYPE= 4
 } field_type_enum;
  
 

--- a/libenkf/src/field_config.c
+++ b/libenkf/src/field_config.c
@@ -341,7 +341,7 @@ field_file_format_type field_config_guess_file_type(const char * filename ) {
     file_type = ECL_KW_FILE;
   else if (rms_file_is_roff(stream))
     file_type = RMS_ROFF_FILE;
-  else if (ecl_kw_is_grdecl_file(stream))  /* This is the weakest test - and should be last in a cascading if / else hierarchy. */
+  else if (ecl_kw_grdecl_fseek_next_kw(stream))  /* This is the weakest test - and should be last in a cascading if / else hierarchy. */
     file_type = ECL_GRDECL_FILE;
   else
     file_type = UNDEFINED_FORMAT;              /* MUST Check on this return value */

--- a/libenkf/src/field_config.c
+++ b/libenkf/src/field_config.c
@@ -431,6 +431,7 @@ field_config_type * field_config_alloc_empty( const char * ecl_kw_name , ecl_gri
   config->__enkf_mode         = true;
   config->grid                = NULL;
   config->write_compressed    = true;
+  config->type                = UNKNOWN_FIELD_TYPE;
 
   config->output_transform      = NULL;
   config->input_transform       = NULL;

--- a/python/python/ert/enkf/config/CMakeLists.txt
+++ b/python/python/ert/enkf/config/CMakeLists.txt
@@ -2,6 +2,7 @@ set(PYTHON_SOURCES
     __init__.py
     custom_kw_config.py
     enkf_config_node.py
+    field_type_enum.py
     field_config.py
     gen_data_config.py
     gen_kw_config.py

--- a/python/python/ert/enkf/config/__init__.py
+++ b/python/python/ert/enkf/config/__init__.py
@@ -1,11 +1,14 @@
 from .custom_kw_config import CustomKWConfig
 from .field_config import FieldConfig
+from .field_type_enum import FieldTypeEnum
 from .gen_data_config import GenDataConfig
 from .gen_kw_config import GenKwConfig
 from .summary_config import SummaryConfig
 from .enkf_config_node import EnkfConfigNode
 
+
 __all__ = ["FieldConfig",
+           "FieldTypeEnum",
            "CustomKWConfig",
            "GenKwConfig",
            "GenDataConfig",

--- a/python/python/ert/enkf/config/field_config.py
+++ b/python/python/ert/enkf/config/field_config.py
@@ -37,7 +37,7 @@ class FieldConfig(BaseCClass):
     _get_nz                    = EnkfPrototype("int    field_config_get_nz(field_config)")
     _get_grid                  = EnkfPrototype("ecl_grid_ref field_config_get_grid(field_config)")
     _export_format             = EnkfPrototype("enkf_field_file_format_enum field_config_default_export_format(char*)", bind = False)
-
+    _guess_filetype            = EnkfPrototype("enkf_field_file_format_enum field_config_guess_file_type(char*)", bind = False)
 
     def __init__(self , kw , grid):
         c_ptr = self._alloc( kw , grid , None , False )
@@ -50,6 +50,10 @@ class FieldConfig(BaseCClass):
             return export_format
         else:
             raise ValueError("Could not determine grdecl / roff format from:%s" % filename)
+
+    @classmethod
+    def guessFiletype(cls, filename):
+        return cls._guess_filetype(filename)
 
     def get_type(self):
         return self._get_type()

--- a/python/python/ert/enkf/config/field_config.py
+++ b/python/python/ert/enkf/config/field_config.py
@@ -1,18 +1,18 @@
-#  Copyright (C) 2012  Statoil ASA, Norway. 
-#   
-#  The file 'field_config.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details.
+# Copyright (C) 2012  Statoil ASA, Norway.
+#
+# This file is part of ERT - Ensemble based Reservoir Tool.
+#
+# ERT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+# for more details.
 from cwrap import BaseCClass
 
 from ert.enkf import EnkfPrototype
@@ -77,6 +77,9 @@ class FieldConfig(BaseCClass):
 
     def get_nz(self):
         return self._get_nz()
+
+    def get_grid(self):
+        return self._get_grid()
 
     def ijk_active(self, i, j, k):
         return self._ijk_active(i, j, k)

--- a/python/python/ert/enkf/config/field_config.py
+++ b/python/python/ert/enkf/config/field_config.py
@@ -18,13 +18,14 @@ from cwrap import BaseCClass
 from ert.enkf import EnkfPrototype
 from ert.enkf.enums import EnkfFieldFileFormatEnum
 from ert.ecl import EclGrid
+from .field_type_enum import FieldTypeEnum
 
 class FieldConfig(BaseCClass):
     TYPE_NAME = "field_config"
 
     _alloc                     = EnkfPrototype("void*  field_config_alloc_empty(char* , ecl_grid , void* , bool)", bind = False)
     _free                      = EnkfPrototype("void   field_config_free( field_config )")
-    _get_type                  = EnkfPrototype("int    field_config_get_type(field_config)")
+    _get_type                  = EnkfPrototype("field_type_enum field_config_get_type(field_config)")
     _get_truncation_mode       = EnkfPrototype("int    field_config_get_truncation_mode(field_config)")
     _get_truncation_min        = EnkfPrototype("double field_config_get_truncation_min(field_config)")
     _get_truncation_max        = EnkfPrototype("double field_config_get_truncation_max(field_config)")
@@ -86,6 +87,5 @@ class FieldConfig(BaseCClass):
     def __repr__(self):
         tp = self.get_type()
         nx,ny,nz = self.get_nx(),self.get_ny(),self.get_nz()
-        ad = self._ad_str()
-        fmt = 'FieldConfig(type = %d, nx = %d, ny = %d, nz = %d) %s'
-        return fmt % (tp, nx,ny,nz, ad)
+        cnt = 'type = %s, nx = %d, ny = %d, nz = %d' % (tp, nx,ny,nz)
+        return self._create_repr(cnt)

--- a/python/python/ert/enkf/config/field_type_enum.py
+++ b/python/python/ert/enkf/config/field_type_enum.py
@@ -1,17 +1,17 @@
-#  Copyright (C) 2016  Statoil ASA, Norway. 
-#   
-#  This file is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  Copyright (C) 2016  Statoil ASA, Norway.
+#
+#  This file is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
 from cwrap import BaseCEnum

--- a/python/python/ert/enkf/config/field_type_enum.py
+++ b/python/python/ert/enkf/config/field_type_enum.py
@@ -1,0 +1,29 @@
+#  Copyright (C) 2016  Statoil ASA, Norway. 
+#   
+#  This file is part of ERT - Ensemble based Reservoir Tool. 
+#   
+#  ERT is free software: you can redistribute it and/or modify 
+#  it under the terms of the GNU General Public License as published by 
+#  the Free Software Foundation, either version 3 of the License, or 
+#  (at your option) any later version. 
+#   
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+#  FITNESS FOR A PARTICULAR PURPOSE.   
+#   
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  for more details.
+
+from cwrap import BaseCEnum
+
+class FieldTypeEnum(BaseCEnum):
+    TYPE_NAME = "field_type_enum"
+    ECLIPSE_RESTART    = None
+    ECLIPSE_PARAMETER  = None
+    GENERAL            = None
+    UNKNOWN_FIELD_TYPE = None
+
+FieldTypeEnum.addEnum('ECLIPSE_RESTART',    1)
+FieldTypeEnum.addEnum('ECLIPSE_PARAMETER',  2)
+FieldTypeEnum.addEnum('GENERAL',            3)
+FieldTypeEnum.addEnum('UNKNOWN_FIELD_TYPE', 4)

--- a/python/tests/ert/enkf/CMakeLists.txt
+++ b/python/tests/ert/enkf/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_SOURCES
     test_update.py
     test_ensemble_config.py
     test_deprecation.py
+    test_field_config.py
     test_field_export.py
     test_hook_workflow.py
     test_forward_load_context.py
@@ -63,6 +64,7 @@ addPythonTest(ert.enkf.local_config tests.ert.enkf.test_local_config.LocalConfig
 addPythonTest(ert.enkf.ensemble_config tests.ert.enkf.test_ensemble_config.EnsembleConfigTest)
 addPythonTest(ert.enkf.hook_workflow tests.ert.enkf.test_hook_workflow.HookWorkFlowTest)
 addPythonTest(ert.enkf.runpath_list tests.ert.enkf.test_runpath_list.RunpathListTest)
+addPythonTest(ert.enkf.field_config tests.ert.enkf.test_field_config.FieldConfigTest)
 
 if (STATOIL_TESTDATA_ROOT)
   addPythonTest(ert.enkf.enkf tests.ert.enkf.test_enkf.EnKFTest LABELS StatoilData)

--- a/python/tests/ert/enkf/test_field_config.py
+++ b/python/tests/ert/enkf/test_field_config.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2017  Statoil ASA, Norway.
+#
+# This file is part of ERT - Ensemble based Reservoir Tool.
+#
+# ERT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+# for more details.
+from os.path import abspath
+
+from ert.ecl import EclGrid
+from ert.enkf.config import FieldTypeEnum, FieldConfig
+from ert.enkf.enums import EnkfFieldFileFormatEnum
+from ert.test import ExtendedTestCase, TestAreaContext
+
+class FieldConfigTest(ExtendedTestCase):
+
+    def test_field_guess_filetype(self):
+        with TestAreaContext('field_config') as test_context:
+            fname = abspath('test.kw.grdecl')
+            print(fname)
+            with open(fname, 'w') as f:
+                f.write("-- my comment\n")
+                f.write("-- more comments\n")
+                f.write("SOWCR\n")
+                for i in range(256//8): # technicalities demand file has >= 256B
+                    f.write("0 0 0 0\n")
+
+            ft = FieldConfig.guessFiletype(fname)
+            grdecl_type = EnkfFieldFileFormatEnum(5)
+            self.assertEqual('ECL_GRDECL_FILE', grdecl_type.name)
+            self.assertEqual(grdecl_type, ft)
+
+    def test_field_type_enum(self):
+        self.assertEqual(FieldTypeEnum(2), FieldTypeEnum.ECLIPSE_PARAMETER)
+        gen = FieldTypeEnum.GENERAL
+        self.assertEqual('GENERAL', str(gen))
+        gen = FieldTypeEnum(3)
+        self.assertEqual('GENERAL', str(gen))
+
+    def test_export_format(self):
+        self.assertEqual(FieldConfig.exportFormat("file.grdecl"),     EnkfFieldFileFormatEnum.ECL_GRDECL_FILE)
+        self.assertEqual(FieldConfig.exportFormat("file.xyz.grdecl"), EnkfFieldFileFormatEnum.ECL_GRDECL_FILE)
+        self.assertEqual(FieldConfig.exportFormat("file.roFF"),       EnkfFieldFileFormatEnum.RMS_ROFF_FILE)
+        self.assertEqual(FieldConfig.exportFormat("file.xyz.roFF"),   EnkfFieldFileFormatEnum.RMS_ROFF_FILE)
+
+        with self.assertRaises(ValueError):
+            FieldConfig.exportFormat("file.xyz")
+
+        with self.assertRaises(ValueError):
+            FieldConfig.exportFormat("file.xyz")
+
+    def test_basics(self):
+        grid = EclGrid.createRectangular((17,13,11),(1,1,1))
+        fc = FieldConfig('PORO',grid)
+        print(fc)
+        print(str(fc))
+        print(repr(fc))
+        pfx = 'FieldConfig(type'
+        rep = repr(fc)
+        self.assertEqual(pfx, rep[:len(pfx)])
+        fc_xyz = fc.get_nx(),fc.get_ny(),fc.get_nz()
+        ex_xyz = 17,13,11
+        self.assertEqual(ex_xyz, fc_xyz)
+        self.assertEqual(0,     fc.get_truncation_mode())
+        self.assertEqual(ex_xyz, (grid.getNX(), grid.getNY(), grid.getNZ()))

--- a/python/tests/ert/enkf/test_field_export.py
+++ b/python/tests/ert/enkf/test_field_export.py
@@ -22,48 +22,46 @@ class FieldExportTest(ExtendedTestCase):
             ert = test_context.getErt()
             ens_config = ert.ensembleConfig()
             fc = ens_config["PERMX"].getFieldModelConfig()
-            self.assertEqual(2, fc.get_type())
+            self.assertEqual(FieldTypeEnum.ECLIPSE_PARAMETER, fc.get_type())
 
-    def test_export_format(self):
-        self.assertEqual(FieldConfig.exportFormat("file.grdecl"),     EnkfFieldFileFormatEnum.ECL_GRDECL_FILE)
-        self.assertEqual(FieldConfig.exportFormat("file.xyz.grdecl"), EnkfFieldFileFormatEnum.ECL_GRDECL_FILE)
-        self.assertEqual(FieldConfig.exportFormat("file.roFF"),       EnkfFieldFileFormatEnum.RMS_ROFF_FILE)
-        self.assertEqual(FieldConfig.exportFormat("file.xyz.roFF"),   EnkfFieldFileFormatEnum.RMS_ROFF_FILE)
-
-        with self.assertRaises(ValueError):
-            FieldConfig.exportFormat("file.xyz")
-
-        with self.assertRaises(ValueError):
-            FieldConfig.exportFormat("file.xyz")
-
-    def test_field_repr(self):
+    def test_field_basics(self):
         with ErtTestContext("export_test", self.config_file) as test_context:
             ert = test_context.getErt()
             ens_config = ert.ensembleConfig()
-            config_node = ens_config["PERMX"]
-            pfx = 'FieldExport(type'
-            rep = repr(config_node)
+            fc = ens_config["PERMX"].getFieldModelConfig()
+            pfx = 'FieldConfig(type'
+            rep = repr(fc)
             self.assertEqual(pfx, rep[:len(pfx)])
+            fc_xyz = fc.get_nx(),fc.get_ny(),fc.get_nz()
+            ex_xyz = 40,64,14
+            self.assertEqual(ex_xyz, fc_xyz)
+            self.assertEqual(1,     fc.get_truncation_mode())
+            self.assertEqual(0.001, fc.get_truncation_min())
+            self.assertEqual(-1.0,  fc.get_truncation_max())
+            self.assertEqual('LOG', fc.get_init_transform_name())
+            self.assertEqual(None,  fc.get_output_transform_name())
+            grid = fc.get_grid()
+            self.assertEqual(ex_xyz, (grid.getNX(), grid.getNY(), grid.getNZ()))
 
     def test_field_export(self):
         with ErtTestContext("export_test", self.config_file) as test_context:
             ert = test_context.getErt()
-            fs_manager = ert.getEnkfFsManager( ) 
+            fs_manager = ert.getEnkfFsManager( )
             ens_config = ert.ensembleConfig()
             config_node = ens_config["PERMX"]
             data_node = EnkfNode( config_node )
             node_id = NodeId( 0 , 0 )
-            fs = fs_manager.getCurrentFileSystem( ) 
+            fs = fs_manager.getCurrentFileSystem( )
             data_node.tryLoad( fs , node_id )
 
             data_node.export("export/with/path/PERMX.grdecl")
-            self.assertTrue( os.path.isfile("export/with/path/PERMX.grdecl") )  
+            self.assertTrue( os.path.isfile("export/with/path/PERMX.grdecl") )
 
 
     def test_field_export_many(self):
         with ErtTestContext("export_test", self.config_file) as test_context:
             ert = test_context.getErt()
-            fs_manager = ert.getEnkfFsManager( ) 
+            fs_manager = ert.getEnkfFsManager( )
             ens_config = ert.ensembleConfig()
             config_node = ens_config["PERMX"]
             iens_list = IntVector( )
@@ -71,14 +69,13 @@ class FieldExportTest(ExtendedTestCase):
             iens_list.append(2)
             iens_list.append(4)
 
-            fs = fs_manager.getCurrentFileSystem( ) 
+            fs = fs_manager.getCurrentFileSystem( )
 
             # Filename without embedded %d - TypeError
             with self.assertRaises(TypeError):
                 EnkfNode.exportMany( config_node , "export/with/path/PERMX.grdecl" , fs , iens_list )
-            
+
             EnkfNode.exportMany( config_node , "export/with/path/PERMX_%d.grdecl" , fs , iens_list )
             self.assertTrue( os.path.isfile("export/with/path/PERMX_0.grdecl") )
             self.assertTrue( os.path.isfile("export/with/path/PERMX_2.grdecl") )
-            self.assertTrue( os.path.isfile("export/with/path/PERMX_4.grdecl") )  
-
+            self.assertTrue( os.path.isfile("export/with/path/PERMX_4.grdecl") )

--- a/python/tests/ert/enkf/test_field_export.py
+++ b/python/tests/ert/enkf/test_field_export.py
@@ -4,7 +4,7 @@ from ert.util import IntVector
 
 from ert.ecl import EclGrid
 
-from ert.enkf.config import FieldConfig
+from ert.enkf.config import FieldTypeEnum, FieldConfig
 from ert.enkf.data import EnkfNode
 from ert.enkf.enums import EnkfFieldFileFormatEnum
 from ert.enkf import NodeId
@@ -17,10 +17,18 @@ class FieldExportTest(ExtendedTestCase):
     def setUp(self):
         self.config_file = self.createTestPath("Statoil/config/obs_testing/config")
 
-        
+    def test_field_type_enum(self):
+        with ErtTestContext("export_test", self.config_file) as test_context:
+            ert = test_context.getErt()
+            ens_config = ert.ensembleConfig()
+            fc = ens_config["PERMX"].getFieldModelConfig()
+            self.assertEqual(2, fc.get_type())
+
     def test_export_format(self):
-        self.assertEqual( FieldConfig.exportFormat("file.grdecl") , EnkfFieldFileFormatEnum.ECL_GRDECL_FILE ) 
-        self.assertEqual( FieldConfig.exportFormat("file.roFF") , EnkfFieldFileFormatEnum.RMS_ROFF_FILE ) 
+        self.assertEqual(FieldConfig.exportFormat("file.grdecl"),     EnkfFieldFileFormatEnum.ECL_GRDECL_FILE)
+        self.assertEqual(FieldConfig.exportFormat("file.xyz.grdecl"), EnkfFieldFileFormatEnum.ECL_GRDECL_FILE)
+        self.assertEqual(FieldConfig.exportFormat("file.roFF"),       EnkfFieldFileFormatEnum.RMS_ROFF_FILE)
+        self.assertEqual(FieldConfig.exportFormat("file.xyz.roFF"),   EnkfFieldFileFormatEnum.RMS_ROFF_FILE)
 
         with self.assertRaises(ValueError):
             FieldConfig.exportFormat("file.xyz")
@@ -28,8 +36,15 @@ class FieldExportTest(ExtendedTestCase):
         with self.assertRaises(ValueError):
             FieldConfig.exportFormat("file.xyz")
 
-            
-            
+    def test_field_repr(self):
+        with ErtTestContext("export_test", self.config_file) as test_context:
+            ert = test_context.getErt()
+            ens_config = ert.ensembleConfig()
+            config_node = ens_config["PERMX"]
+            pfx = 'FieldExport(type'
+            rep = repr(config_node)
+            self.assertEqual(pfx, rep[:len(pfx)])
+
     def test_field_export(self):
         with ErtTestContext("export_test", self.config_file) as test_context:
             ert = test_context.getErt()


### PR DESCRIPTION
The `FieldConfig.get_type()`, with return type `int`, was prone to return `-1`

The function now returns a new type, `FieldTypeEnum`, there is a corresponding `c` enum.

Added a new type `UNKNOWN=4` and initializes the `field_config` objects with `type=UNKNOWN`.