### PR TITLE
fortio test fix: initialize declared variable

### DIFF
--- a/libecl/src/ecl_util.c
+++ b/libecl/src/ecl_util.c
@@ -741,7 +741,7 @@ bool ecl_util_fmt_file(const char *filename , bool * __fmt_file) {
   int report_nr;
   ecl_file_enum file_type;
   bool status = true;
-  bool fmt_file;
+  bool fmt_file = 0;
 
   if (util_file_exists(filename)) {
     file_type = ecl_util_get_file_type(filename , &fmt_file , &report_nr);


### PR DESCRIPTION
Changes `bool fmt_file;` to `bool fmt_file = 0`.  This fixes fortio (and deprecation) test failures in release mode.

There is a branch in `bool ecl_util_fmt_file(const char *filename , bool * __fmt_file)` that does not set the `fmt_file` variable, namely when `util_file_exists(filename)` and `!util_file_size(filename) > min_size`.

This led `fmt_file` to take an undefined value in release mode, whereas it was always initialized to `0` in debug mode.