### PR TITLE
Properly load EnkfSimulationRunner in IES

### DIFF
--- a/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
+++ b/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py
@@ -43,7 +43,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
         source_fs = self.ert().getEnkfFsManager().getCurrentFileSystem()
 
         self.setPhaseName("Pre processing update...", indeterminate=True)
-        EnkfSimulationRunner(ert).runWorkflows(HookRuntime.PRE_UPDATE)
+        self.ert().getEnkfSimulationRunner().runWorkflows(HookRuntime.PRE_UPDATE)
         es_update = self.ert().getESUpdate()
 
         success = es_update.smootherUpdate(source_fs, target_fs)
@@ -51,7 +51,7 @@ class IteratedEnsembleSmoother(BaseRunModel):
             raise ErtRunError("Analysis of simulation failed!")
 
         self.setPhaseName("Post processing update...", indeterminate=True)
-        EnkfSimulationRunner(ert).runWorkflows(HookRuntime.POST_UPDATE)
+        self.ert().getEnkfSimulationRunner().runWorkflows(HookRuntime.POST_UPDATE)
 
     def runSimulations(self, arguments):
         phase_count = getNumberOfIterations() + 1


### PR DESCRIPTION
Fixes issue introduced in ba348c9.
```
Exception in thread ert_gui_simulation_thread:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 811, in __bootstrap_inner
    self.run()
  File "...ert/ert/python/python/ert_gui/simulation/run_dialog.py", line 116, in run
    self._run_model.startSimulations(self._run_arguments)
  File "...ert/ert/python/python/ert_gui/simulation/models/base_run_model.py", line 38, in startSimulations
    self.runSimulations(run_arguments)
  File "...ert/ert/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py", line 85, in runSimulations
    self.analyzeStep(target_fs)
  File "...ert/ert/python/python/ert_gui/simulation/models/iterated_ensemble_smoother.py", line 46, in analyzeStep
    EnkfSimulationRunner(ert).runWorkflows(HookRuntime.PRE_UPDATE)
NameError: global name 'EnkfSimulationRunner' is not defined

```