### PR TITLE
Fixed bug: ert rapid controlled shutdown when summary size and observation size differ

### DIFF
--- a/libenkf/include/ert/enkf/summary.h
+++ b/libenkf/include/ert/enkf/summary.h
@@ -34,6 +34,7 @@
 
 double    summary_get(const summary_type * summary, int report_step );
 bool      summary_active_value( double value );
+int       summary_length(const summary_type * summary);
 
 VOID_HAS_DATA_HEADER(summary);
 UTIL_SAFE_CAST_HEADER(summary);

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1151,7 +1151,7 @@ static FILE * enkf_main_log_step_list(enkf_main_type * enkf_main, const int_vect
  * This is THE ENKF update function.  It should only be called from enkf_main_UPDATE.
  */
 static void enkf_main_update__(enkf_main_type * enkf_main, const int_vector_type * step_list, enkf_fs_type * source_fs,
-        enkf_fs_type * target_fs, int target_step, run_mode_type run_mode, 
+        enkf_fs_type * target_fs, int target_step, run_mode_type run_mode,
         const analysis_config_type * analysis_config, const local_updatestep_type * updatestep,
         const int total_ens_size)
 {
@@ -1166,7 +1166,7 @@ static void enkf_main_update__(enkf_main_type * enkf_main, const int_vector_type
   */
   bool_vector_type * ens_mask = bool_vector_alloc(total_ens_size, false);
   state_map_type * source_state_map = enkf_fs_get_state_map( source_fs );
-  
+
   state_map_select_matching(source_state_map, ens_mask, STATE_HAS_DATA);
   {
     FILE * log_stream = enkf_main_log_step_list(enkf_main, step_list);
@@ -1174,81 +1174,83 @@ static void enkf_main_update__(enkf_main_type * enkf_main, const int_vector_type
     meas_data_type * meas_data = meas_data_alloc(ens_mask);
     obs_data_type * obs_data = obs_data_alloc(global_std_scaling);
     int_vector_type * ens_active_list = bool_vector_alloc_active_list(ens_mask);
-    
-    /* 
-       Copy all the parameter nodes from source case to target case;
-       nodes which are updated will be fetched from the new target
-       case, and nodes which are not updated will be manually copied
-       over there.
+
+    /*
+      Copy all the parameter nodes from source case to target case;
+      nodes which are updated will be fetched from the new target
+      case, and nodes which are not updated will be manually copied
+      over there.
     */
     if (target_fs != source_fs) {
       stringlist_type * param_keys = ensemble_config_alloc_keylist_from_var_type(enkf_main->ensemble_config, PARAMETER);
       for (int i = 0; i < stringlist_get_size(param_keys); i++) {
-	const char * key = stringlist_iget(param_keys, i);
-	enkf_config_node_type * config_node = ensemble_config_get_node(enkf_main->ensemble_config, key);
-	enkf_node_type * data_node = enkf_node_alloc(config_node);
-	for (int j = 0; j < int_vector_size(ens_active_list); j++) {
-	  node_id_type node_id = { .iens = int_vector_iget(ens_active_list, j), .report_step = 0 };
-	  enkf_node_load(data_node, source_fs, node_id);
-	  enkf_node_store(data_node, target_fs, false, node_id);
-	}
-	enkf_node_free(data_node);
+        const char * key = stringlist_iget(param_keys, i);
+        enkf_config_node_type * config_node = ensemble_config_get_node(enkf_main->ensemble_config, key);
+        enkf_node_type * data_node = enkf_node_alloc(config_node);
+        for (int j = 0; j < int_vector_size(ens_active_list); j++) {
+          node_id_type node_id = { .iens = int_vector_iget(ens_active_list, j), .report_step = 0 };
+          enkf_node_load(data_node, source_fs, node_id);
+          enkf_node_store(data_node, target_fs, false, node_id);
+        }
+        enkf_node_free(data_node);
       }
       stringlist_free(param_keys);
     }
-    
+
     {
       hash_type * use_count = hash_alloc();
       int current_step = int_vector_get_last(step_list);
 
-      
+
       /* Looping over local analysis ministep */
       for (int ministep_nr = 0; ministep_nr < local_updatestep_get_num_ministep(updatestep); ministep_nr++) {
-	local_ministep_type * ministep = local_updatestep_iget_ministep(updatestep, ministep_nr);
-	local_obsdata_type * obsdata = local_ministep_get_obsdata(ministep);
-      
-	obs_data_reset(obs_data);
-	meas_data_reset(meas_data);
-	
-	/*
-	  Temporarily we will just force the timestep from the input
-	  argument onto the obsdata instance; in the future the
-	  obsdata should hold it's own here.
-	*/
-	local_obsdata_reset_tstep_list(obsdata, step_list);
-      
-	if (analysis_config_get_std_scale_correlated_obs(enkf_main->analysis_config)) {
-	  double scale_factor = enkf_obs_scale_correlated_std(enkf_main->obs, source_fs, ens_active_list, obsdata);
-	  ert_log_add_fmt_message(1, NULL, "Scaling standard deviation in obdsata set:%s with %g",
-				  local_obsdata_get_name(obsdata), scale_factor);
-	}
-	enkf_obs_get_obs_and_measure_data(enkf_main->obs, source_fs, obsdata, ens_active_list, meas_data, obs_data);
-      
-      
-      
-	double alpha = analysis_config_get_alpha(enkf_main->analysis_config);
-	double std_cutoff = analysis_config_get_std_cutoff(enkf_main->analysis_config);
-	enkf_analysis_deactivate_outliers(obs_data, meas_data, std_cutoff, alpha, enkf_main->verbose);
-      
-	if (enkf_main->verbose)
-	  enkf_analysis_fprintf_obs_summary(obs_data, meas_data, step_list, local_ministep_get_name(ministep), stdout);
-	enkf_analysis_fprintf_obs_summary(obs_data, meas_data, step_list, local_ministep_get_name(ministep), log_stream);
-	
-	if ((obs_data_get_active_size(obs_data) > 0) && (meas_data_get_active_obs_size(meas_data) > 0))
-	  enkf_main_analysis_update(enkf_main,
-				    target_fs,
-				    ens_mask,
-				    target_step,
-				    use_count,
-				    run_mode,
-				    int_vector_get_first(step_list),
-				    current_step,
-				    ministep,
-				    meas_data,
-				    obs_data);
-	else if (target_fs != source_fs)
-	  ert_log_add_fmt_message(1, stderr, "No active observations/parameters for MINISTEP: %s.",
-				  local_ministep_get_name(ministep));
+        local_ministep_type * ministep = local_updatestep_iget_ministep(updatestep, ministep_nr);
+        local_obsdata_type * obsdata = local_ministep_get_obsdata(ministep);
+
+        obs_data_reset(obs_data);
+        meas_data_reset(meas_data);
+
+        /*
+          Temporarily we will just force the timestep from the input
+          argument onto the obsdata instance; in the future the
+          obsdata should hold it's own here.
+        */
+        local_obsdata_reset_tstep_list(obsdata, step_list);
+
+        if (analysis_config_get_std_scale_correlated_obs(enkf_main->analysis_config)) {
+          double scale_factor = enkf_obs_scale_correlated_std(enkf_main->obs, source_fs,
+                                                              ens_active_list, obsdata);
+          ert_log_add_fmt_message(1, NULL,
+                                  "Scaling standard deviation in obdsata set:%s with %g",
+                                  local_obsdata_get_name(obsdata), scale_factor);
+        }
+        enkf_obs_get_obs_and_measure_data(enkf_main->obs, source_fs, obsdata,
+                                          ens_active_list, meas_data, obs_data);
+
+        double alpha = analysis_config_get_alpha(enkf_main->analysis_config);
+        double std_cutoff = analysis_config_get_std_cutoff(enkf_main->analysis_config);
+        enkf_analysis_deactivate_outliers(obs_data, meas_data,
+                                          std_cutoff, alpha, enkf_main->verbose);
+
+        if (enkf_main->verbose)
+          enkf_analysis_fprintf_obs_summary(obs_data, meas_data, step_list, local_ministep_get_name(ministep), stdout);
+        enkf_analysis_fprintf_obs_summary(obs_data, meas_data, step_list, local_ministep_get_name(ministep), log_stream);
+
+        if ((obs_data_get_active_size(obs_data) > 0) && (meas_data_get_active_obs_size(meas_data) > 0))
+            enkf_main_analysis_update(enkf_main,
+                                      target_fs,
+                                      ens_mask,
+                                      target_step,
+                                      use_count,
+                                      run_mode,
+                                      int_vector_get_first(step_list),
+                                      current_step,
+                                      ministep,
+                                      meas_data,
+                                      obs_data);
+        else if (target_fs != source_fs)
+          ert_log_add_fmt_message(1, stderr, "No active observations/parameters for MINISTEP: %s.",
+                                  local_ministep_get_name(ministep));
       }
 
       enkf_main_inflate(enkf_main, source_fs, target_fs, current_step, use_count);
@@ -1258,11 +1260,11 @@ static void enkf_main_update__(enkf_main_type * enkf_main, const int_vector_type
 
     {
       state_map_type * target_state_map = enkf_fs_get_state_map(target_fs);
-    
+
       if (target_state_map != source_state_map) {
-	state_map_set_from_inverted_mask(target_state_map, ens_mask, STATE_PARENT_FAILURE);
-	state_map_set_from_mask(target_state_map, ens_mask, STATE_INITIALIZED);
-	enkf_fs_fsync(target_fs);
+        state_map_set_from_inverted_mask(target_state_map, ens_mask, STATE_PARENT_FAILURE);
+        state_map_set_from_mask(target_state_map, ens_mask, STATE_INITIALIZED);
+        enkf_fs_fsync(target_fs);
       }
     }
 
@@ -1367,7 +1369,7 @@ static void enkf_main_monitor_job_queue ( const enkf_main_type * enkf_main) {
         job_queue_get_num_pending(job_queue) +
         job_queue_get_num_complete(job_queue);
 
-      
+
       if (analysis_config_have_enough_realisations(analysis_config, possible_successes, enkf_main_get_ensemble_size(enkf_main))) {
         cont = false;
       }
@@ -1456,10 +1458,10 @@ void enkf_main_create_run_path(enkf_main_type * enkf_main , const bool_vector_ty
   {
     stringlist_type * param_list = ensemble_config_alloc_keylist_from_var_type( enkf_main->ensemble_config , PARAMETER );
     enkf_main_initialize_from_scratch(enkf_main ,
-				      enkf_main_get_fs( enkf_main ),
-				      param_list ,
-				      iactive,
-				      init_mode);
+              enkf_main_get_fs( enkf_main ),
+              param_list ,
+              iactive,
+              init_mode);
     stringlist_free( param_list );
   }
 
@@ -1627,7 +1629,7 @@ static int enkf_main_run_step(enkf_main_type * enkf_main       ,
         }
       }
     }
-    
+
     enkf_fs_fsync( ert_run_context_get_result_fs( run_context ) );
     if (totalFailed == 0)
       ert_log_add_fmt_message( 1 , NULL , "All jobs complete and data loaded.");
@@ -1694,10 +1696,10 @@ void enkf_main_init_run( enkf_main_type * enkf_main, const ert_run_context_type 
   {
     stringlist_type * param_list = ensemble_config_alloc_keylist_from_var_type( enkf_main->ensemble_config , PARAMETER );
     enkf_main_initialize_from_scratch(enkf_main ,
-				      ert_run_context_get_init_fs( run_context ),
-				      param_list ,
-				      ert_run_context_get_iactive( run_context ),
-				      init_mode);
+              ert_run_context_get_init_fs( run_context ),
+              param_list ,
+              ert_run_context_get_iactive( run_context ),
+              init_mode);
     stringlist_free( param_list );
   }
 }
@@ -1722,7 +1724,7 @@ void enkf_main_run_tui_exp(enkf_main_type * enkf_main ,
   enkf_main_create_run_path( enkf_main , iactive , iter );
   hook_manager_run_workflows(hook_manager, PRE_SIMULATION, enkf_main);
   enkf_main_run_step(enkf_main , run_context);
-  
+
   int active_after = bool_vector_count_equal(iactive, true);
   if (active_after == active_before)
     hook_manager_run_workflows(hook_manager, POST_SIMULATION, enkf_main);
@@ -2592,26 +2594,26 @@ enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , b
       char * base;
       char * ext;
       if (util_is_link( _model_config )) {   /* The command line argument given is a symlink - we start by changing to */
-	                                     /* the real location of the configuration file. */
-	char  * realpath = util_alloc_link_target( _model_config );
-	util_alloc_file_components(realpath , &path , &base , &ext);
-	free( realpath );
+                                       /* the real location of the configuration file. */
+        char  * realpath = util_alloc_link_target( _model_config );
+        util_alloc_file_components(realpath , &path , &base , &ext);
+        free( realpath );
       } else
-	util_alloc_file_components(_model_config , &path , &base , &ext);
+        util_alloc_file_components(_model_config , &path , &base , &ext);
 
       if (path != NULL) {
-	if (util_chdir(path) != 0)
-	  util_abort("%s: failed to change directory to: %s : %s \n",__func__ , path , strerror(errno));
+        if (util_chdir(path) != 0)
+          util_abort("%s: failed to change directory to: %s : %s \n",__func__ , path , strerror(errno));
 
-	if (verbose)
-	  printf("Changing to directory ...................: %s \n",path);
+      if (verbose)
+        printf("Changing to directory ...................: %s \n",path);
 
-	if (ext != NULL)
-	  model_config = util_alloc_filename( NULL , base , ext );
-	else
-	  model_config = util_alloc_string_copy( base );
+      if (ext != NULL)
+        model_config = util_alloc_filename( NULL , base , ext );
+      else
+        model_config = util_alloc_string_copy( base );
       } else
-	model_config = util_alloc_string_copy(_model_config);
+        model_config = util_alloc_string_copy(_model_config);
 
       util_safe_free( path );
       util_safe_free( base );
@@ -2654,42 +2656,42 @@ enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , b
             fprintf(stderr, " %02d : %s \n",i , stringlist_iget( warnings , i ));
         }
       }
-      
+
       if (!config_content_is_valid( content )) {
-	config_error_type * errors = config_content_get_errors( content );
-	config_error_fprintf( errors , true , stderr );
-	exit(1);
+        config_error_type * errors = config_content_get_errors( content );
+        config_error_fprintf( errors , true , stderr );
+        exit(1);
       }
 
       site_config_init( enkf_main->site_config , content );                                   /*  <---- model_config : second pass. */
 
       /*****************************************************************/
       /*
-	OK - now we have parsed everything - and we are ready to start
-	populating the enkf_main object.
+  OK - now we have parsed everything - and we are ready to start
+  populating the enkf_main object.
       */
 
 
 
 
       {
-	char * log_file;
-	int log_level = DEFAULT_LOG_LEVEL;
-	if(config_content_has_item( content , LOG_LEVEL_KEY))
-	  log_level = config_content_get_value_as_int(content , LOG_LEVEL_KEY);
+        char * log_file;
+        int log_level = DEFAULT_LOG_LEVEL;
+        if(config_content_has_item( content , LOG_LEVEL_KEY))
+          log_level = config_content_get_value_as_int(content , LOG_LEVEL_KEY);
 
-	if (config_content_has_item( content , LOG_FILE_KEY))
-	  log_file = util_alloc_string_copy( config_content_get_value(content , LOG_FILE_KEY));
-	else
-	  log_file = util_alloc_filename( NULL , enkf_main->user_config_file , "log");
+        if (config_content_has_item( content , LOG_FILE_KEY))
+          log_file = util_alloc_string_copy( config_content_get_value(content , LOG_FILE_KEY));
+        else
+          log_file = util_alloc_filename( NULL , enkf_main->user_config_file , "log");
 
-	ert_log_init_log(log_level, log_file ,  enkf_main->verbose);
+        ert_log_init_log(log_level, log_file ,  enkf_main->verbose);
 
-	free( log_file );
+        free( log_file );
       }
 
       /*
-	Initializing the various 'large' sub config objects.
+  Initializing the various 'large' sub config objects.
       */
       rng_config_init( enkf_main->rng_config , content );
       enkf_main_rng_init( enkf_main );  /* Must be called before the ensmeble is created. */
@@ -2702,36 +2704,38 @@ enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , b
       ecl_config_init( enkf_main->ecl_config , content );
       plot_settings_init( enkf_main->plot_config , content );
 
-      ensemble_config_init( enkf_main->ensemble_config , content , ecl_config_get_grid( enkf_main->ecl_config ) , ecl_config_get_refcase( enkf_main->ecl_config) );
+      ensemble_config_init( enkf_main->ensemble_config , content ,
+                            ecl_config_get_grid( enkf_main->ecl_config ) ,
+                            ecl_config_get_refcase( enkf_main->ecl_config) );
 
       model_config_init( enkf_main->model_config ,
-			 content ,
-			 enkf_main_get_ensemble_size( enkf_main ),
-			 site_config_get_installed_jobs(enkf_main->site_config) ,
-			 ecl_config_get_last_history_restart( enkf_main->ecl_config ),
-			 ecl_config_get_sched_file(enkf_main->ecl_config) ,
-			 ecl_config_get_refcase( enkf_main->ecl_config ));
+                         content ,
+                         enkf_main_get_ensemble_size( enkf_main ),
+                         site_config_get_installed_jobs(enkf_main->site_config) ,
+                         ecl_config_get_last_history_restart( enkf_main->ecl_config ),
+                         ecl_config_get_sched_file(enkf_main->ecl_config) ,
+                         ecl_config_get_refcase( enkf_main->ecl_config ));
 
       enkf_main_init_hook_manager( enkf_main , content );
       enkf_main_init_data_kw( enkf_main , content );
       enkf_main_update_num_cpu( enkf_main );
       {
-	if (config_content_has_item( content , SCHEDULE_PREDICTION_FILE_KEY )) {
-	  const config_content_item_type * pred_item = config_content_get_item( content , SCHEDULE_PREDICTION_FILE_KEY );
-	  config_content_node_type * pred_node = config_content_item_get_last_node( pred_item );
-	  const char * template_file = config_content_node_iget_as_path( pred_node , 0 );
-	  {
-	    hash_type * opt_hash = hash_alloc();
-	    config_content_node_init_opt_hash( pred_node , opt_hash , 1 );
+        if (config_content_has_item( content , SCHEDULE_PREDICTION_FILE_KEY )) {
+          const config_content_item_type * pred_item = config_content_get_item( content , SCHEDULE_PREDICTION_FILE_KEY );
+          config_content_node_type * pred_node = config_content_item_get_last_node( pred_item );
+          const char * template_file = config_content_node_iget_as_path( pred_node , 0 );
+          {
+            hash_type * opt_hash = hash_alloc();
+            config_content_node_init_opt_hash( pred_node , opt_hash , 1 );
 
-	    const char * parameters = hash_safe_get( opt_hash , "PARAMETERS" );
-	    const char * min_std    = hash_safe_get( opt_hash , "MIN_STD"    );
-	    const char * init_files = hash_safe_get( opt_hash , "INIT_FILES" );
+            const char * parameters = hash_safe_get( opt_hash , "PARAMETERS" );
+            const char * min_std    = hash_safe_get( opt_hash , "MIN_STD"    );
+            const char * init_files = hash_safe_get( opt_hash , "INIT_FILES" );
 
-	    enkf_main_set_schedule_prediction_file__( enkf_main , template_file , parameters , min_std , init_files );
-	    hash_free( opt_hash );
-	  }
-	}
+            enkf_main_set_schedule_prediction_file__( enkf_main , template_file , parameters , min_std , init_files );
+            hash_free( opt_hash );
+          }
+        }
       }
 
 
@@ -2743,47 +2747,46 @@ enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , b
          be wiped after the simulations are complete.
       */
       {
-	{
-	  char * delete_runpath_string = NULL;
-	  int    ens_size              = config_content_get_value_as_int(content , NUM_REALIZATIONS_KEY);
+        {
+          char * delete_runpath_string = NULL;
+          int    ens_size              = config_content_get_value_as_int(content , NUM_REALIZATIONS_KEY);
 
-	  if (config_content_has_item(content , DELETE_RUNPATH_KEY))
-	    delete_runpath_string = config_content_alloc_joined_string(content , DELETE_RUNPATH_KEY , "");
+          if (config_content_has_item(content , DELETE_RUNPATH_KEY))
+            delete_runpath_string = config_content_alloc_joined_string(content , DELETE_RUNPATH_KEY , "");
 
-	  enkf_main_parse_keep_runpath( enkf_main , delete_runpath_string , ens_size );
+          enkf_main_parse_keep_runpath( enkf_main , delete_runpath_string , ens_size );
 
-	  util_safe_free( delete_runpath_string );
-	}
+          util_safe_free( delete_runpath_string );
+        }
 
-	/* This is really in the wrong place ... */
-	{
-	  enkf_main->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
-	  if (config_content_has_item(content , PRE_CLEAR_RUNPATH_KEY))
-	    enkf_main->pre_clear_runpath = config_content_get_value_as_bool( content , PRE_CLEAR_RUNPATH_KEY);
-	}
+        /* This is really in the wrong place ... */
+        {
+          enkf_main->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
+          if (config_content_has_item(content , PRE_CLEAR_RUNPATH_KEY))
+            enkf_main->pre_clear_runpath = config_content_get_value_as_bool( content , PRE_CLEAR_RUNPATH_KEY);
+        }
 
-	ecl_config_static_kw_init( enkf_main->ecl_config , content );
+        ecl_config_static_kw_init( enkf_main->ecl_config , content );
 
-	/* Installing templates */
-	ert_templates_init( enkf_main->templates , content );
+        /* Installing templates */
+        ert_templates_init( enkf_main->templates , content );
+
+        {
+          const char * rft_config_file = NULL;
+          if (config_content_has_item(content , RFT_CONFIG_KEY))
+            rft_config_file = config_content_iget(content , RFT_CONFIG_KEY , 0,0);
+
+          enkf_main_set_rft_config_file( enkf_main , rft_config_file );
+        }
 
 
-	{
-	  const char * rft_config_file = NULL;
-	  if (config_content_has_item(content , RFT_CONFIG_KEY))
-	    rft_config_file = config_content_iget(content , RFT_CONFIG_KEY , 0,0);
-
-	  enkf_main_set_rft_config_file( enkf_main , rft_config_file );
-	}
-
-
-	/*****************************************************************/
+        /*****************************************************************/
         enkf_main_user_select_initial_fs( enkf_main );
 
-	/* Adding ensemble members */
-	enkf_main_resize_ensemble( enkf_main  , config_content_iget_as_int(content , NUM_REALIZATIONS_KEY , 0 , 0) );
+        /* Adding ensemble members */
+        enkf_main_resize_ensemble( enkf_main, config_content_iget_as_int(content, NUM_REALIZATIONS_KEY , 0 , 0) );
 
-	/*****************************************************************/
+        /*****************************************************************/
 
         /* Loading observations */
         enkf_main_alloc_obs(enkf_main);

--- a/libenkf/src/enkf_obs.c
+++ b/libenkf/src/enkf_obs.c
@@ -334,8 +334,8 @@ static void enkf_obs_get_obs_and_measure_summary(const enkf_obs_type      * enkf
                                                  obs_vector_type          * obs_vector ,
                                                  enkf_fs_type             * fs,
                                                  const local_obsdata_node_type * obs_node ,
-                                                 const int_vector_type     * ens_active_list ,
-                                                 meas_data_type             *   meas_data,
+                                                 const int_vector_type      * ens_active_list ,
+                                                 meas_data_type             * meas_data,
                                                  obs_data_type              * obs_data,
                                                  double_vector_type         * obs_value ,
                                                  double_vector_type         * obs_std) {
@@ -1182,13 +1182,17 @@ void enkf_obs_local_scale_std( const enkf_obs_type * enkf_obs , const local_obsd
 }
 
 
-double enkf_obs_scale_correlated_std(const enkf_obs_type * enkf_obs , enkf_fs_type * fs , const int_vector_type * ens_active_list , const local_obsdata_type * local_obsdata) {
+double enkf_obs_scale_correlated_std(const enkf_obs_type * enkf_obs,
+                                     enkf_fs_type * fs,
+                                     const int_vector_type * ens_active_list,
+                                     const local_obsdata_type * local_obsdata) {
   bool_vector_type * ens_mask = int_vector_alloc_mask( ens_active_list );
   meas_data_type * meas_data = meas_data_alloc( ens_mask );
   obs_data_type * obs_data = obs_data_alloc( 1.0 );
   double scale_factor = 1.0;
 
-  enkf_obs_get_obs_and_measure_data( enkf_obs , fs , local_obsdata , ens_active_list , meas_data , obs_data );
+  enkf_obs_get_obs_and_measure_data( enkf_obs , fs , local_obsdata , ens_active_list,
+                                     meas_data , obs_data );
   {
     matrix_type * S      = meas_data_allocS( meas_data );
     if (S) {
@@ -1242,7 +1246,3 @@ local_obsdata_type * enkf_obs_alloc_all_active_local_obs( const enkf_obs_type * 
   }
   return local_obs;
 }
-
-
-
-

--- a/libenkf/src/obs_vector.c
+++ b/libenkf/src/obs_vector.c
@@ -849,7 +849,8 @@ void obs_vector_measure(const obs_vector_type * obs_vector ,
     node_id_type node_id = { .report_step = report_step ,
                              .iens        = 0 };
 
-    for (int active_iens_index =0; active_iens_index < int_vector_size( ens_active_list ); active_iens_index++) {
+    int vec_size = int_vector_size( ens_active_list );
+    for (int active_iens_index = 0; active_iens_index < vec_size; active_iens_index++) {
       node_id.iens = int_vector_iget( ens_active_list , active_iens_index );
 
       enkf_node_load(enkf_node , fs , node_id);
@@ -913,13 +914,13 @@ bool obs_vector_has_data( const obs_vector_type * obs_vector , const bool_vector
   const enkf_config_node_type * data_config = obs_vector->config_node;
   if (enkf_config_node_vector_storage( data_config ))
     return obs_vector_has_vector_data( obs_vector , active_mask , fs );
-  else {
-    for (int report_step = 0; report_step < vector_get_size( obs_vector->nodes ); report_step++) {
-      if (!obs_vector_has_data_at_report_step( obs_vector , active_mask , fs, report_step))
-        return false;
-    }
-    return true;
+
+  int vec_size = vector_get_size( obs_vector->nodes );
+  for (int report_step = 0; report_step < vec_size; report_step++) {
+    if (!obs_vector_has_data_at_report_step( obs_vector , active_mask , fs, report_step))
+      return false;
   }
+  return true;
 }
 
 
@@ -947,7 +948,7 @@ bool obs_vector_has_data( const obs_vector_type * obs_vector , const bool_vector
 static double obs_vector_chi2__(const obs_vector_type * obs_vector , int report_step , const enkf_node_type * node, node_id_type node_id) {
   void * obs_node = vector_iget( obs_vector->nodes , report_step );
 
-  if ( obs_node != NULL)
+  if (obs_node)
     return obs_vector->chi2( obs_node , enkf_node_value_ptr( node ), node_id);
   else
     return 0.0;  /* Observation not active for this report step. */
@@ -1031,12 +1032,12 @@ void obs_vector_ensemble_chi2(const obs_vector_type * obs_vector ,
 
 
 double obs_vector_total_chi2(const obs_vector_type * obs_vector , enkf_fs_type * fs , int iens) {
-  int report_step;
   double sum_chi2 = 0;
   enkf_node_type * enkf_node = enkf_node_deep_alloc( obs_vector->config_node );
   node_id_type node_id = {.report_step = 0, .iens = iens };
 
-  for (report_step = 0; report_step < vector_get_size( obs_vector->nodes ); report_step++) {
+  int vec_size = vector_get_size( obs_vector->nodes );
+  for (int report_step = 0; report_step < vec_size; report_step++) {
     if (vector_iget(obs_vector->nodes , report_step) != NULL) {
       node_id.report_step = report_step;
 
@@ -1072,7 +1073,8 @@ void obs_vector_ensemble_total_chi2(const obs_vector_type * obs_vector , enkf_fs
   {
     node_id_type node_id = {.report_step = 0, .iens = iens };
     enkf_node_type * enkf_node = enkf_node_alloc( obs_vector->config_node );
-    for (report_step = 0; report_step < vector_get_size( obs_vector->nodes); report_step++) {
+    int vec_size = vector_get_size( obs_vector->nodes);
+    for (report_step = 0; report_step < vec_size; report_step++) {
       if (verbose) {
         msg_text = util_realloc_sprintf( msg_text , "%s[%03d]" , obs_vector->obs_key , report_step);
         msg_update(msg , msg_text);

--- a/libenkf/src/obs_vector.c
+++ b/libenkf/src/obs_vector.c
@@ -893,23 +893,18 @@ static bool obs_vector_has_data_at_report_step( const obs_vector_type * obs_vect
 */
 
 static bool obs_vector_has_vector_data( const obs_vector_type * obs_vector , const bool_vector_type * active_mask , enkf_fs_type * fs) {
-  bool has_data = true;
-  int iens = 0;
+  int vec_size = bool_vector_size( active_mask );
 
-  while (true) {
+  for (int iens = 0; iens < vec_size; iens++) {
     const enkf_config_node_type * data_config = obs_vector->config_node;
     if (bool_vector_iget( active_mask , iens )) {
       if (!enkf_config_node_has_vector(data_config , fs , iens)) {
-        has_data = false;
-        break;
+        return false;
       }
     }
-    iens++;
-    if (iens >= bool_vector_size( active_mask ))
-      break;
   }
 
-  return has_data;
+  return true;
 }
 
 

--- a/libenkf/src/summary.c
+++ b/libenkf/src/summary.c
@@ -174,6 +174,9 @@ void summary_deserialize(summary_type * summary , node_id_type node_id , const a
   SUMMARY_SET_VALUE( summary , node_id.report_step , value );
 }
 
+int summary_length(const summary_type * summary) {
+  return double_vector_size(summary->data_vector);
+}
 
 double summary_get(const summary_type * summary, int report_step) {
   return SUMMARY_GET_VALUE( summary , report_step );

--- a/python/python/ert/enkf/util/time_map.py
+++ b/python/python/ert/enkf/util/time_map.py
@@ -185,8 +185,11 @@ class TimeMap(BaseCClass):
         self._free()
 
     def __repr__(self):
-        strict_ = 'strict' if self.isStrict() else 'not strict'
-        return 'TimeMap(%s, size = %d) %s' % (strict_, len(self), self._ad_str())
+        ls = len(self)
+        la = self.getLastStep()
+        st = 'strict' if self.isStrict() else 'not strict'
+        cnt = 'size = %d, last_step = %d, %s' % (ls, la, st)
+        return self._create_repr(cnt)
 
     def dump(self):
         """ 

--- a/python/tests/ert/enkf/test_time_map.py
+++ b/python/tests/ert/enkf/test_time_map.py
@@ -16,7 +16,12 @@ class TimeMapTest(ExtendedTestCase):
         tm = TimeMap()
         with self.assertRaises(IndexError):
             t = tm[10]
-            
+
+        pfx = 'TimeMap('
+        rep = repr(tm)
+        print('repr(time_map) = "%s"' % repr(tm))
+        self.assertEqual(pfx, rep[:len(pfx)])
+
         self.assertTrue( tm.update(0 , datetime.date(2000 , 1, 1)))
         self.assertEqual( tm[0] , datetime.date(2000 , 1, 1))
         


### PR DESCRIPTION
In Commit af5ee96 we test whether `obs_length > summary` in which case we disable the observation.

That same commit extracts some functionality from `enkf_obs_get_obs_and_measure_summary` out to a new function `estimate_covar_alloc_matrix`.

Prior to that commit, a small update to `TimeMap`s `repr` function.

After that follow three commits, all have no real semantic change on the code base.

1. Removed unused variable `bool has_data = true;` which was never read, and also
2. extracted `xxx_vector_size(·)` out of for loops, making the complexity from $O(n^2)$ to $O(n)$ for several loops*
3. removed tabs and replaced with two spaces as is the standard in ert.

_*_ for ridiculously small $n$, of course, but nevertheless not necessary to repeated reading of the size