### PR TITLE
expose active_list_get_active_size in py

### DIFF
--- a/libenkf/include/ert/enkf/active_list.h
+++ b/libenkf/include/ert/enkf/active_list.h
@@ -30,7 +30,6 @@ extern "C" {
 typedef struct active_list_struct active_list_type;
 
   active_list_type * active_list_alloc( );
-  void               active_list_reset(active_list_type * );
   void               active_list_add_index(active_list_type * , int);
   void               active_list_free( active_list_type *);
   const int        * active_list_get_active(const active_list_type * );

--- a/libenkf/src/active_list.c
+++ b/libenkf/src/active_list.c
@@ -50,7 +50,6 @@ a fault object. Then the code will be like:
 
 
    ....
-   active_list_reset(multflt_config->active_list);
    active_list_add_index(multflt_config->active_list , 0);
    active_list_add_index(multflt_config->active_list , 4);
    active_list_add_index(multflt_config->active_list , 5);
@@ -117,17 +116,6 @@ void active_list_free__( void * arg ) {
   active_list_free(active_list);
 }
 
-
-
-
-
-/*
-  Setting the counter back to zero - i.e. a call to
-  active_list_reset() will mean that we have *NO* active elements.
-*/
-void active_list_reset(active_list_type * active_list) {
-  int_vector_reset( active_list->index_list );
-}
 
 
 /**

--- a/libenkf/src/active_list.c
+++ b/libenkf/src/active_list.c
@@ -135,6 +135,8 @@ void active_list_reset(active_list_type * active_list) {
    setting the mode to PARTLY_ACTIVE.
 */
 void active_list_add_index(active_list_type * active_list, int new_index) {
+  if (int_vector_contains(active_list->index_list , new_index ))
+    return;
   active_list->mode = PARTLY_ACTIVE;
   int_vector_append( active_list->index_list , new_index );
 }

--- a/python/python/ert/enkf/active_list.py
+++ b/python/python/ert/enkf/active_list.py
@@ -16,6 +16,7 @@
 
 from cwrap import BaseCClass
 from ert.enkf import EnkfPrototype
+from ert.enkf import ActiveMode
 
 class ActiveList(BaseCClass):
     TYPE_NAME = "active_list"
@@ -23,6 +24,7 @@ class ActiveList(BaseCClass):
     _alloc     = EnkfPrototype("void* active_list_alloc()", bind = False)
     _free      = EnkfPrototype("void  active_list_free(active_list)")
     _add_index = EnkfPrototype("void  active_list_add_index(active_list , int)")
+    _asize     = EnkfPrototype("int   active_list_get_active_size(active_list, int)")
     _get_mode  = EnkfPrototype("active_mode_enum active_list_get_mode(active_list)")
 
     def __init__(self):
@@ -35,8 +37,24 @@ class ActiveList(BaseCClass):
     def addActiveIndex(self, index):
         self._add_index(index)
 
+    def getActiveSize(self, default_value):
+        """In mode PARTLY_ACTIVE, we return the size of the active set; In mode
+        INACTIVE 0 is returned and if the mode is ALL_ACTIVE, the input
+        default_value is returned.
+        """
+        mode = self.getMode()
+        if mode == ActiveMode.PARTLY_ACTIVE:
+            return self._asize(0)
+        if mode == ActiveMode.INACTIVE:
+            return 0
+        return default_value
+
     def free(self):
         self._free()
 
     def __repr__(self):
-        return 'ActiveList(mode = %s) at 0x%x' % (str(self.getMode()), self._address())
+        size = ''
+        if self.getMode() == ActiveMode.PARTLY_ACTIVE:
+            size = ', active_size = %d' % self._asize(0)
+        cnt = 'mode = %s%s' % (self.getMode(), size)
+        return self._create_repr(cnt)

--- a/python/tests/ert/enkf/test_active_list.py
+++ b/python/tests/ert/enkf/test_active_list.py
@@ -21,10 +21,46 @@ from ert.test import ExtendedTestCase
 
 
 class ActiveListTest(ExtendedTestCase):
-    
+
+    def test_active_mode_enum(self):
+        self.assertEqual(ActiveMode.ALL_ACTIVE,    1)
+        self.assertEqual(ActiveMode.INACTIVE,      2)
+        self.assertEqual(ActiveMode.PARTLY_ACTIVE, 3)
+        self.assertEqual(ActiveMode(1).name, 'ALL_ACTIVE')
+        self.assertEqual(ActiveMode(2).name, 'INACTIVE')
+        self.assertEqual(ActiveMode(3).name, 'PARTLY_ACTIVE')
+
+    def test_active_size(self):
+        al = ActiveList()
+        self.assertEqual(None, al.getActiveSize(None))
+        self.assertEqual(7,    al.getActiveSize(7))
+        self.assertEqual(-1,   al.getActiveSize(-1))
+
+        al.addActiveIndex( 10 )
+        self.assertEqual(1, al.getActiveSize(7))
+        al.addActiveIndex( 10 )
+        self.assertEqual(1, al.getActiveSize(7))
+        al.addActiveIndex( 100 )
+        self.assertEqual(2, al.getActiveSize(7))
+
     def test_create(self):
         active_list = ActiveList()
         self.assertEqual( active_list.getMode() , ActiveMode.ALL_ACTIVE )
         active_list.addActiveIndex( 10 )
-        
-        
+        self.assertEqual( active_list.getMode() , ActiveMode.PARTLY_ACTIVE )
+
+    def test_repr(self):
+        al = ActiveList()
+        rep = repr(al)
+        self.assertFalse('PARTLY_ACTIVE' in rep)
+        self.assertFalse('INACTIVE' in rep)
+        self.assertTrue('ALL_ACTIVE' in rep)
+        pfx = 'ActiveList('
+        self.assertEqual(pfx, rep[:len(pfx)])
+        for i in range(150):
+            al.addActiveIndex( 3*i )
+        rep = repr(al)
+        self.assertTrue('150' in rep)
+        self.assertTrue('PARTLY_ACTIVE' in rep)
+        self.assertFalse('INACTIVE' in rep)
+        self.assertFalse('ALL_ACTIVE' in rep)


### PR DESCRIPTION
1. `active_list` no longer adds repeated indices
2. expose `active_list_get_active_size` in python
3. removed unused function `active_list_reset`
