### PR TITLE
made dump file readable by others

### DIFF
--- a/libert_util/src/util_abort_gnu.c
+++ b/libert_util/src/util_abort_gnu.c
@@ -293,7 +293,7 @@ void util_abort__(const char * file , const char * function , int line , const c
       }
       fprintf(stderr, "\nSee file: %s for more details of the crash.\nSetting the environment variable \"ERT_SHOW_BACKTRACE\" will show the backtrace on stderr.\n", filename);
     }
-
+    chmod(filename, 00644); // -rw-r--r--
     free(filename);
   }
 
@@ -304,4 +304,3 @@ void util_abort__(const char * file , const char * function , int line , const c
 
 
 /*****************************************************************/
-


### PR DESCRIPTION
Previously, the permissions on the dump logs where `-rw-rw----`, which made it difficult to assist in debugging.  The permissions are after this PR set to be readable by others `-rw-r--r--`, but not writable by group.