### PR TITLE
Double containment for points on cell faces

### DIFF
--- a/libecl/src/ecl_grid.c
+++ b/libecl/src/ecl_grid.c
@@ -3952,11 +3952,6 @@ bool ecl_grid_cell_contains_xyz3( const ecl_grid_type * ecl_grid , int i, int j 
   return true;
 }
 
-#undef NOT_ON_FACE
-#undef BELONGS_TO_CELL
-#undef BELONGS_TO_OTHER
-
-
 
 bool ecl_grid_cell_contains_xyz1( const ecl_grid_type * ecl_grid , int global_index, double x , double y , double z) {
   int i,j,k;

--- a/libecl/src/ecl_grid.c
+++ b/libecl/src/ecl_grid.c
@@ -500,43 +500,44 @@ which splits the lower face along the 0-3 diagnoal and the upper face
 along the 5-6 diagonal.
 */
 
+
 static const int tetrahedron_permutations[2][12][3] = {{
-                                                        // Top
+                                                        // K-
                                                         {0,1,2},
                                                         {3,2,1},
-                                                        // North
+                                                        // J+
                                                         {6,2,7},
                                                         {3,7,2},
-                                                        // West
+                                                        // I-
                                                         {0,2,4},
                                                         {6,4,2},
-                                                        // East
+                                                        // I+
                                                         {3,1,7},
                                                         {5,7,1},
-                                                        // South
+                                                        // J-
                                                         {0,4,1},
                                                         {5,1,4},
-                                                        // Bottom
+                                                        // K+
                                                         {5,4,7},
                                                         {6,7,4}
                                                         },
                                                        {
-                                                        // Top
+                                                        // K-
                                                         {1,3,0},
                                                         {2,0,3},
-                                                        // North
+                                                        // J+
                                                         {2,3,6},
                                                         {7,6,3},
-                                                        // West
+                                                        // I-
                                                         {2,6,0},
                                                         {4,0,6},
-                                                        // East
+                                                        // I+
                                                         {7,3,5},
                                                         {1,5,3},
-                                                        // South
+                                                        // J-
                                                         {1,0,5},
                                                         {4,5,0},
-                                                        // Bottom
+                                                        // K+
                                                         {7,5,6},
                                                         {4,6,5}
                                                        }};
@@ -3856,7 +3857,7 @@ static face_status_enum ecl_grid_on_cell_face(const ecl_cell_type * cell, const 
         const point_type * p,
         const bool max_i, const bool max_j, const bool max_k) {
 
-  int top = 0, north = 1, west = 2, east = 3, south = 4, bottom = 5;
+  int k_minus = 0, j_pluss = 1, i_minus = 2, i_pluss = 3, j_minus = 4, k_pluss = 5;
   bool on[6];
   for(int i = 0; i < 6; ++i) {
     on[i] = (
@@ -3866,16 +3867,16 @@ static face_status_enum ecl_grid_on_cell_face(const ecl_cell_type * cell, const 
   }
 
   // Not on any of the cell sides
-  if(!on[top] && !on[bottom] && !on[north] && !on[south] && !on[west] && !on[east])
+  if(!on[k_minus] && !on[k_pluss] && !on[j_pluss] && !on[j_minus] && !on[i_minus] && !on[i_pluss])
     return NOT_ON_FACE;
 
   // Not on any of the lower priority sides
-  if(!on[bottom] && !on[north] && !on[east])
+  if(!on[k_pluss] && !on[j_pluss] && !on[i_pluss])
     return BELONGS_TO_CELL;
 
   // Contained in cell due to border conditions
   // NOTE: One should read X <= Y as X "implies" Y
-  if((on[east] <= max_i) && (on[north] <= max_j) && (on[bottom] <= max_k))
+  if((on[i_pluss] <= max_i) && (on[j_pluss] <= max_j) && (on[k_pluss] <= max_k))
     return BELONGS_TO_CELL;
 
   return BELONGS_TO_OTHER;

--- a/libecl/src/ecl_grid.c
+++ b/libecl/src/ecl_grid.c
@@ -3805,9 +3805,7 @@ bool ecl_grid_compare(const ecl_grid_type * g1 , const ecl_grid_type * g2 , bool
 
 /*****************************************************************/
 
-#define NOT_ON_FACE 0
-#define BELONGS_TO_CELL 1
-#define BELONGS_TO_OTHER -1
+typedef enum {NOT_ON_FACE, BELONGS_TO_CELL, BELONGS_TO_OTHER} face_status_enum;
 
 /*
     Returns whether the given point is contained within the minimal cube
@@ -3854,7 +3852,7 @@ static bool ecl_grid_on_plane(const ecl_cell_type * cell, const int method,
    Note: The correctness of this function relies *HEAVILY* on the permutation of the
    tetrahedrons in the decompositions.
 */
-static int ecl_grid_on_cell_face(const ecl_cell_type * cell, const int method,
+static face_status_enum ecl_grid_on_cell_face(const ecl_cell_type * cell, const int method,
         const point_type * p,
         const bool max_i, const bool max_j, const bool max_k) {
 
@@ -3915,7 +3913,7 @@ bool ecl_grid_cell_contains_xyz3( const ecl_grid_type * ecl_grid , int i, int j 
   bool max_i = (i == ecl_grid->nx-1);
   bool max_j = (j == ecl_grid->ny-1);
   bool max_k = (k == ecl_grid->nz-1);
-  int face_status = ecl_grid_on_cell_face(cell, method, &p, max_i, max_j, max_k);
+  face_status_enum face_status = ecl_grid_on_cell_face(cell, method, &p, max_i, max_j, max_k);
 
   if(face_status != NOT_ON_FACE)
     return face_status == BELONGS_TO_CELL;

--- a/python/tests/core/ecl/test_grid.py
+++ b/python/tests/core/ecl/test_grid.py
@@ -300,8 +300,6 @@ class GridTest(ExtendedTestCase):
                             )
 
     def test_cell_face_containment(self):
-        # TODO: Activate this test
-        return
         n = 4
         d = 10
         grid = EclGrid.createRectangular( (n, n, n), (d, d, d))
@@ -316,8 +314,6 @@ class GridTest(ExtendedTestCase):
                     )
 
     def test_cell_unique_containment(self):
-        # TODO: Activate this test
-        return
         n = 4
         d = 4
         grid = EclGrid.createRectangular( (n, n, n), (d, d, d))


### PR DESCRIPTION
Points that lie on a cells face will be reported as contained in all cells sharing this face. The code for handling corner cases only handles corners..

As a first step I will implement functionality for testing whether a point lies on any of the "sides" of a cell (a cell is considered to have at most 6 sides, each one consisting of either two triangles or one rectangle). One can then use this logic instead for a direct compare to decide whether a point is indeed one of the cells corners (in particular, if a point lies on three of a cells sides it forms one of the eight corners).