### PR TITLE
Adding parsing of the last (optional) config token for the SLAVES kwd

### DIFF
--- a/libecl/src/ecl_util.c
+++ b/libecl/src/ecl_util.c
@@ -1336,8 +1336,15 @@ static int ecl_util_get_num_slave_cpu__(basic_parser_type* parser, FILE* stream,
         if (first_item[0] == '/') {
           break;
         }
-        else
-          ++num_cpu;
+        else{
+                int no_of_tokens = stringlist_get_size(tokens);
+                int no_of_slaves =0;
+                if(no_of_tokens == 6 && util_sscanf_int(stringlist_iget(tokens, 4), &no_of_slaves)){
+                    num_cpu += no_of_slaves;
+                }else{
+                    ++num_cpu;
+                }
+            }
       }
       stringlist_free( tokens );
     }

--- a/libecl/tests/data/num_cpu3
+++ b/libecl/tests/data/num_cpu3
@@ -1,8 +1,9 @@
 SLAVES
 -- slave datafile machine directory
 -- name root hostname of data file
-'RES-R2' 'base' 'rios' '/usr/models/res2' /
-'RES-R3' 'base' 'sg-indigo' '/usr/models/res3' /
+'RES-R2' 'base' 'rios' '/usr/models/res2' 3 /
+'RES-R3' 'base' 'sg-indigo' '/usr/models/res3' A / -- a wrongfully added character in the
+-- "slaves token" position doesn't brake parsing
 -- Testing comments in middle
-'RES-R5' 'base' 'sg-indigo' '/usr/models/res5' /
-   /testRubbish
+'RES-R5' 'base' 'sg-indigo' '/usr/models/res5' 10 /
+   /testRubbish -- this line also counts

--- a/libecl/tests/ecl_get_num_cpu_test.c
+++ b/libecl/tests/ecl_get_num_cpu_test.c
@@ -28,11 +28,11 @@ int main(int argc , char ** argv) {
   const char * filename3 = argv[3];
   const char * filename4 = argv[4];
 
-  int num_cpu = 4;
-  test_assert_int_equal(ecl_util_get_num_cpu(filename1), num_cpu);
-  test_assert_int_equal(ecl_util_get_num_cpu(filename2), num_cpu);
-  test_assert_int_equal(ecl_util_get_num_cpu(filename3), num_cpu);
-  test_assert_int_equal(ecl_util_get_num_cpu(filename4), num_cpu);
+
+  test_assert_int_equal(ecl_util_get_num_cpu(filename1), 4);
+  test_assert_int_equal(ecl_util_get_num_cpu(filename2), 4);
+  test_assert_int_equal(ecl_util_get_num_cpu(filename3), 15);
+  test_assert_int_equal(ecl_util_get_num_cpu(filename4), 4);
   exit(0);
 
 }


### PR DESCRIPTION
If the last token is an integer, this specifies the number of cpu's for the configuration. If not each line counts as one cpu.