### PR TITLE
Torque invalid reply

### DIFF
--- a/libjob_queue/include/ert/job_queue/queue_driver.h
+++ b/libjob_queue/include/ert/job_queue/queue_driver.h
@@ -65,10 +65,11 @@ extern "C" {
     JOB_QUEUE_SUCCESS     = 16384,
     JOB_QUEUE_RUNNING_CALLBACK = 32768,
     JOB_QUEUE_FAILED      = 65536,
-    JOB_QUEUE_DO_KILL_NODE_FAILURE = 131072 /* LSF will attempt to blacklist the nodes that failed this job */
+    JOB_QUEUE_DO_KILL_NODE_FAILURE = 131072, /* LSF will attempt to blacklist the nodes that failed this job */
+    JOB_QUEUE_STATUS_FAILURE = 262144        /* The command to get job_status has failed - let the status remain unchanged. */
   } job_status_type;
 
-#define JOB_QUEUE_MAX_STATE 13
+#define JOB_QUEUE_MAX_STATE 14
 
   /*
     All jobs which are in the status set defined by

--- a/libjob_queue/src/job_queue_status.c
+++ b/libjob_queue/src/job_queue_status.c
@@ -128,6 +128,14 @@ bool job_queue_status_transition(job_queue_status_type * status_count, job_statu
         job_status_type target_status) {
   if (src_status == target_status)
     return false;
+
+  /*
+    The target_status indicates that the routine which queried for new
+    status failed; we just remain in the current status.
+  */
+  if (target_status == JOB_QUEUE_STATUS_FAILURE)
+    return false;
+
   job_queue_status_dec( status_count, src_status );
   job_queue_status_inc( status_count, target_status );
   return true;

--- a/libjob_queue/src/torque_driver.c
+++ b/libjob_queue/src/torque_driver.c
@@ -501,7 +501,8 @@ job_status_type torque_driver_get_job_status(void * __driver, void * __job) {
   } else if (strcmp(status, "Q") == 0) {
     result = JOB_QUEUE_PENDING;
   } else {
-    util_abort("%s: Unknown status found (%s), expecting one of R, E, C and Q.\n", __func__, status);
+    fprintf(stderr, "%s: Unknown status found (%s), expecting one of R, E, C and Q.\n", __func__, status);
+    result = JOB_QUEUE_STATUS_FAILURE;
   }
   free(status);
 

--- a/libjob_queue/tests/job_torque_submit_test.c
+++ b/libjob_queue/tests/job_torque_submit_test.c
@@ -20,20 +20,25 @@
 #include <unistd.h>
 
 #include <ert/util/util.h>
+#include <ert/util/test_work_area.h>
 #include <ert/util/test_util.h>
 
 #include <ert/job_queue/torque_driver.h>
