### PR TITLE
Issue with `char* ecl_grid_get_name( ecl_grid )` returning nullptr

### DIFF
--- a/python/python/ert/ecl/ecl_grid.py
+++ b/python/python/ert/ecl/ecl_grid.py
@@ -344,15 +344,15 @@ class EclGrid(BaseCClass):
 
     def getName(self):
         """
-        Name of the current grid.
-        
+        Name of the current grid, returns a string.
+
         For the main grid this is the filename given to the
         constructor when loading the grid; for an LGR this is the name
         of the LGR. If the grid instance has been created with the
         create() classmethod this can be None.
         """
-        return self._get_name( )
-
+        n = self._get_name()
+        return str(n) if n else ''
 
     def global_index( self , active_index = None, ijk = None):
         """

--- a/python/tests/core/ecl/test_grid.py
+++ b/python/tests/core/ecl/test_grid.py
@@ -85,10 +85,22 @@ class GridTest(ExtendedTestCase):
         actnum[1] = 0
         grid = EclGrid.createRectangular( (10,20,30) , (1,1,1) , actnum = actnum)
         self.assertEqual( grid.getNumActive( ) , 30*20*10 - 2)
-    
-    
-    
-    
+
+    def test_repr_and_name(self):
+        grid = EclGrid.createRectangular((2,2,2), (10,10,10), actnum=[0,0,0,0,1,1,1,1])
+        pfx = 'EclGrid('
+        rep = repr(grid)
+        self.assertEqual(pfx, rep[:len(pfx)])
+        self.assertEqual(type(rep), type(''))
+        self.assertEqual(type(grid.getName()), type(''))
+        with TestAreaContext("python/ecl_grid/repr"):
+            grid.save_EGRID("CASE.EGRID")
+            g2 = EclGrid("CASE.EGRID")
+            r2 = repr(g2)
+            self.assertEqual(pfx, r2[:len(pfx)])
+            self.assertEqual(type(r2), type(''))
+            self.assertEqual(type(g2.getName()), type(''))
+
     def test_node_pos(self):
         grid = EclGrid.createRectangular( (10,20,30) , (1,1,1) )
         with self.assertRaises(IndexError):


### PR DESCRIPTION
Improved `EclGrid.getName` function, which made `EclGrid.__repr__(·)` "hickup".

In the case that a grid is synthetically constructed, `EclGrid.getName()` returned `None`.  Now we guarantee that `EclGrid.getName()` returns a string.