### PR TITLE
explicitly turn on DeprecationWarning always

### DIFF
--- a/python/python/ert/__init__.py
+++ b/python/python/ert/__init__.py
@@ -57,6 +57,10 @@ before giving up completely.
 """
 import os.path
 import sys
+
+import warnings
+warnings.simplefilter('always', DeprecationWarning) # see #1437
+
 from cwrap import load as cwrapload
 
 try:


### PR DESCRIPTION
`DeprecationWarning`s are silenced by default [1] in python 2.7 and later. If we want users to see the deprecation warning, we need to explicitly turn it off in our modules.

This PR turns `DeprecationWarning` on `always` in `ert`.


See discussion at #1437, #1358.

[1] [Base category for warnings about deprecated features (ignored by default).](https://docs.python.org/2/library/warnings.html)