+
+void assert_status( torque_driver_type * driver, torque_job_type * job, int status_mask) {
+  int torque_status = torque_driver_get_job_status(driver, job);
+  if ((torque_status & status_mask) == 0)
+    test_exit("Incorrect status:%d  - expected overlap with: %d\n" , torque_status , status_mask);
+}
+
+
 
 void test_submit(torque_driver_type * driver, const char * cmd) {
   char * run_path = util_alloc_cwd();
   torque_job_type * job = torque_driver_submit_job(driver, cmd, 1, run_path, "TEST-TORQUE-SUBMIT", 0, NULL);
 
   if (job != NULL) {
-    int torque_status = torque_driver_get_job_status(driver, job);
-    if (!((torque_status == JOB_QUEUE_RUNNING) || (torque_status == JOB_QUEUE_PENDING))) {
-      test_exit("After start of job, the status is %d, it should have been JOB_QUEUE_RUNNING(%d) or JOB_QUEUE_PENDING (%d). Other statuses are JOB_QUEUE_EXIT(%d) and JOB_QUEUE_FAILED(%d)\n", torque_status, JOB_QUEUE_RUNNING, JOB_QUEUE_PENDING, JOB_QUEUE_EXIT, JOB_QUEUE_FAILED);
-    }
-
+    assert_status( driver , job, JOB_QUEUE_RUNNING + JOB_QUEUE_PENDING);
     torque_driver_kill_job(driver, job);
     printf("Waiting 2 seconds");
     for (int i = 0; i < 2; i++) {
@@ -43,7 +48,7 @@ void test_submit(torque_driver_type * driver, const char * cmd) {
     }
     printf("\n");
 
-    torque_status = torque_driver_get_job_status(driver, job);
+    int torque_status = torque_driver_get_job_status(driver, job);
     if (torque_status != JOB_QUEUE_EXIT && torque_status != JOB_QUEUE_DONE) {
       exit(1);
       test_exit("After kill of job, the status is %d, it should have been JOB_QUEUE_EXIT, which is %d\n", torque_status, JOB_QUEUE_EXIT);
@@ -61,12 +66,46 @@ void test_submit_nocommand(torque_driver_type * driver) {
   test_submit(driver, NULL);
 }
 
+
+
+
+void test_submit_failed_qstat(torque_driver_type * driver, const char * cmd) {
+  char * run_path = util_alloc_cwd();
+  torque_job_type * job = torque_driver_submit_job(driver, cmd, 1, run_path, "TEST-TORQUE-SUBMIT", 0, NULL);
+
+  {
+    test_work_area_type * work_area = test_work_area_alloc("torque-failed-qstat");
+    test_work_area_copy_file( work_area , torque_driver_get_option( driver , TORQUE_QSTAT_CMD ));
+    assert_status( driver , job , JOB_QUEUE_RUNNING + JOB_QUEUE_PENDING);
+
+    {
+      char * qstat_cmd = util_alloc_abs_path( "qstat.local" );
+      FILE * stream = util_fopen( qstat_cmd , "w");
+      fprintf(stream , "#!/bin/sh\n");
+      fprintf(stream , "echo XYZ - Error\n");
+      fclose( stream );
+      util_addmode_if_owner(qstat_cmd, S_IXUSR );
+      torque_driver_set_option(driver, TORQUE_QSTAT_CMD, qstat_cmd);
+      free( qstat_cmd );
+    }
+
+    assert_status( driver , job , JOB_QUEUE_STATUS_FAILURE );
+    test_work_area_free( work_area );
+  }
+
+  torque_driver_free_job(job);
+  free(run_path);
+}
+
+
+
 int main(int argc, char ** argv) {
   torque_driver_type * driver = torque_driver_alloc();
   if (argc == 1) {
     test_submit_nocommand(driver);
   } else if (argc == 2) {
     test_submit(driver, argv[1]);
+    test_submit_failed_qstat( driver , argv[1] );
   } else {
     printf("Only accepts zero or one arguments (the job script to run)\n");
     exit(1);

--- a/python/python/ert/job_queue/job_status_type_enum.py
+++ b/python/python/ert/job_queue/job_status_type_enum.py
@@ -32,7 +32,8 @@ class JobStatusType(BaseCEnum):
     JOB_QUEUE_RUNNING_CALLBACK = None
     JOB_QUEUE_FAILED = None
     JOB_QUEUE_DO_KILL_NODE_FAILURE = None
-
+    JOB_QUEUE_STATUS_FAILURE = None
+    
 
 JobStatusType.addEnum("JOB_QUEUE_NOT_ACTIVE", 1)
 JobStatusType.addEnum("JOB_QUEUE_WAITING", 4)
@@ -47,3 +48,4 @@ JobStatusType.addEnum("JOB_QUEUE_SUCCESS", 16384)
 JobStatusType.addEnum("JOB_QUEUE_RUNNING_CALLBACK", 32768)
 JobStatusType.addEnum("JOB_QUEUE_FAILED", 65536)
 JobStatusType.addEnum("JOB_QUEUE_DO_KILL_NODE_FAILURE", 131072)
+JobStatusType.addEnum("JOB_QUEUE_STATUS_FAILURE", 262144)


### PR DESCRIPTION
The torque driver will not abort if the qstat command returns an invalid status.