### PR TITLE
Hunting compilation warnings

### DIFF
--- a/libanalysis/src/bootstrap_enkf.c
+++ b/libanalysis/src/bootstrap_enkf.c
@@ -154,7 +154,6 @@ void bootstrap_enkf_updateA(void * module_data ,
     {
       int ensemble_members_loop;
       for ( ensemble_members_loop = 0; ensemble_members_loop < ens_size; ensemble_members_loop++) {
-        int unique_bootstrap_components;
         int ensemble_counter;
         /* Resample A and meas_data. Here we are careful to resample the working copy.*/
         {
@@ -167,7 +166,6 @@ void bootstrap_enkf_updateA(void * module_data ,
               matrix_copy_column( S_resampled , S  , ensemble_counter , random_column );
             }
             int_vector_select_unique( bootstrap_components );
-            unique_bootstrap_components = int_vector_size( bootstrap_components );
             int_vector_free( bootstrap_components );
           }
 

--- a/libconfig/src/config_schema_item.c
+++ b/libconfig/src/config_schema_item.c
@@ -155,16 +155,6 @@ static void validate_set_argc_minmax(validate_type * validate , int argc_min , i
 
   if ((argc_max != CONFIG_DEFAULT_ARG_MAX) && (argc_max < argc_min))
     util_abort("%s invalid arg min/max values. argc_min:%d  argc_max:%d \n",__func__ , argc_min , argc_max);
-
-  {
-    int internal_type_size = 0;  /* Should end up in the range [argc_min,argc_max] */
-
-    if (argc_max > 0)
-      internal_type_size = argc_max;
-    else
-      internal_type_size = argc_min;
-  }
-
 }
 
 

--- a/libconfig/src/config_settings.c
+++ b/libconfig/src/config_settings.c
@@ -116,7 +116,6 @@ static void setting_node_set_double_value( setting_node_type * node, double valu
 
 
 static void setting_node_set_bool_value( setting_node_type * node, bool value) {
-  bool bool_value;
   setting_node_assert_type( node , CONFIG_BOOL );
   if (value)
     setting_node_set_value( node , "True");

--- a/libenkf/applications/ert_tui/enkf_tui_export.c
+++ b/libenkf/applications/ert_tui/enkf_tui_export.c
@@ -116,7 +116,6 @@ void enkf_tui_export_gen_data(void * arg) {
   enkf_main_type * enkf_main = enkf_main_safe_cast( arg );
   const ensemble_config_type * ensemble_config = enkf_main_get_ensemble_config(enkf_main);
   {
-    enkf_var_type var_type;
     int report_step;
     int iens1 , iens2;
     const int last_report = enkf_main_get_history_length( enkf_main );
@@ -125,7 +124,6 @@ void enkf_tui_export_gen_data(void * arg) {
     path_fmt_type * file_fmt;
 
     config_node    = enkf_tui_util_scanf_key(ensemble_config , PROMPT_LEN ,  GEN_DATA , INVALID_VAR);
-    var_type       = enkf_config_node_get_var_type(config_node);
     
     
     report_step = util_scanf_int_with_limits("Report step: ", PROMPT_LEN , 0 , last_report);

--- a/libenkf/applications/ert_tui/enkf_tui_fs.c
+++ b/libenkf/applications/ert_tui/enkf_tui_fs.c
@@ -205,13 +205,9 @@ void enkf_tui_fs_initialize_case_from_copy(void * arg)
 {
   int prompt_len =50;
   char * source_case;
-  int ens_size;
   int last_report;
   int src_step;
   enkf_main_type   * enkf_main = enkf_main_safe_cast( arg );
-
-  ens_size = enkf_main_get_ensemble_size( enkf_main );
-
 
   last_report  = enkf_main_get_history_length( enkf_main );
 

--- a/libenkf/src/enkf_node.c
+++ b/libenkf/src/enkf_node.c
@@ -239,8 +239,6 @@ bool enkf_node_vector_storage( const enkf_node_type * node ) {
   return node->vector_storage;
 }
 
-static UTIL_IS_INSTANCE_FUNCTION( enkf_node , ENKF_NODE_TYPE_ID )
-
 
 /*****************************************************************/
 

--- a/libert_util/include/ert/util/util.h
+++ b/libert_util/include/ert/util/util.h
@@ -294,6 +294,8 @@ typedef enum {left_pad   = 0,
   bool         util_string_isspace(const char * s);
 
   char *  util_alloc_dump_filename(void);
+  void    util_abort_test_set_intercept_function(const char *);
+  bool    util_addr2line_lookup(const void *, char **, char **, int *);
   void    util_exit(const char * fmt , ...);
   void    util_install_signals(void);
   void    util_update_signals(void);

--- a/libert_util/src/test_util.c
+++ b/libert_util/src/test_util.c
@@ -29,7 +29,7 @@
 #include <ert/util/arg_pack.h>
 #include <ert/util/test_util.h>
 #include <ert/util/stringlist.h>
-
+#include <ert/util/util.h>
 
 void test_error_exit( const char * fmt , ...) {
   char * s;

--- a/libjob_queue/src/forward_model.c
+++ b/libjob_queue/src/forward_model.c
@@ -142,13 +142,11 @@ void forward_model_parse_init(forward_model_type * forward_model , const char * 
   while (true) {
     ext_job_type *  current_job;
     char         * job_name;
-    int            job_index;
     {
       int job_length  = strcspn(p1 , " (");  /* scanning until we meet ' ' or '(' */
       job_name = util_alloc_substring_copy(p1 , 0 , job_length);
       p1 += job_length;
     }
-    job_index = vector_get_size( forward_model->jobs );
     current_job = forward_model_add_job(forward_model , job_name);
 
     if (*p1 == '(') {  /* the function has arguments. */

--- a/libjob_queue/src/job_queue_manager.c
+++ b/libjob_queue/src/job_queue_manager.c
@@ -73,15 +73,15 @@ void job_queue_manager_wait( job_queue_manager_type * manager) {
 
 
 bool job_queue_manager_try_wait( job_queue_manager_type * manager , int timeout_seconds) {
-  struct timespec ts;
   time_t timeout_time = time( NULL );
 
   util_inplace_forward_seconds_utc(&timeout_time , timeout_seconds );
-  ts.tv_sec = timeout_time;
-  ts.tv_nsec = 0;
 
 #ifdef HAVE_TIMEDJOIN
   {
+    struct timespec ts;
+    ts.tv_sec = timeout_time;
+    ts.tv_nsec = 0;
     int join_return = pthread_timedjoin_np( manager->queue_thread , NULL , &ts);  /* Wait for the main thread to complete. */
     if (join_return == 0)
       return true;

--- a/libjob_queue/src/torque_driver.c
+++ b/libjob_queue/src/torque_driver.c
@@ -283,7 +283,7 @@ stringlist_type * torque_driver_alloc_cmd(torque_driver_type * driver,
   return argv;
 }
 
-static void torque_debug(torque_driver_type * driver , const char * fmt , ...) {
+static void torque_debug(const torque_driver_type * driver , const char * fmt , ...) {
   if (driver->debug_stream) {
     {
       va_list ap;


### PR DESCRIPTION
ERT generates a number of compilation warnings when compiling, many of them due to variables that are never used etc.