### PR TITLE
Adjustet comments in ert_api_check.cmake: 'zlib.h not found'

### DIFF
--- a/cmake/ert_api_check.cmake
+++ b/cmake/ert_api_check.cmake
@@ -25,9 +25,13 @@ find_path( ZLIB_HEADER zlib.h /usr/include )
 if (ZLIB_LIBRARY AND ZLIB_HEADER)
    set( ERT_HAVE_ZLIB ON )
 else()
-   message("ZLib not found - zlib support will not be included." )       
+   if(NOT DEFINED ZLIB_LIBRARY)
+      message(STATUS "ZLib library not found - zlib support will not be included." )       
+   endif()
+   if(NOT DEFINED ZLIB_HEADER)
+      message(STATUS "zlib.h not found - zlib support will not be included.")
+   endif()
 endif()
-
 #-----------------------------------------------------------------
 
 try_compile( ERT_HAVE_ISFINITE ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_isfinite.c )


### PR DESCRIPTION
Adjustet messages in ert_api_check.cmake differentiating between zlib library not found and zlib header not found. 