### PR TITLE
WIP removed some uses of CFILE

### DIFF
--- a/libecl/src/ecl_sum.c
+++ b/libecl/src/ecl_sum.c
@@ -662,6 +662,11 @@ double ecl_sum_get_general_var(const ecl_sum_type * ecl_sum , int time_index , c
   return ecl_sum_data_iget( ecl_sum->data , time_index  , params_index);
 }
 
+void ecl_sum_fwrite_interp_csv_line_to_filename(const ecl_sum_type * ecl_sum, time_t sim_time, const ecl_sum_vector_type * key_words, const char* fname){
+  FILE * filestream = util_fopen__( fname , "w");
+  ecl_sum_data_fwrite_interp_csv_line(ecl_sum->data, sim_time, key_words, fname);
+  fclose(filestream);
+}
 
 void ecl_sum_fwrite_interp_csv_line(const ecl_sum_type * ecl_sum, time_t sim_time, const ecl_sum_vector_type * key_words, FILE *fp){
   ecl_sum_data_fwrite_interp_csv_line(ecl_sum->data, sim_time, key_words, fp);

--- a/libenkf/include/ert/enkf/gen_kw.h
+++ b/libenkf/include/ert/enkf/gen_kw.h
@@ -59,6 +59,9 @@ char           * gen_kw_alloc_user_key(const gen_kw_config_type *  , const char 
 void             gen_kw_set_subst_parent(gen_kw_type * gen_kw , const subst_list_type * parent_subst);
 void             gen_kw_ecl_write_template(const gen_kw_type * gen_kw , const char * file_name);
 
+void             gen_kw_write_export_to_filename(const gen_kw_type * gen_kw, char * filename);
+void             gen_kw_write_export_file(const gen_kw_type * gen_kw, FILE * filestream);
+
 
 UTIL_SAFE_CAST_HEADER(gen_kw);
 UTIL_SAFE_CAST_HEADER_CONST(gen_kw);

--- a/libenkf/src/gen_kw.c
+++ b/libenkf/src/gen_kw.c
@@ -253,6 +253,12 @@ void gen_kw_filter_file(const gen_kw_type * gen_kw , const char * target_file) {
 }
 
 
+void gen_kw_write_export_to_filename(const gen_kw_type * gen_kw, char * fname) {
+  FILE * filestream = util_fopen__( fname , "w");
+  gen_kw_write_export_file(gen_kw, filestream);
+  fclose(filestream);
+}
+
 void gen_kw_write_export_file(const gen_kw_type * gen_kw, FILE * filestream) {
   const int size = gen_kw_config_get_data_size(gen_kw->config );
   int ikw;

--- a/libert_util/src/matrix.c
+++ b/libert_util/src/matrix.c
@@ -546,7 +546,11 @@ void matrix_pretty_print(const matrix_type * matrix , const char * name , const 
   matrix_pretty_fprint(matrix , name , fmt , stdout );
 }
 
-
+void matrix_fprint_to_filename( const matrix_type * matrix , const char * fmt , const char * fname) {
+  FILE * filestream = util_fopen__( fname , "w");
+  matrix_fprintf(matrix, fmt, filestream);
+  fclose(filestream);
+}
 void matrix_fprintf( const matrix_type * matrix , const char * fmt , FILE * stream ) {
   int i,j;
   for (i=0; i < matrix->rows; i++) {

--- a/python/python/ert/ecl/ecl_kw.py
+++ b/python/python/ert/ecl/ecl_kw.py
@@ -247,8 +247,11 @@ class EclKW(BaseCClass):
         @kw, in which case the method will load the first keyword
         it finds in the file.
         """
-        
-        cfile  = CFILE( fileH )
+
+        if isinstance(cfile, str):
+            fname = cfile
+        else:
+            raise NotImplementedError('Does not support reading file, must be filename.')
         if kw:
             if len(kw) > 8:
                 raise TypeError("Sorry keyword:%s is too long, must be eight characters or less." % kw)

--- a/python/python/ert/ecl/ecl_sum.py
+++ b/python/python/ert/ecl/ecl_sum.py
@@ -30,7 +30,7 @@ import os.path
 # regarding order of arguments: The C code generally takes the time
 # index as the first argument and the key/key_index as second
 # argument. In the python code this order has been reversed.
-from cwrap import BaseCClass, CFILE
+from cwrap import BaseCClass
 from ert.ecl import EclSumTStep
 from ert.ecl import EclSumVarType
 from ert.ecl.ecl_sum_vector import EclSumVector
@@ -1206,14 +1206,15 @@ class EclSum(BaseCClass):
         content = 'name = "%s", time = [%s, %s], keys = %d' % (name, s_time, e_time, num_keys)
         return self._create_repr(content)
 
-    def dumpCSVLine(self, time, keywords, pfile):
+    def dumpCSVLine(self, time, keywords, pfile=None, fname=None):
         """
         Will dump a csv formatted line of the keywords in @keywords,
         evaluated at the intertpolated time @time. @pfile should point to an open Python file handle.
         """
-        cfile = CFILE(pfile )
+        if pfile:
+            raise NotImplementedError('Cannot provide file handle, use filename.')
         ctime = CTime( time )
-        EclSum._dump_csv_line(self , ctime, keywords, cfile)
+        EclSum._dump_csv_line(self , ctime, keywords, fname)
 
 
     def exportCSV(self , filename , keys = None , date_format = "%Y-%m-%d" , sep = ";"):
@@ -1242,4 +1243,4 @@ class EclSum(BaseCClass):
 
 
 import ert.ecl.ecl_sum_keyword_vector
-EclSum._dump_csv_line = EclPrototype("void  ecl_sum_fwrite_interp_csv_line(ecl_sum , time_t , ecl_sum_vector, FILE)" , bind = False)
+EclSum._dump_csv_line = EclPrototype("void  ecl_sum_fwrite_interp_csv_line_to_filename(ecl_sum , time_t , ecl_sum_vector, char*)" , bind = False)

--- a/python/python/ert/enkf/data/gen_kw.py
+++ b/python/python/ert/enkf/data/gen_kw.py
@@ -15,7 +15,7 @@
 #  for more details.
 import os.path
 
-from cwrap import BaseCClass, CFILE
+from cwrap import BaseCClass
 
 from ert.util import DoubleVector
 from ert.enkf import EnkfPrototype
@@ -26,7 +26,7 @@ class GenKw(BaseCClass):
     TYPE_NAME = "gen_kw"
     _alloc             = EnkfPrototype("void*  gen_kw_alloc(gen_kw_config)", bind = False)
     _free              = EnkfPrototype("void   gen_kw_free(gen_kw_config)")
-    _export_parameters = EnkfPrototype("void   gen_kw_write_export_file(gen_kw , FILE)")
+    _export_parameters = EnkfPrototype("void   gen_kw_write_export_to_filename(gen_kw , char*)")
     _export_template   = EnkfPrototype("void   gen_kw_ecl_write_template(gen_kw , char* )")
     _data_iget         = EnkfPrototype("double gen_kw_data_iget(gen_kw, int, bool)")
     _data_iset         = EnkfPrototype("void   gen_kw_data_iset(gen_kw, int, double)")
@@ -35,7 +35,7 @@ class GenKw(BaseCClass):
     _data_set          = EnkfPrototype("void   gen_kw_data_set(gen_kw, char*, double)")
     _size              = EnkfPrototype("int    gen_kw_data_size(gen_kw)")
     _has_key           = EnkfPrototype("bool   gen_kw_data_has_key(gen_kw, char*)")
-    _ecl_write         = EnkfPrototype("void   gen_kw_ecl_write(gen_kw,    char* , char* , FILE)")
+    _ecl_write         = EnkfPrototype("void   gen_kw_ecl_write(gen_kw,    char* , char* , void*)")
     _iget_key          = EnkfPrototype("char*  gen_kw_get_name(gen_kw, int)")
     
 
@@ -50,13 +50,11 @@ class GenKw(BaseCClass):
             self.__str__ = self.__repr__
         else:
             raise ValueError('Cannot issue a GenKw from the given keyword config: %s.' % str(gen_kw_config))
-    
 
-    def exportParameters(self, file_name):
+
+    def exportParameters(self, fname):
         """ @type: str """
-        with open(file_name , "w") as py_file:
-            cfile  = CFILE( py_file )
-            self._export_parameters(cfile)
+        self._export_parameters(fname)
 
 
     def exportTemplate(self, file_name):
@@ -107,14 +105,13 @@ class GenKw(BaseCClass):
                         self._data_iget(index, do_transform)) )
         return v
 
-        
+
     def eclWrite(self , path , filename , export_file = None):
         if not path is None:
             if not os.path.isdir(path):
                 raise IOError("The directory:%s does not exist" % path)
         if export_file:
-            with open(export_file , "w") as fileH:
-                self._ecl_write(path , filename , CFILE( fileH ))
+            raise NotImplementedError('Cannot use export_file, must use filename')
         else:
             self._ecl_write( path , filename , None )
 

--- a/python/python/ert/util/matrix.py
+++ b/python/python/ert/util/matrix.py
@@ -28,7 +28,7 @@
 # choice.
 
 
-from cwrap import BaseCClass,CFILE
+from cwrap import BaseCClass
 from ert.util import UtilPrototype
 
 
@@ -51,6 +51,7 @@ class Matrix(BaseCClass):
     _equal             = UtilPrototype("bool matrix_equal(matrix, matrix)")
     _pretty_print      = UtilPrototype("void matrix_pretty_print(matrix, char*, char*)")
     _fprint            = UtilPrototype("void matrix_fprintf(matrix, char*, FILE)")
+    _fprint_to_filename= UtilPrototype("void matrix_fprintf(matrix, char*, char*)")
     _random_init       = UtilPrototype("void matrix_random_init(matrix, rng)")
     _dump_csv          = UtilPrototype("void matrix_dump_csv(matrix, char*)")
     
@@ -188,7 +189,7 @@ class Matrix(BaseCClass):
     def prettyPrint(self, name, fmt="%6.3g"):
         self._pretty_print(name, fmt)
 
-    def fprint(self , fileH , fmt = "%g "):
+    def fprint(self , fileH = None , filename = None, fmt = "%g "):
         """Will print ASCII representation of matrix.
 
         The fileH argument should point to an open Python
@@ -212,7 +213,9 @@ class Matrix(BaseCClass):
          6 7 8
 
         """
-        self._fprint( fmt , CFILE( fileH))
+        if fileH is not None:
+            raise NotImplementedError('Unsupported operation.  Please provide a filename.')
+        self._fprint_to_filename( fmt , filename)
 
         
     def randomInit(self, rng):

--- a/python/python/ert/util/vector_template.py
+++ b/python/python/ert/util/vector_template.py
@@ -44,7 +44,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import  sys
 
-from cwrap import CFILE, BaseCClass
+from cwrap import BaseCClass
 from ert.util import UtilPrototype
 
     
@@ -401,18 +401,6 @@ class VectorTemplate(BaseCClass):
         The number of elements in the vector.
         """
         return self._size( )
-
-
-    def printf(self, fmt=None, name=None, stream=sys.stdout):
-        """
-        See also the str() method which returns string representantion
-        of the vector.
-        """
-        cfile = CFILE(stream)
-        if not fmt:
-            fmt = self.default_format
-        self._fprintf(cfile, name, fmt)
-
 
     def max(self):
         if len(self) > 0:

--- a/python/tests/core/ecl/test_ecl_sum.py
+++ b/python/tests/core/ecl/test_ecl_sum.py
@@ -16,7 +16,7 @@
 #  for more details.
 import datetime
 import os.path
-from cwrap import CFILE
+
 from ert.ecl import EclSum, EclSumKeyWordVector, EclFile,FortIO, openFortIO,openEclFile,EclKW
 from ert.test import ExtendedTestCase , TestAreaContext
 
@@ -51,8 +51,7 @@ class EclSumTest(ExtendedTestCase):
         dtime = datetime.datetime( 2002 , 1 , 1 , 0 , 0 , 0 )
         with TestAreaContext("EclSum/csv_dump"):
             test_file_name = self.createTestPath("dump.csv")
-            outputH = open(test_file_name , "w")
-            self.ecl_sum.dumpCSVLine( dtime, ecl_sum_vector, outputH)
+            self.ecl_sum.dumpCSVLine( dtime, ecl_sum_vector, fname = test_file_name)
             assert os.path.isfile(test_file_name)
 
 


### PR DESCRIPTION
The goal with this WIP PR is to have a conversation regarding the future of CFILE, streams, file handles and descriptors, and python 3 compatibility.

Today, the CFILE implementation and strategy is not Python 3 compatible, and not possible to make python 3 compatible (due to the removal of `FILE *fp = PyFile_AsFile(p);` from Python 3).

We should agree on a strategy to get rid of the use of `PyFile`.

Kjør debatt.