### PR TITLE
Protect against invalid job status.

### DIFF
--- a/python/python/ert_gui/simulation/models/simulations_tracker.py
+++ b/python/python/ert_gui/simulation/models/simulations_tracker.py
@@ -78,6 +78,12 @@ class SimulationsTracker(object):
 
     def __checkForUnusedEnums(self):
         for enum in JobStatusType.enums():
+            # The status check routines can return this status; if e.g. the bjobs call fails,
+            # but a job will never get this status.
+            if enum == JobStatusType.JOB_QUEUE_STATUS_FAILURE:
+                continue
+                
+                
             used = False
             for state in self.states:
                 if enum in state.state:


### PR DESCRIPTION
The job status update routines can return the status:
JOB_QUEUE_STATUS_FAILURE; the queue layer will interepret that as:

  Do not update the job status.

Hence no job can actually have this status while running.