### PR TITLE
Prints message regarding MAX_SUBMIT

### DIFF
--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -860,8 +860,8 @@ static void lsf_driver_node_failure(lsf_driver_type * driver, long lsf_job_id) {
     fprintf(stderr, "%s blacklisting nodes %s.\n", __func__, hostnames);
 
     fprintf(stderr,
-            "%s Realization %ld seems to have failed as a result of LSF node failure.\n",
-            __func__, lsf_job_id
+            "Realization %ld seems to have failed as a result of LSF node failure.\n",
+            lsf_job_id
             );
     fprintf(stderr,
             "This job will be re-submitted to a different node according to the "

--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -859,6 +859,15 @@ static void lsf_driver_node_failure(lsf_driver_type * driver, long lsf_job_id) {
     char* hostnames = stringlist_alloc_joined_string(hosts, ", ");
     fprintf(stderr, "%s blacklisting nodes %s.\n", __func__, hostnames);
 
+    fprintf(stderr,
+            "%s Realization %ld seems to have failed as a result of LSF node failure.\n",
+            __func__, lsf_job_id
+            );
+    fprintf(stderr,
+            "This job will be re-submitted to a different node according to the "
+            "number of re-submit specified in MAX_SUBMIT in the ert config file.\n"
+            );
+
     lsf_driver_add_exclude_hosts(driver, hostnames);
 
     util_free(hostnames);


### PR DESCRIPTION
When a node fails we should inform the user that this failure counts towards the specified MAX_SUBMIT.