### PR TITLE
removed unnecessary __str__ = __repr__

### DIFF
--- a/python/python/ert/ecl/ecl_sum.py
+++ b/python/python/ert/ecl/ecl_sum.py
@@ -160,7 +160,6 @@ class EclSum(BaseCClass):
         else:
             super(EclSum, self).__init__(c_pointer)
             self.__private_init( )
-        self.__str__ = self.__repr__
         self._load_case = load_case
 
 


### PR DESCRIPTION
Not necessary, and potential cause of memory leak

Possibly Fixes #1447 