### PR TITLE
Documentation: Refactored `user/localization` RST.

### DIFF
--- a/docs/user/localization/index.rst
+++ b/docs/user/localization/index.rst
@@ -123,7 +123,7 @@ ERT script function                                                        Purpo
 
    ::
 
-   updatestep = local_config.getUpdatestep()
+      updatestep = local_config.getUpdatestep()
 
 
 .. #####################################################################
@@ -161,9 +161,9 @@ ERT script function                                                        Purpo
    current analysis module.
 
    A given observation set can be attached to a given ministep with
-   attachObsset.The ministep is then ready for adding data. Before the ministep
-   can be used you must attach it to an updatestep with the attachMinistep
-   command
+   ``attachObsset``.  The ministep is then ready for adding data. Before the
+   ministep can be used you must attach it to an updatestep with the
+   ``attachMinistep`` command
 
    *Example:*
 
@@ -186,7 +186,7 @@ ERT script function                                                        Purpo
 
    This function will create a new dataset with a given name, i.e. a collection
    of enkf_nodes which should be updated together. Before you can actually use a
-   dataset you must attach it to a ministep with the attachDataset command.
+   dataset you must attach it to a ministep with the ``attachDataset`` command.
 
 
    *Example:*
@@ -200,7 +200,7 @@ ERT script function                                                        Purpo
 .. _copy_dataset:
 .. topic:: copyDataset
 
-   Will create a new local_obsset instance which is a copy of the source
+   Will create a new ``local_obsset`` instance which is a copy of the source
    dataset; this is a deep copy where also the lowest level active_list
    instances are copied, and can then subsequently be updated independently of
    each other.
@@ -210,7 +210,8 @@ ERT script function                                                        Purpo
 
    ::
 
-      dataset_multflt_copy = local_config.copyDataset("DATASET_MULTFLT","DATASET_MULTFLT_COPY")
+      dataset_multflt_copy = local_config.copyDataset("DATASET_MULTFLT",
+                                                      "DATASET_MULTFLT_COPY")
 
 
 .. #####################################################################
@@ -218,9 +219,9 @@ ERT script function                                                        Purpo
 .. topic:: createObsdata
 
    This function will create an observation set, i.e. a collection of
-   observation keys which will be used as the observations in one
-   ministep. Before the obsset can be used it must be attached to a ministep
-   with the attachDataset command.
+   observation keys which will be used as the observations in one ministep.
+   Before the ``obsset`` can be used it must be attached to a ministep with the
+   ``attachDataset`` command.
 
 
    *Example:*
@@ -234,7 +235,7 @@ ERT script function                                                        Purpo
 .. _copy_obsset:
 .. topic:: copyObsdata
 
-   Will create a new local_obsset instance which is a copy of the source
+   Will create a new ``local_obsset`` instance which is a copy of the source
    dataset; this is a deep copy where also the lowest level active_list
    instances are copied, and can then subsequently be updated independently of
    each other.
@@ -278,7 +279,7 @@ ERT script function                                                        Purpo
 .. _attach_obsset:
 .. topic:: attachObsset
 
-   Will attach the given obsset to the ministep.
+   Will attach the given ``obsset`` to the ``ministep``.
 
    *Example:*
 
@@ -323,7 +324,7 @@ ERT script function                                                        Purpo
 .. topic:: addNode
 
    This function will install the observation ``OBS_KEY`` as an observation for
-   this ``obsset`` - similarly to the ``addNode`` function.
+   this ``obsset`` --- similarly to the ``addNode`` function.
 
    *Example:*
 
@@ -434,10 +435,10 @@ ERT script function                                                        Purpo
 .. _load_file:
 .. topic:: EclGrid, EclInitFile
 
-   This function will load an ECLIPSE file in restart format (i.e. restart file or
-   INIT file), the keywords in this file can then subsequently be used in
-   ``ECLREGION_SELECT_VALUE_XXX`` commands below.  The ``KEY`` argument is a string
-   which will be used later when we refer to the content of this file.
+   This function will load an ECLIPSE file in restart format (i.e. restart file
+   or INIT file), the keywords in this file can then subsequently be used in
+   ``ECLREGION_SELECT_VALUE_XXX`` commands below.  The ``KEY`` argument is a
+   string which will be used later when we refer to the content of this file.
 
    *Example:*
 
@@ -470,7 +471,7 @@ ERT script function                                                        Purpo
 .. _eclregion_select_all:
 .. topic:: select_active
 
-   Will select all the cells in the region (or deselect if ``SELECT == FALSE``).
+   Will select all the cells in the region (or deselect if ``SELECT == False``).
 
 
    *Example:*
@@ -532,7 +533,7 @@ ERT script function                                                        Purpo
 
    This function will compare an ``ecl_kw`` instance loaded from disc with a
    numerical value, and select all cells which have numerical above the limiting
-   value. The ``ecl_kw`` value should be a floating point value like
+   value.  The ``ecl_kw`` value should be a floating point value like
    e.g. PRESSURE or PORO. The arguments are just as for
    ``ECLREGION_SELECT_VALUE_EQUAL``.
 
@@ -549,8 +550,8 @@ ERT script function                                                        Purpo
 .. topic:: select_box
 
    This function will select (or deselect) all the cells in the box defined by
-   the six coordinates ``i1 i2 j1 j2 k1 k2``. The coordinates are inclusive, and
-   the counting starts at 1.
+   the six coordinates ``i1 i2 j1 j2 k1 k2``.  The coordinates are inclusive,
+   and the counting starts at 1.
 
 
    *Example:*
@@ -565,11 +566,13 @@ ERT script function                                                        Purpo
 .. topic:: select_islice, _jslice,_kslice
 
    This function will select a slice in the direction given by ``dir``', which
-   can ``x``, ``y``, or ``z``. Depending on the value of ``dir`` the numbers
+   can ``x``, ``y``, or ``z``.  Depending on the value of ``dir`` the numbers
    ``n1`` and ``n2`` are interpreted as ``(i1 i2)``, ``(j1 j2)``, or ``(k1
-   k2)``, respectively.  The numbers ``n1`` and ``n2`` are inclusive and the
-   counting starts at 1.  It is OK to use very high/low values to imply *"the
-   rest of the cells"* in one direction.
+   k2)``, respectively.
+
+   The numbers ``n1`` and ``n2`` are inclusive and the counting starts at 1.  It
+   is OK to use very high/low values to imply *"the rest of the cells"* in one
+   direction.
 
 
    *Example:*
@@ -592,7 +595,7 @@ ERT script function                                                        Purpo
 
    ::
 
-      eclreg_poro.select_below_plane((1,1,1),(0,0,0))
+      eclreg_poro.select_below_plane((1,1,1), (0,0,0))
 
 
 .. #####################################################################
@@ -600,7 +603,7 @@ ERT script function                                                        Purpo
 .. topic:: select_inside_polygon
 
    Well select all the points which are inside the polygon with name
-   ``POLYGON_NAME``. The polygon should have been created with command
+   ``POLYGON_NAME``.  The polygon should have been created with command
    ``CREATE_POLYGON`` or loaded with command ``LOAD_POLYGON`` first.
 
 
@@ -608,7 +611,7 @@ ERT script function                                                        Purpo
 
    ::
 
-      polygon = [(0,0) , (0,1) , (1,0)]
+      polygon = [(0,0), (0,1), (1,0)]
       eclreg_poro.select_inside_polygon(polygon)
 
 
@@ -620,11 +623,12 @@ ERT script function                                                        Purpo
 
    ``(x1,y1), (x2,y2), (x3,y3), ...``
 
-   The polygon should not be explicitly closed - i.e. you should in general have
+   The polygon should not be explicitly closed --- i.e., you should in general
+   have
 
    ``(x1,y1) != (xn,yn).``
 
-   The polygon will be stored under the name ``POLYGON_NAME`` - which should
+   The polygon will be stored under the name ``POLYGON_NAME`` --- which should
    later be used when referring to the polygon in region select operations.
 
 
@@ -632,15 +636,15 @@ ERT script function                                                        Purpo
 
    ::
 
-      polygon = [(0,0) , (0,1) , (1,0)]
+      polygon = [(0,0), (0,1), (1,0)]
 
 
 .. #####################################################################
 .. _load_polygon:
 .. topic:: Example load polygon
 
-   Will load a polygon instance from the file ``FILENAME`` - the file should be
-   in irap RMS format.  The polygon will be stored under the name
+   Will load a polygon instance from the file ``FILENAME`` --- the file should
+   be in *irap RMS* format.  The polygon will be stored under the name
    ``POLYGON_NAME`` which can then later be used to refer to the polygon for
    e.g. select operations.
 
@@ -651,6 +655,6 @@ ERT script function                                                        Purpo
 
       polygon = []
       with open("polygon.ply", "r") as ply_file:
-          for line in ply_file.readlines():
+          for line in ply_file:
               xs, ys = map(float, line.split())
               polygon.append(xs, ys)

--- a/docs/user/localization/index.rst
+++ b/docs/user/localization/index.rst
@@ -6,8 +6,8 @@ Keywords for the local configuration file
 General overview
 ----------------
 
-To create a configuration for localization you must "program" your own
-local config commands by writing a Python script, and invoking it from a workflow.
+To create a configuration for localization you must *"program"* your own local
+config commands by writing a Python script, and invoking it from a workflow.
 
 
 **Local config python script example:**
@@ -31,14 +31,15 @@ local config commands by writing a Python script, and invoking it from a workflo
          # Get local config object
          local_config = ert.getLocalConfig()
 
-         # Reset internal local config structure. From now you need to specify what to localize
+         # Reset internal local config structure.  From now you need to
+         # specify what to localize
          local_config.clear()
 
          # There is only one update step
          updatestep = local_config.getUpdatestep()
 
          # A ministep
-         ministep   = local_config.createMinistep("MINISTEP" )
+         ministep = local_config.createMinistep("MINISTEP" )
 
          # Add some dataset you want to localize here.
          dataset_multflt = local_config.createDataset("DATASET_MULTFLT")
@@ -47,7 +48,7 @@ local config commands by writing a Python script, and invoking it from a workflo
          data_poro = local_config.createDataset("DATA_PORO")
          ecl_grid = local_config.getGrid()
          ecl_region = EclRegion(ecl_grid, False)
-         ecl_region.select_box((0,0,0),(3,3,3))
+         ecl_region.select_box((0,0,0), (3,3,3))
          data_poro.addField("PORO", ecl_region)
 
 
@@ -56,11 +57,12 @@ local config commands by writing a Python script, and invoking it from a workflo
          active_list = dataset_multflt.getActiveList("MULTFLT")
          active_list.addActiveIndex(0)
 
-         # Add existing observations from WOPR:OP_1. Alternatively, use getObservations
-         # and filter the observations you want to use for this ministep.
+         # Add existing observations from WOPR:OP_1.  Alternatively, use
+         # getObservations  and filter the observations you want to use
+         # for this ministep.
          obsdata_wopr = local_config.createObsdata("WOPR:OP_1_10")
-         for i in range(1,10):
-             obsdata_wopr.addNode("OBS"+str(i))
+         for i in range(1, 10):
+             obsdata_wopr.addNode("OBS" + str(i))
 
          # Attach the created dataset and obsset to the ministep
          ministep.attachDataset(dataset_multflt)
@@ -69,7 +71,7 @@ local config commands by writing a Python script, and invoking it from a workflo
          # Then attach the ministep to the update step
          updatestep.attachMinistep(ministep)
 
-         # Write a .csv file for debugging. The generated file can be imported
+         # Write a .csv file for debugging.  The generated file can be imported
          # into Excel for better tabulation of the setup
          local_config.writeSummaryFile("tmp/summary_local_config.csv")
 
@@ -107,6 +109,8 @@ ERT script function                                                        Purpo
 :ref:`select_inside_polygon            <eclregion_select_in_polygon>`      Selects or deselects cells in region inside polygon
 :ref:`Example create polygon           <create_polygon>`                   Creates a geo-polygon based on coordinate list
 :ref:`Example load polygon             <load_polygon>`                     Loads polygon in Irap RMS format from file
+:ref:`Select polygon from surface      <geo_region__select_polygon>`       Selects the inside of a polygon from a surface
+:ref:`Select halfspace from surface    <geo_region__select_halfspace>`     Selects above or below a line from a surface
 
 =========================================================================  ===================================================================================
 
@@ -115,7 +119,7 @@ ERT script function                                                        Purpo
 .. _create_updatestep:
 .. topic:: getUpdatestep
 
-   This function will create the default updatestep.
+   This function will create the default ``updatestep``.
 
    Observe that you must get, otherwise it will not be able to do anything.
 
@@ -156,13 +160,13 @@ ERT script function                                                        Purpo
 .. _create_ministep:
 .. topic:: createMinistep
 
-   This function will create a new ministep with a given name and an optional
-   analysis module. The default analysis module for this ministep is ERT's
-   current analysis module.
+   This function will create a new ``ministep`` with a given name and an
+   optional analysis module.  The default analysis module for this ``ministep``
+   is ERT's current analysis module.
 
-   A given observation set can be attached to a given ministep with
-   ``attachObsset``.  The ministep is then ready for adding data. Before the
-   ministep can be used you must attach it to an updatestep with the
+   A given observation set can be attached to a given ``ministep`` with
+   ``attachObsset``.  The ``ministep`` is then ready for adding data.  Before
+   the ``ministep`` can be used you must attach it to an ``updatestep`` with the
    ``attachMinistep`` command
 
    *Example:*
@@ -184,9 +188,10 @@ ERT script function                                                        Purpo
 .. _create_dataset:
 .. topic:: createDataset
 
-   This function will create a new dataset with a given name, i.e. a collection
-   of enkf_nodes which should be updated together. Before you can actually use a
-   dataset you must attach it to a ministep with the ``attachDataset`` command.
+   This function will create a new ``dataset`` with a given name, i.e., a
+   collection of ``enkf_nodes`` which should be updated together.  Before you
+   can actually use a ``dataset`` you must attach it to a ``ministep`` with the
+   ``attachDataset`` command.
 
 
    *Example:*
@@ -201,7 +206,7 @@ ERT script function                                                        Purpo
 .. topic:: copyDataset
 
    Will create a new ``local_obsset`` instance which is a copy of the source
-   dataset; this is a deep copy where also the lowest level active_list
+   ``dataset``; this is a deep copy where also the lowest level active_list
    instances are copied, and can then subsequently be updated independently of
    each other.
 
@@ -218,10 +223,10 @@ ERT script function                                                        Purpo
 .. _create_obsset:
 .. topic:: createObsdata
 
-   This function will create an observation set, i.e. a collection of
-   observation keys which will be used as the observations in one ministep.
-   Before the ``obsset`` can be used it must be attached to a ministep with the
-   ``attachDataset`` command.
+   This function will create an observation set, i.e., a collection of
+   observation keys which will be used as the observations in one ``ministep``.
+   Before the ``obsset`` can be used it must be attached to a ``ministep`` with
+   the ``attachDataset`` command.
 
 
    *Example:*
@@ -236,7 +241,7 @@ ERT script function                                                        Purpo
 .. topic:: copyObsdata
 
    Will create a new ``local_obsset`` instance which is a copy of the source
-   dataset; this is a deep copy where also the lowest level active_list
+   ``dataset``; this is a deep copy where also the lowest level ``active_list``
    instances are copied, and can then subsequently be updated independently of
    each other.
 
@@ -252,7 +257,7 @@ ERT script function                                                        Purpo
 .. _attach_ministep:
 .. topic:: attachMinistep
 
-   This function will attach the ministep to the default updatestep.
+   This function will attach the ``ministep`` to the default ``updatestep``.
 
    *Example:*
 
@@ -265,7 +270,7 @@ ERT script function                                                        Purpo
 .. _attach_dataset:
 .. topic:: attachDataset
 
-   Will attach the given dataset to the ministep.
+   Will attach the given ``dataset`` to the ``ministep``.
 
 
    *Example:*
@@ -294,7 +299,7 @@ ERT script function                                                        Purpo
 
    This function will add the data ``KEY`` as one *enkf* node which should be
    updated in this dataset.  If you do not manipulate the ``KEY`` further with
-   ``addActiveIndex``, the ``KEY`` will be added as ``ALL_ACTIVE``, i.e. all
+   ``addActiveIndex``, the ``KEY`` will be added as ``ALL_ACTIVE``, i.e., all
    elements will be updated.
 
 
@@ -341,7 +346,7 @@ ERT script function                                                        Purpo
 .. _del_obs:
 .. topic:: del (obs)
 
-   This function will delete the obs ``OBS_KEY`` from the obsset
+   This function will delete the obs ``OBS_KEY`` from the ``obsset``
    ``NAME_OF_OBSSET``.
 
 
@@ -356,7 +361,7 @@ ERT script function                                                        Purpo
 .. _dataset_del_all_data:
 .. topic:: clear
 
-   This function will delete all the data keys from the dataset.
+   This function will delete all the data keys from the ``dataset``.
 
    *Example:*
 
@@ -369,8 +374,8 @@ ERT script function                                                        Purpo
 .. _active_list_add_data_index:
 .. topic:: addActiveIndex (data)
 
-   This function will say that the data with name ``DATA_KEY`` in dataset with
-   name ``DATASTEP_NAME`` should have the index ``INDEX`` active.
+   This function will say that the data with name ``DATA_KEY`` in ``dataset``
+   with name ``DATASTEP_NAME`` should have the index ``INDEX`` active.
 
 
    *Example:*
@@ -385,8 +390,8 @@ ERT script function                                                        Purpo
 .. _active_list_add_obs_index:
 .. topic:: addActiveIndex (obs)
 
-   This function will say that the observation with name ``OBS_KEY`` in obsset
-   with name ``OBSSET_NAME`` should have the index ``INDEX`` active.
+   This function will say that the observation with name ``OBS_KEY`` in
+   ``obsset`` with name ``OBSSET_NAME`` should have the index ``INDEX`` active.
 
    *Example:*
 
@@ -401,10 +406,11 @@ ERT script function                                                        Purpo
 .. _add_field:
 .. topic:: addField
 
-   This function will install the node with name ``FIELD_NAME`` in the dataset
-   ``DATASET_NAME``.  It will in addition select all the (currently) active
-   cells in the region ``ECLREGION_NAME`` as active for this field/ministep
-   combination.  The ``ADD_FIELD`` command is actually a shortcut of:
+   This function will install the node with name ``FIELD_NAME`` in the
+   ``dataset`` ``DATASET_NAME``.  It will in addition select all the (currently)
+   active cells in the region ``ECLREGION_NAME`` as active for this
+   ``field``/``ministep`` combination.  The ``ADD_FIELD`` command is actually a
+   shortcut of:
 
    ``ADD_DATA DATASET FIELD_NAME``;
 
@@ -435,10 +441,11 @@ ERT script function                                                        Purpo
 .. _load_file:
 .. topic:: EclGrid, EclInitFile
 
-   This function will load an ECLIPSE file in restart format (i.e. restart file
-   or INIT file), the keywords in this file can then subsequently be used in
-   ``ECLREGION_SELECT_VALUE_XXX`` commands below.  The ``KEY`` argument is a
-   string which will be used later when we refer to the content of this file.
+   This function will load an ECLIPSE file in restart format (i.e., *restart
+   file* or *INIT file*), the keywords in this file can then subsequently be
+   used in ``ECLREGION_SELECT_VALUE_XXX`` commands below.  The ``KEY`` argument
+   is a string which will be used later when we refer to the content of this
+   file.
 
    *Example:*
 
@@ -471,7 +478,7 @@ ERT script function                                                        Purpo
 .. _eclregion_select_all:
 .. topic:: select_active
 
-   Will select all the cells in the region (or deselect if ``SELECT == False``).
+   Will select (or deselect) all the cells in the region.
 
 
    *Example:*
@@ -479,6 +486,7 @@ ERT script function                                                        Purpo
    ::
 
       eclreg_poro.select_active()
+      eclreg_poro.deselect_active()
 
 
 .. #####################################################################
@@ -516,8 +524,8 @@ ERT script function                                                        Purpo
 
    This function will compare an ``ecl_kw`` instance loaded from disc with a
    numerical value, and select all cells which have numerical below the limiting
-   value.  The ``ecl_kw`` value should be a floating point value like
-   e.g. PRESSURE or PORO.  The arguments are just as for
+   value.  The ``ecl_kw`` value should be a floating point value like e.g.,
+   ``PRESSURE`` or ``PORO``.  The arguments are just as for
    ``ECLREGION_SELECT_VALUE_EQUAL``.
 
    *Example:*
@@ -533,8 +541,8 @@ ERT script function                                                        Purpo
 
    This function will compare an ``ecl_kw`` instance loaded from disc with a
    numerical value, and select all cells which have numerical above the limiting
-   value.  The ``ecl_kw`` value should be a floating point value like
-   e.g. PRESSURE or PORO. The arguments are just as for
+   value.  The ``ecl_kw`` value should be a floating point value like e.g.,
+   ``PRESSURE`` or ``PORO``.  The arguments are just as for
    ``ECLREGION_SELECT_VALUE_EQUAL``.
 
 
@@ -621,7 +629,7 @@ ERT script function                                                        Purpo
 
    Will create a ``geo_polygon`` instance based on the coordinate list:
 
-   ``(x1,y1), (x2,y2), (x3,y3), ...``
+   ``[(x1,y1), (x2,y2), (x3,y3), ..., (xn,yn)]``
 
    The polygon should not be explicitly closed --- i.e., you should in general
    have
@@ -646,7 +654,7 @@ ERT script function                                                        Purpo
    Will load a polygon instance from the file ``FILENAME`` --- the file should
    be in *irap RMS* format.  The polygon will be stored under the name
    ``POLYGON_NAME`` which can then later be used to refer to the polygon for
-   e.g. select operations.
+   e.g., select operations.
 
 
    *Example:*
@@ -658,3 +666,59 @@ ERT script function                                                        Purpo
           for line in ply_file:
               xs, ys = map(float, line.split())
               polygon.append(xs, ys)
+
+
+.. #####################################################################
+.. _geo_region__select_polygon:
+.. topic:: Select polygon from surface
+
+   Will select or deselect all points from a surface contained inside a given
+   polygon.
+
+
+   *Example:*
+
+   ::
+
+      nx,ny = 12, 12
+      xinc,yinc = 1, 1
+      xstart,ystart = -1, -1
+      angle = 0.0
+      s_args = (None, nx, ny, xinc, yinc, xstart, ystart, angle)
+      surface = Surface(*s_args)  # an irap surface
+      pointset = GeoPointset.fromSurface(surface)
+      georegion = GeoRegion(pointset)
+      points = [(-0.1,2.0), (1.9,8.1), (6.1,8.1), (9.1,5), (7.1,0.9)]
+      polygon = CPolyline(name='test_polygon', init_points=points)
+
+      georegion.select_inside(polygon)
+      georegion.select_outside(polygon)
+      georegion.deselect_inside(polygon)
+      georegion.select_polygon(polygon, inside=False, select=False)  # deselect outside
+
+
+.. #####################################################################
+.. _geo_region__select_halfspace:
+.. topic:: Select halfspace from surface
+
+   Will select or deselect all points from a surface above or below a line.
+
+
+   *Example:*
+
+   ::
+
+      nx,ny = 12, 12
+      xinc,yinc = 1, 1
+      xstart,ystart = -1, -1
+      angle = 0.0
+      s_args = (None, nx, ny, xinc, yinc, xstart, ystart, angle)
+      surface = Surface(*s_args)  # an irap surface
+      pointset = GeoPointset.fromSurface(surface)
+      georegion = GeoRegion(pointset)
+      line = [(-0.1,2.0), (1.9,8.1)]
+
+      georegion.select_above(line)
+      georegion.deselect_above(line)
+      georegion.select_below(line)
+      georegion.select_halfspace(line, above=False, select=False)  # deselect below

--- a/docs/user/localization/index.rst
+++ b/docs/user/localization/index.rst
@@ -109,9 +109,10 @@ ERT script function                                                        Purpo
 :ref:`select_inside_polygon            <eclregion_select_in_polygon>`      Selects or deselects cells in region inside polygon
 :ref:`Example create polygon           <create_polygon>`                   Creates a geo-polygon based on coordinate list
 :ref:`Example load polygon             <load_polygon>`                     Loads polygon in Irap RMS format from file
+:ref:`Load surface from IRAP file      <surface__init>`                    Create a polygon from IRAP file
 :ref:`Select polygon from surface      <geo_region__select_polygon>`       Selects the inside of a polygon from a surface
 :ref:`Select halfspace from surface    <geo_region__select_halfspace>`     Selects above or below a line from a surface
-
+:ref:`Add a surface to dataset         <local_dataset__add_surface>`       Add a surface node to a dataset
 =========================================================================  ===================================================================================
 
 
@@ -669,6 +670,36 @@ ERT script function                                                        Purpo
 
 
 .. #####################################################################
+.. _surface__init:
+.. topic:: Load surface from IRAP file
+
+   Will load a surface from an *IRAP file*.  We can also create a surface
+   programmatically.  It is also possible to obtain the underlying pointset.
+
+
+   *Example for creating programmatically:*
+
+   ::
+
+      # values copied from irap surface_small
+      nx, ny = 30,20
+      xinc, yinc = 50.0, 50.0
+      xstart, ystart = 463325.5625, 7336963.5
+      angle = -65.0
+      s_args = (None, nx, ny, xinc, yinc, xstart, ystart, angle)
+      s = Surface(*s_args)
+
+   *Example loading from file:*
+
+   ::
+
+      surface = Surface('path/to/surface.irap')
+      # we can also obtain the underlying pointset
+      pointset = GeoPointset.fromSurface(surface)
+      georegion = GeoRegion(pointset)
+
+
+.. #####################################################################
 .. _geo_region__select_polygon:
 .. topic:: Select polygon from surface
 
@@ -708,12 +739,7 @@ ERT script function                                                        Purpo
 
    ::
 
-      nx,ny = 12, 12
-      xinc,yinc = 1, 1
-      xstart,ystart = -1, -1
-      angle = 0.0
-      s_args = (None, nx, ny, xinc, yinc, xstart, ystart, angle)
-      surface = Surface(*s_args)  # an irap surface
+      surface = Surface(...)  # an irap surface, see above
       pointset = GeoPointset.fromSurface(surface)
       georegion = GeoRegion(pointset)
       line = [(-0.1,2.0), (1.9,8.1)]
@@ -722,3 +748,32 @@ ERT script function                                                        Purpo
       georegion.deselect_above(line)
       georegion.select_below(line)
       georegion.select_halfspace(line, above=False, select=False)  # deselect below
+
+
+.. #####################################################################
+.. _local_dataset__add_surface:
+.. topic:: Add a surface to dataset
+
+   Adds a surface to a local dataset just as one can add a field node to a
+   dataset (see add_field_).
+
+
+   *Example:*
+
+   ::
+
+      main = test_context.getErt()
+      local_config = main.getLocalConfig()
+
+      # Creating dataset
+      data_scale = local_config.createDataset('DATA_SCALE')
+      surface = Surface(...)  # an irap surface, see above
+      pointset = surface.getPointset()
+      georegion = GeoRegion(pointset)
+      data_scale.addSurface('TOP', georegion)
+
+      # similar use to
+      grid = local_config.getGrid()
+      eclregion = EclRegion(grid, False)
+      eclregion.select_islice(10, 20)
+      data_scale.addField('PERMX', eclregion)

--- a/docs/user/localization/index.rst
+++ b/docs/user/localization/index.rst
@@ -1,4 +1,3 @@
-
 Keywords for the local configuration file
 =========================================
 
@@ -20,583 +19,616 @@ local config commands by writing a Python script, and invoking it from a workflo
  from ert.ecl import EclGrid, EclRegion, Ecl3DKW, EclFile, EclInitFile, EclKW, EclTypeEnum
 
  class LocalConfigJob(ErtScript):
- 
- 
+
+
      def run(self):
-     
+
          # This example can be used with the REEK data set from the ERT tutorial
- 
+
          # Get the ert object
          ert = self.ert()
- 
+
          # Get local config object
          local_config = ert.getLocalConfig()
- 
+
          # Reset internal local config structure. From now you need to specify what to localize
          local_config.clear()
- 
+
          # There is only one update step
          updatestep = local_config.getUpdatestep()
- 
+
          # A ministep
          ministep   = local_config.createMinistep("MINISTEP" )
- 
+
          # Add some dataset you want to localize here.
          dataset_multflt = local_config.createDataset("DATASET_MULTFLT")
- 
+
          # Add some field and localize inside a box
          data_poro = local_config.createDataset("DATA_PORO")
          ecl_grid = local_config.getGrid()
          ecl_region = EclRegion(ecl_grid, False)
          ecl_region.select_box((0,0,0),(3,3,3))
          data_poro.addField("PORO", ecl_region)
- 
- 
+
+
          # Add some index from MULTFLT to the dataset
          dataset_multflt.addNode("MULTFLT")
          active_list = dataset_multflt.getActiveList("MULTFLT")
          active_list.addActiveIndex(0)
- 
-         # Add existing observations from WOPR:OP_1. Alternatively, use getObservations and filter the observations you want to use for this ministep.
+
+         # Add existing observations from WOPR:OP_1. Alternatively, use getObservations
+         # and filter the observations you want to use for this ministep.
          obsdata_wopr = local_config.createObsdata("WOPR:OP_1_10")
          for i in range(1,10):
              obsdata_wopr.addNode("OBS"+str(i))
- 
+
          # Attach the created dataset and obsset to the ministep
          ministep.attachDataset(dataset_multflt)
          ministep.attachObsset(obsdata_wopr)
- 
+
          # Then attach the ministep to the update step
          updatestep.attachMinistep(ministep)
- 
-         # Write a .csv file for debugging. The generated file can be imported into Excel for better tabulation of the setup
+
+         # Write a .csv file for debugging. The generated file can be imported
+         # into Excel for better tabulation of the setup
          local_config.writeSummaryFile("tmp/summary_local_config.csv")
 
-===========================================================================================   ==============================================================================================================================================
-ERT script function                                                                           Purpose
-===========================================================================================   ==============================================================================================================================================
-:ref:`getObservations                  <all_obs>`                                             Get the observations currently imported, use to filter the observations to localize
-:ref:`getGrid                          <ert_grid>`                                            Get the underlying grid use to define active cells in a field
-:ref:`getUpdatestep                    <create_updatestep>`                                   Creates and gets default updatestep
-:ref:`createMinistep                   <create_ministep>`                                     Creates ministep
-:ref:`createDataset                    <create_dataset>`                                      Creates dataset
-:ref:`copyDataset                      <copy_dataset>`                                        Deep copy of dataset
-:ref:`createObsdata                    <create_obsset>`                                       Creates observation set
-:ref:`copyObsdata                      <copy_obsset>`                                         Deep copy of observation set
-:ref:`attachMinistep                   <attach_ministep>`                                     Attaches ministep to update step
-:ref:`attachDataset                    <attach_dataset>`                                      Attaches dataset to mini step
-:ref:`attachObsset                     <attach_obsset>`                                       Attaches observation set to mini step
-:ref:`addNode                          <add_data>`                                            Adds data node to dataset
-:ref:`del (data)                       <del_data>`                                            Deletes observation node from dataset
-:ref:`addNode, addNodeAndRange         <add_obs>`                                             Adds observation node to observation set for all times or in a given time range
-:ref:`del (obs)                        <del_obs>`                                             Deletes observation node from observation set
-:ref:`clear                            <dataset_del_all_data>`                                Delete all the data keys from a dataset
-:ref:`addActiveIndex (data)            <active_list_add_data_index>`                          Adds several data indices to the list of active indices
-:ref:`addActiveIndex (obs)             <active_list_add_obs_index>`                           Adds several observation indices to the list of active indices
-:ref:`addField                         <add_field>`                                           Adds field node to dataset
-:ref:`EclGrid, EclInitFile             <load_file>`                                           Loads eclipse file in restart format
-:ref:`EclRegion                        <create_eclregion>`                                    Creates a new region for use when defining active regions for fields
-:ref:`select_active                    <eclregion_select_all>`                                Selects or deselects cells in a region
-:ref:`select_equal                     <eclregion_select_value_equal>`                        Selects or deselects cells in a region equal to given value
-:ref:`select_less                      <eclregion_select_value_less>`                         Selects or deselects cells in a region equal less than a given value
-:ref:`select_more                      <eclregion_select_value_more>`                         Selects or deselects cells in a region equal greater than a given value
-:ref:`select_box                       <eclregion_select_box>`                                Selects or deselects cells in a box
-:ref:`select_islice, _jslice,_kslice   <eclregion_select_slice>`                              Selects or deselects cells in a slice
-:ref:`select_below_plane               <eclregion_select_plane>`                              Selects or deselects cells in a half space defined by a plane
-:ref:`select_inside_polygon            <eclregion_select_in_polygon>`                         Selects or deselects cells in region inside polygon
-:ref:`Example create polygon           <create_polygon>`                                      Creates a geo-polygon based on coordinate list
-:ref:`Example load polygon             <load_polygon>`                                        Loads polygon in Irap RMS format from file
+=========================================================================  ===================================================================================
+ERT script function                                                        Purpose
+=========================================================================  ===================================================================================
+:ref:`getObservations                  <all_obs>`                          Get the observations currently imported, use to filter the observations to localize
+:ref:`getGrid                          <ert_grid>`                         Get the underlying grid use to define active cells in a field
+:ref:`getUpdatestep                    <create_updatestep>`                Creates and gets default updatestep
+:ref:`createMinistep                   <create_ministep>`                  Creates ministep
+:ref:`createDataset                    <create_dataset>`                   Creates dataset
+:ref:`copyDataset                      <copy_dataset>`                     Deep copy of dataset
+:ref:`createObsdata                    <create_obsset>`                    Creates observation set
+:ref:`copyObsdata                      <copy_obsset>`                      Deep copy of observation set
+:ref:`attachMinistep                   <attach_ministep>`                  Attaches ministep to update step
+:ref:`attachDataset                    <attach_dataset>`                   Attaches dataset to mini step
+:ref:`attachObsset                     <attach_obsset>`                    Attaches observation set to mini step
+:ref:`addNode                          <add_data>`                         Adds data node to dataset
+:ref:`del (data)                       <del_data>`                         Deletes observation node from dataset
+:ref:`addNode, addNodeAndRange         <add_obs>`                          Adds observation node to observation set for all times or in a given time range
+:ref:`del (obs)                        <del_obs>`                          Deletes observation node from observation set
+:ref:`clear                            <dataset_del_all_data>`             Delete all the data keys from a dataset
+:ref:`addActiveIndex (data)            <active_list_add_data_index>`       Adds several data indices to the list of active indices
+:ref:`addActiveIndex (obs)             <active_list_add_obs_index>`        Adds several observation indices to the list of active indices
+:ref:`addField                         <add_field>`                        Adds field node to dataset
+:ref:`EclGrid, EclInitFile             <load_file>`                        Loads eclipse file in restart format
+:ref:`EclRegion                        <create_eclregion>`                 Creates a new region for use when defining active regions for fields
+:ref:`select_active                    <eclregion_select_all>`             Selects or deselects cells in a region
+:ref:`select_equal                     <eclregion_select_value_equal>`     Selects or deselects cells in a region equal to given value
+:ref:`select_less                      <eclregion_select_value_less>`      Selects or deselects cells in a region equal less than a given value
+:ref:`select_more                      <eclregion_select_value_more>`      Selects or deselects cells in a region equal greater than a given value
+:ref:`select_box                       <eclregion_select_box>`             Selects or deselects cells in a box
+:ref:`select_islice, _jslice,_kslice   <eclregion_select_slice>`           Selects or deselects cells in a slice
+:ref:`select_below_plane               <eclregion_select_plane>`           Selects or deselects cells in a half space defined by a plane
+:ref:`select_inside_polygon            <eclregion_select_in_polygon>`      Selects or deselects cells in region inside polygon
+:ref:`Example create polygon           <create_polygon>`                   Creates a geo-polygon based on coordinate list
+:ref:`Example load polygon             <load_polygon>`                     Loads polygon in Irap RMS format from file
 
-===========================================================================================   ==============================================================================================================================================
+=========================================================================  ===================================================================================
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _create_updatestep:
 .. topic:: getUpdatestep
 
-  | This function will create the default updatestep. 
-  | Observe that you must get, otherwise it will not be able to do anything.
-  
-  *Example:*
+This function will create the default updatestep.
 
-  ::
-  
-    updatestep = local_config.getUpdatestep()
+Observe that you must get, otherwise it will not be able to do anything.
 
-.. ###########################################################################################################
+*Example:*
 
+::
+
+updatestep = local_config.getUpdatestep()
+
+
+.. #####################################################################
 .. _all_obs:
 .. topic:: getObservations
 
-  | This function will retrieve ERT's observations
-  
-  *Example:*
+This function will retrieve ERT's observations
 
-  ::
-  
-    all_obs = local_config.getObservations()
+*Example:*
 
-.. ###########################################################################################################
+::
 
+   all_obs = local_config.getObservations()
+
+
+.. #####################################################################
 .. _ert_grid:
 .. topic:: getGrid
 
-  | This function will retrieve ERT's grid
-  
-  *Example:*
+This function will retrieve ERT's grid
 
-  ::
-  
-    grid = local_config.getGrid()
+*Example:*
 
-.. ###########################################################################################################
+::
+
+   grid = local_config.getGrid()
 
 
+.. #####################################################################
 .. _create_ministep:
-.. topic:: createMinistep 
+.. topic:: createMinistep
 
-  | This function will create a new ministep with a given name and an optional analysis module. The default analysis module for this ministep is ERT's current analysis module.
-  | A given observation set can be attached to a given ministep with attachObsset.The ministep is then ready for adding data. Before the ministep can be used you must attach it to an updatestep with the attachMinistep command 
-  
-  *Example:*
+This function will create a new ministep with a given name and an optional
+analysis module. The default analysis module for this ministep is ERT's current
+analysis module.
 
-  ::
-  
-    ministep = local_config.createMinistep("MINISTEP")
+A given observation set can be attached to a given ministep with
+attachObsset.The ministep is then ready for adding data. Before the ministep can
+be used you must attach it to an updatestep with the attachMinistep command
 
-  *Example:*
+*Example:*
 
-  ::
+::
 
-    analysis_config = ert.analysisConfig()
-    std_enkf_analysis_module = analysis_config.getModule("STD_ENKF")
-    ministep_using_std_enkf = local_config.createMinistep("MINISTEP", std_enkf_analysis_module)
+   ministep = local_config.createMinistep("MINISTEP")
+
+*Example:*
+
+::
+
+   analysis_config = ert.analysisConfig()
+   std_enkf_analysis_module = analysis_config.getModule("STD_ENKF")
+   ministep_using_std_enkf = local_config.createMinistep("MINISTEP", std_enkf_analysis_module)
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _create_dataset:
 .. topic:: createDataset
 
-  | This function will create a new dataset with a given name, i.e. a collection of enkf_nodes which should be updated together. Before you can actually use a dataset you must attach it to a ministep with the attachDataset command.  
-  
+This function will create a new dataset with a given name, i.e. a collection of
+enkf_nodes which should be updated together. Before you can actually use a
+dataset you must attach it to a ministep with the attachDataset command.
 
-  *Example:*
 
-  ::
+*Example:*
 
-    dataset_multflt = local_config.createDataset("DATASET_MULTFLT")    
+::
 
-.. ###########################################################################################################
+   dataset_multflt = local_config.createDataset("DATASET_MULTFLT")
 
+
+.. #####################################################################
 .. _copy_dataset:
 .. topic:: copyDataset
 
-  | Will create a new local_obsset instance which is a copy of the
-    source dataset; this is a deep copy where also the lowest level active_list instances are copied, and can then subsequently be updated independently of each other.
+Will create a new local_obsset instance which is a copy of the source dataset;
+this is a deep copy where also the lowest level active_list instances are
+copied, and can then subsequently be updated independently of each other.
 
 
-  *Example:*
+*Example:*
 
-  ::
+::
 
-    dataset_multflt_copy = local_config.copyDataset("DATASET_MULTFLT","DATASET_MULTFLT_COPY")   
+   dataset_multflt_copy = local_config.copyDataset("DATASET_MULTFLT","DATASET_MULTFLT_COPY")
 
-.. ###########################################################################################################
 
+.. #####################################################################
 .. _create_obsset:
 .. topic:: createObsdata
 
-  | This function will create an observation set, i.e. a collection of observation keys which will be used as the observations in one ministep. Before the obsset can be used it must be attached to a ministep with the attachDataset command.
-  
-  
-  *Example:*
-
-  ::
-
-    obsset_obs_well = local_config.createObsdata("OBS_WELL")       
+This function will create an observation set, i.e. a collection of observation
+keys which will be used as the observations in one ministep. Before the obsset
+can be used it must be attached to a ministep with the attachDataset command.
 
 
-.. ###########################################################################################################
+*Example:*
 
+::
+
+   obsset_obs_well = local_config.createObsdata("OBS_WELL")
+
+
+.. #####################################################################
 .. _copy_obsset:
 .. topic:: copyObsdata
 
-  | Will create a new local_obsset instance which is a copy of the
-    source dataset; this is a deep copy where also the lowest level active_list instances are copied, and can then subsequently be updated independently of each other.
-  
+Will create a new local_obsset instance which is a copy of the source dataset;
+this is a deep copy where also the lowest level active_list instances are
+copied, and can then subsequently be updated independently of each other.
 
-  *Example:*
 
-  ::
+*Example:*
 
-    obsset_obs_well_copy = local_config.copyObsdata("OBS_WELL", "OBS_WELL_COPY")
+::
 
-.. ###########################################################################################################
+   obsset_obs_well_copy = local_config.copyObsdata("OBS_WELL", "OBS_WELL_COPY")
 
+
+.. #####################################################################
 .. _attach_ministep:
 .. topic:: attachMinistep
 
-  | This function will attach the ministep to the default updatestep.
+This function will attach the ministep to the default updatestep.
 
-  *Example:*
+*Example:*
 
-  ::
+::
 
-    update_step.attachMinistep(ministep)       
+   update_step.attachMinistep(ministep)
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _attach_dataset:
 .. topic:: attachDataset
 
-  | Will attach the given dataset to the ministep.
+Will attach the given dataset to the ministep.
 
 
-  *Example:*
+*Example:*
 
-  ::
+::
 
-    ministep.attachDataset(dataset_multflt)       
+   ministep.attachDataset(dataset_multflt)
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _attach_obsset:
 .. topic:: attachObsset
 
-  | Will attach the given obsset to the ministep.
-  
-  *Example:*
+Will attach the given obsset to the ministep.
 
-  ::
+*Example:*
 
-    ministep.attachObsset(obsset_obs_well)       
+::
+
+   ministep.attachObsset(obsset_obs_well)
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _add_data:
 .. topic:: addNode
 
-  | This function will add the data KEY as one enkf node which should be updated in this dataset. If you do not manipulate the KEY further with addActiveIndex, the KEY will be added as 'ALL_ACTIVE', i.e. all elements will be updated.
-  
-  
-  *Example:*
+This function will add the data KEY as one enkf node which should be updated in
+this dataset. If you do not manipulate the KEY further with addActiveIndex, the
+KEY will be added as 'ALL_ACTIVE', i.e. all elements will be updated.
 
-  ::
 
-    dataset_multflt.addNode("MULTFLT")
+*Example:*
 
-.. ###########################################################################################################
+::
 
+   dataset_multflt.addNode("MULTFLT")
+
+
+.. #####################################################################
 .. _del_data:
 .. topic:: del (data)
 
-  | This function will delete the data 'KEY' from the dataset.
-  
-  
-  *Example:*
-
-  ::
-
-    del dataset_multflt["MULTFLT"]
+This function will delete the data 'KEY' from the dataset.
 
 
-.. ###########################################################################################################
+*Example:*
 
+::
+
+   del dataset_multflt["MULTFLT"]
+
+
+.. #####################################################################
 .. _add_obs:
 .. topic:: addNode
 
-  | This function will install the observation 'OBS_KEY' as an observation for this obsset - similarly to the addNode function.
-  
-  *Example:*
+This function will install the observation 'OBS_KEY' as an observation for this
+obsset - similarly to the addNode function.
 
-  ::
-  
-    -- The obsset has a time range
-    obsset_obs_well.addNodeAndRange("WOPR:OBS_WELL", 0, 1)
-    
-    -- All times are active
-    obsset_obs_well.addNode("WOPR:OBS_WELL")
+*Example:*
+
+::
+
+   # The obsset has a time range
+   obsset_obs_well.addNodeAndRange("WOPR:OBS_WELL", 0, 1)
+
+   # All times are active
+   obsset_obs_well.addNode("WOPR:OBS_WELL")
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _del_obs:
 .. topic:: del (obs)
 
-  | This function will delete the obs 'OBS_KEY' from the obsset 'NAME_OF_OBSSET'.
-  
-  
-  *Example:*
-
-  ::
-
-    del obsset_obs_well["WOPR:OBS_WELL"]
+This function will delete the obs 'OBS_KEY' from the obsset 'NAME_OF_OBSSET'.
 
 
-.. ###########################################################################################################
+*Example:*
 
+::
+
+   del obsset_obs_well["WOPR:OBS_WELL"]
+
+
+.. #####################################################################
 .. _dataset_del_all_data:
 .. topic:: clear
 
-  | This function will delete all the data keys from the dataset.
-  
-  *Example:*
+This function will delete all the data keys from the dataset.
 
-  ::
+*Example:*
 
-    dataset_multflt.clear()
-    
-.. ###########################################################################################################
+::
 
+   dataset_multflt.clear()
+
+
+.. #####################################################################
 .. _active_list_add_data_index:
 .. topic:: addActiveIndex (data)
 
-  | This function will say that the data with name 'DATA_KEY' in dataset with name 'DATASTEP_NAME' should have the index 'INDEX' active.
-  
-  
-  *Example:*
+This function will say that the data with name 'DATA_KEY' in dataset with name
+'DATASTEP_NAME' should have the index 'INDEX' active.
 
-  ::
 
-    active_list = dataset_multflt.getActiveList("MULTFLT")
-    active_list.addActiveIndex(0);
+*Example:*
 
-.. ###########################################################################################################
+::
+
+   active_list = dataset_multflt.getActiveList("MULTFLT")
+   active_list.addActiveIndex(0);
+
+.. #####################################################################
 
 .. _active_list_add_obs_index:
 .. topic:: addActiveIndex (obs)
 
-  | This function will say that the observation with name 'OBS_KEY' in obsset with name 'OBSSET_NAME' should have the index 'INDEX' active.
-  
-  *Example:*
+This function will say that the observation with name 'OBS_KEY' in obsset with
+name 'OBSSET_NAME' should have the index 'INDEX' active.
 
-  ::
+*Example:*
 
-    active_list = obsset_obs_well.getActiveList("WOPR:OBS_WELL")
-    active_list.addActiveIndex(0);
+::
+
+   active_list = obsset_obs_well.getActiveList("WOPR:OBS_WELL")
+   active_list.addActiveIndex(0);
 
 
-.. ###########################################################################################################
+.. #####################################################################
 
 .. _add_field:
 .. topic:: addField
 
-  | This function will install the node with name 'FIELD_NAME' in the dataset 'DATASET_NAME'. It will in addition select all the (currently) active cells in the region 'ECLREGION_NAME' as active for this field/ministep combination. The ADD_FIELD command is actually a shortcut of:   ADD_DATA   DATASET  FIELD_NAME; followed by: ACTIVE_LIST_ADD_MANY_DATA_INDEX  <All the indices from the region>
-  
-  *Example:*
+This function will install the node with name 'FIELD_NAME' in the dataset
+'DATASET_NAME'. It will in addition select all the (currently) active cells in
+the region 'ECLREGION_NAME' as active for this field/ministep combination. The
+ADD_FIELD command is actually a shortcut of: ADD_DATA DATASET FIELD_NAME;
+followed by: ACTIVE_LIST_ADD_MANY_DATA_INDEX <All the indices from the region>
 
-  ::
-  
-    # Load Eclipse grid
-    ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
-    
-    with open("path/to/LOCAL.GRDECL","r") as fileH:
-        local_kw = Ecl3DKW.read_grdecl(ecl_grid, fileH, "LOCAL")
-        
-    # Define Eclipse region    
-    eclreg_poro = EclRegion(ecl_grid, False)
-    eclreg_poro.select_more(local_kw, 1)  
-    
-    # Create dataset and add field to dataset
-    data_poro = local_config.createDataset("DATA_PORO")
-    data_poro.addField("PORO", eclreg_poro)        
+*Example:*
+
+::
+
+   # Load Eclipse grid
+   ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
+
+   with open("path/to/LOCAL.GRDECL","r") as fileH:
+       local_kw = Ecl3DKW.read_grdecl(ecl_grid, fileH, "LOCAL")
+
+   # Define Eclipse region
+   eclreg_poro = EclRegion(ecl_grid, False)
+   eclreg_poro.select_more(local_kw, 1)
+
+   # Create dataset and add field to dataset
+   data_poro = local_config.createDataset("DATA_PORO")
+   data_poro.addField("PORO", eclreg_poro)
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _load_file:
 .. topic:: EclGrid, EclInitFile
 
-  | This function will load an ECLIPSE file in restart format (i.e. restart file or INIT file), the keywords in this file can then subsequently be used in ECLREGION_SELECT_VALUE_XXX commands below. The 'KEY' argument is a string which will be used later when we refer to the content of this file.
-  
-  *Example:*
+This function will load an ECLIPSE file in restart format (i.e. restart file or
+INIT file), the keywords in this file can then subsequently be used in
+ECLREGION_SELECT_VALUE_XXX commands below. The 'KEY' argument is a string which
+will be used later when we refer to the content of this file.
 
-  ::
-  
-    # Load Eclipse grid and init file
-    ecl_grid = EclGrid("path/to/FULLMODEL.GRDECL")
-    refinit_file = EclInitFile(grid , "path/to/somefile.init")      
+*Example:*
 
-.. ###########################################################################################################
+::
 
+   # Load Eclipse grid and init file
+   ecl_grid = EclGrid("path/to/FULLMODEL.GRDECL")
+   refinit_file = EclInitFile(grid , "path/to/somefile.init")
+
+
+.. #####################################################################
 .. _create_eclregion:
 .. topic:: EclRegion
 
-  | This function will create a new region 'ECLREGION_NAME', which can subsequently be used when defining active regions for fields. The second argument, SELECT_ALL, is a boolean value. If this value is set to true the region will start with all cells selected, if set to false the region will start with no cells selected.
-  
-  *Example:*
+This function will create a new region 'ECLREGION_NAME', which can subsequently
+be used when defining active regions for fields. The second argument,
+SELECT_ALL, is a boolean value. If this value is set to true the region will
+start with all cells selected, if set to false the region will start with no
+cells selected.
 
-  ::
-   
-    # Define Eclipse region    
-    eclreg_poro = EclRegion(ecl_grid, False)
+*Example:*
 
-.. ###########################################################################################################
+::
 
+   # Define Eclipse region
+   eclreg_poro = EclRegion(ecl_grid, False)
+
+
+.. #####################################################################
 .. _eclregion_select_all:
 .. topic:: select_active
 
-  | Will select all the cells in the region (or deselect if SELECT == FALSE).
-  
-
-  *Example:*
-
-  ::
-         
-    eclreg_poro.select_active()  
+Will select all the cells in the region (or deselect if SELECT == FALSE).
 
 
-.. ###########################################################################################################
+*Example:*
 
+::
+
+   eclreg_poro.select_active()
+
+
+.. #####################################################################
 .. _eclregion_select_value_equal:
 .. topic:: select_equal
 
-  | This function will compare an ecl_kw instance loaded from file with a user supplied value, and select (or deselect) all cells which match this value. It is assumed that the ECLIPSE keyword is an INTEGER keyword, for float comparisons use the ECLREGION_SELECT_VALUE_LESS and ECLREGION_SELECT_VALUE_MORE functions.
+This function will compare an ecl_kw instance loaded from file with a user
+supplied value, and select (or deselect) all cells which match this value. It is
+assumed that the ECLIPSE keyword is an INTEGER keyword, for float comparisons
+use the ECLREGION_SELECT_VALUE_LESS and ECLREGION_SELECT_VALUE_MORE functions.
 
-  *Example:*
+*Example:*
 
-  ::
-                      
-    # Load Eclipse grid
-    ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
-    
-    with open("path/to/LOCAL.GRDECL","r") as fileH:
-        local_kw = Ecl3DKW.read_grdecl(ecl_grid, fileH, "LOCAL", ecl_type= EclTypeEnum.ECL_INT_TYPE)
-        
-    # Define Eclipse region    
-    eclreg_poro = EclRegion(ecl_grid, False)
-    eclreg_poro.select_equal(local_kw, 1)
-    print 'GRID LOADED%s' % ecl_grid 
-    print ecl_grid.getDims()
-    print local_kw.header   
-    
-        
+::
 
-.. ###########################################################################################################
+   # Load Eclipse grid
+   ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
 
+   with open("path/to/LOCAL.GRDECL","r") as fileH:
+       local_kw = Ecl3DKW.read_grdecl(ecl_grid, fileH, "LOCAL", ecl_type= EclTypeEnum.ECL_INT_TYPE)
+
+   # Define Eclipse region
+   eclreg_poro = EclRegion(ecl_grid, False)
+   eclreg_poro.select_equal(local_kw, 1)
+   print 'GRID LOADED%s' % ecl_grid
+   print ecl_grid.getDims()
+   print local_kw.header
+
+
+.. #####################################################################
 .. _eclregion_select_value_less:
 .. topic:: select_less
 
-  | This function will compare an ecl_kw instance loaded from disc with a numerical value, and select all cells which have numerical below the limiting value. The ecl_kw value should be a floating point value like e.g. PRESSURE or PORO. The arguments are just as for ECLREGION_SELECT_VALUE_EQUAL. 
+This function will compare an ecl_kw instance loaded from disc with a numerical
+value, and select all cells which have numerical below the limiting value. The
+ecl_kw value should be a floating point value like e.g. PRESSURE or PORO. The
+arguments are just as for ECLREGION_SELECT_VALUE_EQUAL.
 
-  *Example:*
+*Example:*
 
-  ::
-                          
-    eclreg_poro.select_less(local_kw, 1) 
-        
-    
-.. ###########################################################################################################
+::
 
+   eclreg_poro.select_less(local_kw, 1)
+
+
+.. #####################################################################
 .. _eclregion_select_value_more:
 .. topic:: select_more
 
-  | This function will compare an ecl_kw instance loaded from disc with a numerical value, and select all cells which have numerical above the limiting value. The ecl_kw value should be a floating point value like e.g. PRESSURE or PORO. The arguments are just as for ECLREGION_SELECT_VALUE_EQUAL. 
-  
+This function will compare an ecl_kw instance loaded from disc with a numerical
+value, and select all cells which have numerical above the limiting value. The
+ecl_kw value should be a floating point value like e.g. PRESSURE or PORO. The
+arguments are just as for ECLREGION_SELECT_VALUE_EQUAL.
 
-  *Example:*
 
-  ::
-                          
-    eclreg_poro.select_more(local_kw, 1)     
-    
-.. ###########################################################################################################
+*Example:*
 
+::
+
+   eclreg_poro.select_more(local_kw, 1)
+
+
+.. #####################################################################
 .. _eclregion_select_box:
 .. topic:: select_box
 
-  | This function will select (or deselect) all the cells in the box defined by the six coordinates i1 i2 j1 j2 k1 k2. The coordinates are inclusive, and the counting starts at 1.   
-    
-
-  *Example:*
-
-  ::
-                          
-    eclreg_poro.select_box((0,2,4),(1,3,5))  
-        
+This function will select (or deselect) all the cells in the box defined by the
+six coordinates i1 i2 j1 j2 k1 k2. The coordinates are inclusive, and the
+counting starts at 1.
 
 
-.. ###########################################################################################################
+*Example:*
 
+::
+
+   eclreg_poro.select_box((0,2,4),(1,3,5))
+
+
+.. #####################################################################
 .. _eclregion_select_slice:
 .. topic:: select_islice, _jslice,_kslice
 
-  | This function will select a slice in the direction given by 'dir', which can 'x', 'y' or 'z'. Depending on the value of 'dir' the numbers n1 and n2 are interpreted as (i1 i2), (j1 j2) or (k1 k2) respectively. The numbers n1 and n2 are inclusice and the counting starts at 1. It is OK to use very high/low values to imply "the rest of the cells" in one direction.
-     
-  
-  *Example:*
-
-  ::
-                          
-    eclreg_poro.select_kslice(2,3)  
+This function will select a slice in the direction given by 'dir', which can
+'x', 'y' or 'z'. Depending on the value of 'dir' the numbers n1 and n2 are
+interpreted as (i1 i2), (j1 j2) or (k1 k2) respectively. The numbers n1 and n2
+are inclusice and the counting starts at 1. It is OK to use very high/low values
+to imply "the rest of the cells" in one direction.
 
 
-.. ###########################################################################################################
+*Example:*
+
+::
+
+   eclreg_poro.select_kslice(2,3)
+
+
+.. #####################################################################
 
 .. _eclregion_select_plane:
 .. topic:: select_below_plane
 
-  | Will select all points which have positive (sign > 0) distance to the plane defined by normal vector n = (nx,ny,nz) and point p = (px,py,pz). If sign < 0 all cells with negative distance to plane will be selected.
-  
-  *Example:*
+Will select all points which have positive (sign > 0) distance to the plane
+defined by normal vector n = (nx,ny,nz) and point p = (px,py,pz). If sign < 0
+all cells with negative distance to plane will be selected.
 
-  ::
-     
-    eclreg_poro.select_below_plane((1,1,1),(0,0,0))
+*Example:*
+
+::
+
+   eclreg_poro.select_below_plane((1,1,1),(0,0,0))
 
 
-.. ###########################################################################################################
-
+.. #####################################################################
 .. _eclregion_select_in_polygon:
 .. topic:: select_inside_polygon
 
-  | Well select all the points which are inside the polygon with name 'POLYGON_NAME'. The polygon should have been created with command CREATE_POLYGON or loaded with command 'LOAD_POLYGON' first.
-  
-  
-  
-  *Example:*
+Well select all the points which are inside the polygon with name
+'POLYGON_NAME'. The polygon should have been created with command CREATE_POLYGON
+or loaded with command 'LOAD_POLYGON' first.
 
-  ::
-  
-    polygon = [(0,0) , (0,1) , (1,0)]
-    eclreg_poro.select_inside_polygon(polygon)
-    
-.. ###########################################################################################################
 
+*Example:*
+
+::
+
+   polygon = [(0,0) , (0,1) , (1,0)]
+   eclreg_poro.select_inside_polygon(polygon)
+
+
+.. #####################################################################
 .. _create_polygon:
 .. topic:: Example create polygon
 
-  | Will create a geo_polygon instance based on the coordinate list: (x1,y1), (x2,y2), (x3,y3), ... The polygon should not be explicitly closed - i.e. you should in general have (x1,y1) != (xn,yn). The polygon will be stored under the name 'POLYGON_NAME' - which should later be used when referring to the polygon in region select operations.
-  
+Will create a geo_polygon instance based on the coordinate list: (x1,y1),
+(x2,y2), (x3,y3), ... The polygon should not be explicitly closed - i.e. you
+should in general have (x1,y1) != (xn,yn). The polygon will be stored under the
+name 'POLYGON_NAME' - which should later be used when referring to the polygon
+in region select operations.
 
 
-  *Example:*
+*Example:*
 
-  ::
-  
-    polygon = [(0,0) , (0,1) , (1,0)]    
+::
 
-.. ###########################################################################################################
+   polygon = [(0,0) , (0,1) , (1,0)]
 
+
+.. #####################################################################
 .. _load_polygon:
 .. topic:: Example load polygon
 
-  | Will load a polygon instance from the file 'FILENAME' - the file should be in irap RMS format. The polygon will be stored under the name 'POLYGON_NAME' which can then later be used to refer to the polygon for e.g. select operations.  
-
-    
-  *Example:*
-
-  ::
-      
-    polygon = []
-    with open("polygon.ply","r") as fileH:
-     for line in fileH.readlines():
-       tmp = line.split()
-       polygon.append( (float(tmp[0]) , float(tmp[1])))
+Will load a polygon instance from the file 'FILENAME' - the file should be in
+irap RMS format. The polygon will be stored under the name 'POLYGON_NAME' which
+can then later be used to refer to the polygon for e.g. select operations.
 
 
+*Example:*
+
+::
+
+   polygon = []
+   with open("polygon.ply", "r") as ply_file:
+       for line in ply_file.readlines():
+           xs, ys = map(float, line.split())
+           polygon.append(xs, ys)

--- a/docs/user/localization/index.rst
+++ b/docs/user/localization/index.rst
@@ -15,11 +15,11 @@ local config commands by writing a Python script, and invoking it from a workflo
 ::
 
  from ert.enkf import ErtScript
- from ert.enkf import LocalConfig, LocalObsdata, LocalObsdataNode, LocalMinistep, LocalUpdateStep, LocalDataset, ActiveList
+ from ert.enkf import (LocalConfig, LocalObsdata, LocalObsdataNode,
+                       LocalMinistep, LocalUpdateStep, LocalDataset, ActiveList)
  from ert.ecl import EclGrid, EclRegion, Ecl3DKW, EclFile, EclInitFile, EclKW, EclTypeEnum
 
  class LocalConfigJob(ErtScript):
-
 
      def run(self):
 
@@ -115,278 +115,284 @@ ERT script function                                                        Purpo
 .. _create_updatestep:
 .. topic:: getUpdatestep
 
-This function will create the default updatestep.
+   This function will create the default updatestep.
 
-Observe that you must get, otherwise it will not be able to do anything.
+   Observe that you must get, otherwise it will not be able to do anything.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-updatestep = local_config.getUpdatestep()
+   updatestep = local_config.getUpdatestep()
 
 
 .. #####################################################################
 .. _all_obs:
 .. topic:: getObservations
 
-This function will retrieve ERT's observations
+   This function will retrieve ERT's observations
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   all_obs = local_config.getObservations()
+      all_obs = local_config.getObservations()
 
 
 .. #####################################################################
 .. _ert_grid:
 .. topic:: getGrid
 
-This function will retrieve ERT's grid
+   This function will retrieve ERT's grid
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   grid = local_config.getGrid()
+      grid = local_config.getGrid()
 
 
 .. #####################################################################
 .. _create_ministep:
 .. topic:: createMinistep
 
-This function will create a new ministep with a given name and an optional
-analysis module. The default analysis module for this ministep is ERT's current
-analysis module.
+   This function will create a new ministep with a given name and an optional
+   analysis module. The default analysis module for this ministep is ERT's
+   current analysis module.
 
-A given observation set can be attached to a given ministep with
-attachObsset.The ministep is then ready for adding data. Before the ministep can
-be used you must attach it to an updatestep with the attachMinistep command
+   A given observation set can be attached to a given ministep with
+   attachObsset.The ministep is then ready for adding data. Before the ministep
+   can be used you must attach it to an updatestep with the attachMinistep
+   command
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   ministep = local_config.createMinistep("MINISTEP")
+      ministep = local_config.createMinistep("MINISTEP")
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   analysis_config = ert.analysisConfig()
-   std_enkf_analysis_module = analysis_config.getModule("STD_ENKF")
-   ministep_using_std_enkf = local_config.createMinistep("MINISTEP", std_enkf_analysis_module)
+      analysis_config = ert.analysisConfig()
+      std_enkf_analysis_module = analysis_config.getModule("STD_ENKF")
+      ministep_using_std_enkf = local_config.createMinistep("MINISTEP", std_enkf_analysis_module)
 
 
 .. #####################################################################
 .. _create_dataset:
 .. topic:: createDataset
 
-This function will create a new dataset with a given name, i.e. a collection of
-enkf_nodes which should be updated together. Before you can actually use a
-dataset you must attach it to a ministep with the attachDataset command.
+   This function will create a new dataset with a given name, i.e. a collection
+   of enkf_nodes which should be updated together. Before you can actually use a
+   dataset you must attach it to a ministep with the attachDataset command.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   dataset_multflt = local_config.createDataset("DATASET_MULTFLT")
+      dataset_multflt = local_config.createDataset("DATASET_MULTFLT")
 
 
 .. #####################################################################
 .. _copy_dataset:
 .. topic:: copyDataset
 
-Will create a new local_obsset instance which is a copy of the source dataset;
-this is a deep copy where also the lowest level active_list instances are
-copied, and can then subsequently be updated independently of each other.
+   Will create a new local_obsset instance which is a copy of the source
+   dataset; this is a deep copy where also the lowest level active_list
+   instances are copied, and can then subsequently be updated independently of
+   each other.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   dataset_multflt_copy = local_config.copyDataset("DATASET_MULTFLT","DATASET_MULTFLT_COPY")
+      dataset_multflt_copy = local_config.copyDataset("DATASET_MULTFLT","DATASET_MULTFLT_COPY")
 
 
 .. #####################################################################
 .. _create_obsset:
 .. topic:: createObsdata
 
-This function will create an observation set, i.e. a collection of observation
-keys which will be used as the observations in one ministep. Before the obsset
-can be used it must be attached to a ministep with the attachDataset command.
+   This function will create an observation set, i.e. a collection of
+   observation keys which will be used as the observations in one
+   ministep. Before the obsset can be used it must be attached to a ministep
+   with the attachDataset command.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   obsset_obs_well = local_config.createObsdata("OBS_WELL")
+      obsset_obs_well = local_config.createObsdata("OBS_WELL")
 
 
 .. #####################################################################
 .. _copy_obsset:
 .. topic:: copyObsdata
 
-Will create a new local_obsset instance which is a copy of the source dataset;
-this is a deep copy where also the lowest level active_list instances are
-copied, and can then subsequently be updated independently of each other.
+   Will create a new local_obsset instance which is a copy of the source
+   dataset; this is a deep copy where also the lowest level active_list
+   instances are copied, and can then subsequently be updated independently of
+   each other.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   obsset_obs_well_copy = local_config.copyObsdata("OBS_WELL", "OBS_WELL_COPY")
+      obsset_obs_well_copy = local_config.copyObsdata("OBS_WELL", "OBS_WELL_COPY")
 
 
 .. #####################################################################
 .. _attach_ministep:
 .. topic:: attachMinistep
 
-This function will attach the ministep to the default updatestep.
+   This function will attach the ministep to the default updatestep.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   update_step.attachMinistep(ministep)
+      update_step.attachMinistep(ministep)
 
 
 .. #####################################################################
 .. _attach_dataset:
 .. topic:: attachDataset
 
-Will attach the given dataset to the ministep.
+   Will attach the given dataset to the ministep.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   ministep.attachDataset(dataset_multflt)
+      ministep.attachDataset(dataset_multflt)
 
 
 .. #####################################################################
 .. _attach_obsset:
 .. topic:: attachObsset
 
-Will attach the given obsset to the ministep.
+   Will attach the given obsset to the ministep.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   ministep.attachObsset(obsset_obs_well)
+      ministep.attachObsset(obsset_obs_well)
 
 
 .. #####################################################################
 .. _add_data:
 .. topic:: addNode
 
-This function will add the data KEY as one enkf node which should be updated in
-this dataset. If you do not manipulate the KEY further with addActiveIndex, the
-KEY will be added as 'ALL_ACTIVE', i.e. all elements will be updated.
+   This function will add the data ``KEY`` as one *enkf* node which should be
+   updated in this dataset.  If you do not manipulate the ``KEY`` further with
+   ``addActiveIndex``, the ``KEY`` will be added as ``ALL_ACTIVE``, i.e. all
+   elements will be updated.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   dataset_multflt.addNode("MULTFLT")
+      dataset_multflt.addNode("MULTFLT")
 
 
 .. #####################################################################
 .. _del_data:
 .. topic:: del (data)
 
-This function will delete the data 'KEY' from the dataset.
+   This function will delete the data ``KEY`` from the dataset.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   del dataset_multflt["MULTFLT"]
+      del dataset_multflt["MULTFLT"]
 
 
 .. #####################################################################
 .. _add_obs:
 .. topic:: addNode
 
-This function will install the observation 'OBS_KEY' as an observation for this
-obsset - similarly to the addNode function.
+   This function will install the observation ``OBS_KEY`` as an observation for
+   this ``obsset`` - similarly to the ``addNode`` function.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   # The obsset has a time range
-   obsset_obs_well.addNodeAndRange("WOPR:OBS_WELL", 0, 1)
+      # The obsset has a time range
+      obsset_obs_well.addNodeAndRange("WOPR:OBS_WELL", 0, 1)
 
-   # All times are active
-   obsset_obs_well.addNode("WOPR:OBS_WELL")
+      # All times are active
+      obsset_obs_well.addNode("WOPR:OBS_WELL")
 
 
 .. #####################################################################
 .. _del_obs:
 .. topic:: del (obs)
 
-This function will delete the obs 'OBS_KEY' from the obsset 'NAME_OF_OBSSET'.
+   This function will delete the obs ``OBS_KEY`` from the obsset
+   ``NAME_OF_OBSSET``.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   del obsset_obs_well["WOPR:OBS_WELL"]
+      del obsset_obs_well["WOPR:OBS_WELL"]
 
 
 .. #####################################################################
 .. _dataset_del_all_data:
 .. topic:: clear
 
-This function will delete all the data keys from the dataset.
+   This function will delete all the data keys from the dataset.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   dataset_multflt.clear()
+      dataset_multflt.clear()
 
 
 .. #####################################################################
 .. _active_list_add_data_index:
 .. topic:: addActiveIndex (data)
 
-This function will say that the data with name 'DATA_KEY' in dataset with name
-'DATASTEP_NAME' should have the index 'INDEX' active.
+   This function will say that the data with name ``DATA_KEY`` in dataset with
+   name ``DATASTEP_NAME`` should have the index ``INDEX`` active.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   active_list = dataset_multflt.getActiveList("MULTFLT")
-   active_list.addActiveIndex(0);
+      active_list = dataset_multflt.getActiveList("MULTFLT")
+      active_list.addActiveIndex(0);
 
 .. #####################################################################
 
 .. _active_list_add_obs_index:
 .. topic:: addActiveIndex (obs)
 
-This function will say that the observation with name 'OBS_KEY' in obsset with
-name 'OBSSET_NAME' should have the index 'INDEX' active.
+   This function will say that the observation with name ``OBS_KEY`` in obsset
+   with name ``OBSSET_NAME`` should have the index ``INDEX`` active.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   active_list = obsset_obs_well.getActiveList("WOPR:OBS_WELL")
-   active_list.addActiveIndex(0);
+      active_list = obsset_obs_well.getActiveList("WOPR:OBS_WELL")
+      active_list.addActiveIndex(0);
 
 
 .. #####################################################################
@@ -394,173 +400,183 @@ name 'OBSSET_NAME' should have the index 'INDEX' active.
 .. _add_field:
 .. topic:: addField
 
-This function will install the node with name 'FIELD_NAME' in the dataset
-'DATASET_NAME'. It will in addition select all the (currently) active cells in
-the region 'ECLREGION_NAME' as active for this field/ministep combination. The
-ADD_FIELD command is actually a shortcut of: ADD_DATA DATASET FIELD_NAME;
-followed by: ACTIVE_LIST_ADD_MANY_DATA_INDEX <All the indices from the region>
+   This function will install the node with name ``FIELD_NAME`` in the dataset
+   ``DATASET_NAME``.  It will in addition select all the (currently) active
+   cells in the region ``ECLREGION_NAME`` as active for this field/ministep
+   combination.  The ``ADD_FIELD`` command is actually a shortcut of:
 
-*Example:*
+   ``ADD_DATA DATASET FIELD_NAME``;
 
-::
+   followed by:
 
-   # Load Eclipse grid
-   ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
+   ``ACTIVE_LIST_ADD_MANY_DATA_INDEX <All the indices from the region>``
 
-   with open("path/to/LOCAL.GRDECL","r") as fileH:
-       local_kw = Ecl3DKW.read_grdecl(ecl_grid, fileH, "LOCAL")
+   *Example:*
 
-   # Define Eclipse region
-   eclreg_poro = EclRegion(ecl_grid, False)
-   eclreg_poro.select_more(local_kw, 1)
+   ::
 
-   # Create dataset and add field to dataset
-   data_poro = local_config.createDataset("DATA_PORO")
-   data_poro.addField("PORO", eclreg_poro)
+      # Load Eclipse grid
+      ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
+
+      with open("path/to/LOCAL.GRDECL","r") as grdecl_file:
+          local_kw = Ecl3DKW.read_grdecl(ecl_grid, grdecl_file, "LOCAL")
+
+      # Define Eclipse region
+      eclreg_poro = EclRegion(ecl_grid, False)
+      eclreg_poro.select_more(local_kw, 1)
+
+      # Create dataset and add field to dataset
+      data_poro = local_config.createDataset("DATA_PORO")
+      data_poro.addField("PORO", eclreg_poro)
 
 
 .. #####################################################################
 .. _load_file:
 .. topic:: EclGrid, EclInitFile
 
-This function will load an ECLIPSE file in restart format (i.e. restart file or
-INIT file), the keywords in this file can then subsequently be used in
-ECLREGION_SELECT_VALUE_XXX commands below. The 'KEY' argument is a string which
-will be used later when we refer to the content of this file.
+   This function will load an ECLIPSE file in restart format (i.e. restart file or
+   INIT file), the keywords in this file can then subsequently be used in
+   ``ECLREGION_SELECT_VALUE_XXX`` commands below.  The ``KEY`` argument is a string
+   which will be used later when we refer to the content of this file.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   # Load Eclipse grid and init file
-   ecl_grid = EclGrid("path/to/FULLMODEL.GRDECL")
-   refinit_file = EclInitFile(grid , "path/to/somefile.init")
+      # Load Eclipse grid and init file
+      ecl_grid = EclGrid("path/to/FULLMODEL.GRDECL")
+      refinit_file = EclInitFile(grid , "path/to/somefile.init")
 
 
 .. #####################################################################
 .. _create_eclregion:
 .. topic:: EclRegion
 
-This function will create a new region 'ECLREGION_NAME', which can subsequently
-be used when defining active regions for fields. The second argument,
-SELECT_ALL, is a boolean value. If this value is set to true the region will
-start with all cells selected, if set to false the region will start with no
-cells selected.
+   This function will create a new region ``ECLREGION_NAME``, which can
+   subsequently be used when defining active regions for fields.  The second
+   argument, ``SELECT_ALL``, is a *boolean* value.  If this value is set to true
+   the region will start with all cells selected, if set to false the region
+   will start with no cells selected.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   # Define Eclipse region
-   eclreg_poro = EclRegion(ecl_grid, False)
+      # Define Eclipse region
+      eclreg_poro = EclRegion(ecl_grid, False)
 
 
 .. #####################################################################
 .. _eclregion_select_all:
 .. topic:: select_active
 
-Will select all the cells in the region (or deselect if SELECT == FALSE).
+   Will select all the cells in the region (or deselect if ``SELECT == FALSE``).
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   eclreg_poro.select_active()
+      eclreg_poro.select_active()
 
 
 .. #####################################################################
 .. _eclregion_select_value_equal:
 .. topic:: select_equal
 
-This function will compare an ecl_kw instance loaded from file with a user
-supplied value, and select (or deselect) all cells which match this value. It is
-assumed that the ECLIPSE keyword is an INTEGER keyword, for float comparisons
-use the ECLREGION_SELECT_VALUE_LESS and ECLREGION_SELECT_VALUE_MORE functions.
+   This function will compare an ``ecl_kw`` instance loaded from file with a
+   user supplied value, and select (or deselect) all cells which match this
+   value.  It is assumed that the ECLIPSE keyword is an INTEGER keyword, for
+   float comparisons use the ``ECLREGION_SELECT_VALUE_LESS`` and
+   ``ECLREGION_SELECT_VALUE_MORE`` functions.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   # Load Eclipse grid
-   ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
+      # Load Eclipse grid
+      ecl_grid = EclGrid("path/to/LOCAL.GRDECL")
 
-   with open("path/to/LOCAL.GRDECL","r") as fileH:
-       local_kw = Ecl3DKW.read_grdecl(ecl_grid, fileH, "LOCAL", ecl_type= EclTypeEnum.ECL_INT_TYPE)
+      with open("path/to/LOCAL.GRDECL","r") as grdecl_file:
+          local_kw = Ecl3DKW.read_grdecl(ecl_grid, grdecl_file, "LOCAL",
+                                         ecl_type=EclTypeEnum.ECL_INT_TYPE)
 
-   # Define Eclipse region
-   eclreg_poro = EclRegion(ecl_grid, False)
-   eclreg_poro.select_equal(local_kw, 1)
-   print 'GRID LOADED%s' % ecl_grid
-   print ecl_grid.getDims()
-   print local_kw.header
+      # Define Eclipse region
+      eclreg_poro = EclRegion(ecl_grid, False)
+      eclreg_poro.select_equal(local_kw, 1)
+      print('GRID LOADED: %s' % ecl_grid)
+      print(ecl_grid.getDims())
+      print(local_kw.header)
 
 
 .. #####################################################################
 .. _eclregion_select_value_less:
 .. topic:: select_less
 
-This function will compare an ecl_kw instance loaded from disc with a numerical
-value, and select all cells which have numerical below the limiting value. The
-ecl_kw value should be a floating point value like e.g. PRESSURE or PORO. The
-arguments are just as for ECLREGION_SELECT_VALUE_EQUAL.
+   This function will compare an ``ecl_kw`` instance loaded from disc with a
+   numerical value, and select all cells which have numerical below the limiting
+   value.  The ``ecl_kw`` value should be a floating point value like
+   e.g. PRESSURE or PORO.  The arguments are just as for
+   ``ECLREGION_SELECT_VALUE_EQUAL``.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   eclreg_poro.select_less(local_kw, 1)
+      eclreg_poro.select_less(local_kw, 1)
 
 
 .. #####################################################################
 .. _eclregion_select_value_more:
 .. topic:: select_more
 
-This function will compare an ecl_kw instance loaded from disc with a numerical
-value, and select all cells which have numerical above the limiting value. The
-ecl_kw value should be a floating point value like e.g. PRESSURE or PORO. The
-arguments are just as for ECLREGION_SELECT_VALUE_EQUAL.
+   This function will compare an ``ecl_kw`` instance loaded from disc with a
+   numerical value, and select all cells which have numerical above the limiting
+   value. The ``ecl_kw`` value should be a floating point value like
+   e.g. PRESSURE or PORO. The arguments are just as for
+   ``ECLREGION_SELECT_VALUE_EQUAL``.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   eclreg_poro.select_more(local_kw, 1)
+      eclreg_poro.select_more(local_kw, 1)
 
 
 .. #####################################################################
 .. _eclregion_select_box:
 .. topic:: select_box
 
-This function will select (or deselect) all the cells in the box defined by the
-six coordinates i1 i2 j1 j2 k1 k2. The coordinates are inclusive, and the
-counting starts at 1.
+   This function will select (or deselect) all the cells in the box defined by
+   the six coordinates ``i1 i2 j1 j2 k1 k2``. The coordinates are inclusive, and
+   the counting starts at 1.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   eclreg_poro.select_box((0,2,4),(1,3,5))
+      eclreg_poro.select_box((0,2,4),(1,3,5))
 
 
 .. #####################################################################
 .. _eclregion_select_slice:
 .. topic:: select_islice, _jslice,_kslice
 
-This function will select a slice in the direction given by 'dir', which can
-'x', 'y' or 'z'. Depending on the value of 'dir' the numbers n1 and n2 are
-interpreted as (i1 i2), (j1 j2) or (k1 k2) respectively. The numbers n1 and n2
-are inclusice and the counting starts at 1. It is OK to use very high/low values
-to imply "the rest of the cells" in one direction.
+   This function will select a slice in the direction given by ``dir``', which
+   can ``x``, ``y``, or ``z``. Depending on the value of ``dir`` the numbers
+   ``n1`` and ``n2`` are interpreted as ``(i1 i2)``, ``(j1 j2)``, or ``(k1
+   k2)``, respectively.  The numbers ``n1`` and ``n2`` are inclusive and the
+   counting starts at 1.  It is OK to use very high/low values to imply *"the
+   rest of the cells"* in one direction.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   eclreg_poro.select_kslice(2,3)
+      eclreg_poro.select_kslice(2,3)
 
 
 .. #####################################################################
@@ -568,67 +584,73 @@ to imply "the rest of the cells" in one direction.
 .. _eclregion_select_plane:
 .. topic:: select_below_plane
 
-Will select all points which have positive (sign > 0) distance to the plane
-defined by normal vector n = (nx,ny,nz) and point p = (px,py,pz). If sign < 0
-all cells with negative distance to plane will be selected.
+   Will select all points which have positive (sign > 0) distance to the plane
+   defined by normal vector ``n = (nx,ny,nz)`` and point ``p = (px,py,pz)``. If
+   sign < 0 all cells with negative distance to plane will be selected.
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   eclreg_poro.select_below_plane((1,1,1),(0,0,0))
+      eclreg_poro.select_below_plane((1,1,1),(0,0,0))
 
 
 .. #####################################################################
 .. _eclregion_select_in_polygon:
 .. topic:: select_inside_polygon
 
-Well select all the points which are inside the polygon with name
-'POLYGON_NAME'. The polygon should have been created with command CREATE_POLYGON
-or loaded with command 'LOAD_POLYGON' first.
+   Well select all the points which are inside the polygon with name
+   ``POLYGON_NAME``. The polygon should have been created with command
+   ``CREATE_POLYGON`` or loaded with command ``LOAD_POLYGON`` first.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   polygon = [(0,0) , (0,1) , (1,0)]
-   eclreg_poro.select_inside_polygon(polygon)
+      polygon = [(0,0) , (0,1) , (1,0)]
+      eclreg_poro.select_inside_polygon(polygon)
 
 
 .. #####################################################################
 .. _create_polygon:
 .. topic:: Example create polygon
 
-Will create a geo_polygon instance based on the coordinate list: (x1,y1),
-(x2,y2), (x3,y3), ... The polygon should not be explicitly closed - i.e. you
-should in general have (x1,y1) != (xn,yn). The polygon will be stored under the
-name 'POLYGON_NAME' - which should later be used when referring to the polygon
-in region select operations.
+   Will create a ``geo_polygon`` instance based on the coordinate list:
+
+   ``(x1,y1), (x2,y2), (x3,y3), ...``
+
+   The polygon should not be explicitly closed - i.e. you should in general have
+
+   ``(x1,y1) != (xn,yn).``
+
+   The polygon will be stored under the name ``POLYGON_NAME`` - which should
+   later be used when referring to the polygon in region select operations.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   polygon = [(0,0) , (0,1) , (1,0)]
+      polygon = [(0,0) , (0,1) , (1,0)]
 
 
 .. #####################################################################
 .. _load_polygon:
 .. topic:: Example load polygon
 
-Will load a polygon instance from the file 'FILENAME' - the file should be in
-irap RMS format. The polygon will be stored under the name 'POLYGON_NAME' which
-can then later be used to refer to the polygon for e.g. select operations.
+   Will load a polygon instance from the file ``FILENAME`` - the file should be
+   in irap RMS format.  The polygon will be stored under the name
+   ``POLYGON_NAME`` which can then later be used to refer to the polygon for
+   e.g. select operations.
 
 
-*Example:*
+   *Example:*
 
-::
+   ::
 
-   polygon = []
-   with open("polygon.ply", "r") as ply_file:
-       for line in ply_file.readlines():
-           xs, ys = map(float, line.split())
-           polygon.append(xs, ys)
+      polygon = []
+      with open("polygon.ply", "r") as ply_file:
+          for line in ply_file.readlines():
+              xs, ys = map(float, line.split())
+              polygon.append(xs, ys)

--- a/python/python/ert/geo/geo_region.py
+++ b/python/python/ert/geo/geo_region.py
@@ -16,6 +16,7 @@
 from cwrap import BaseCClass
 from ert.util import IntVector
 from ert.geo import GeoPrototype
+from .cpolyline import CPolyline
 
 class GeoRegion(BaseCClass):
     TYPE_NAME = "geo_region"
@@ -23,15 +24,15 @@ class GeoRegion(BaseCClass):
     _alloc = GeoPrototype("void* geo_region_alloc(geo_pointset, bool)", bind=False)
     _free  = GeoPrototype("void  geo_region_free(geo_region)")
     _reset = GeoPrototype("void  geo_region_reset(geo_region)")
-    #_select_inside_polygon    = GeoPrototype("void geo_region_select_inside_polygon(geo_region,  geo_polygon)")
-    #_select_outside_polygon   = GeoPrototype("void geo_region_select_outside_polygon(geo_region,  geo_polygon)")
-    #_deselect_inside_polygon  = GeoPrototype("void geo_region_deselect_inside_polygon(geo_region,  geo_polygon)")
-    #_deselect_outside_polygon = GeoPrototype("void geo_region_deselect_outside_polygon(geo_region,  geo_polygon)")
+    _get_index_list = GeoPrototype("int_vector_ref geo_region_get_index_list(geo_region)")
+    _select_inside_polygon    = GeoPrototype("void geo_region_select_inside_polygon(geo_region, geo_polygon)")
+    _select_outside_polygon   = GeoPrototype("void geo_region_select_outside_polygon(geo_region, geo_polygon)")
+    _deselect_inside_polygon  = GeoPrototype("void geo_region_deselect_inside_polygon(geo_region, geo_polygon)")
+    _deselect_outside_polygon = GeoPrototype("void geo_region_deselect_outside_polygon(geo_region, geo_polygon)")
     #_select_above_line        = GeoPrototype("void geo_region_select_above_line(geo_region, const double xcoords[2], const double ycoords[2])")
     #_select_below_line        = GeoPrototype("void geo_region_select_below_line(geo_region, const double xcoords[2], const double ycoords[2])")
     #_deselect_above_line      = GeoPrototype("void geo_region_deselect_above_line(geo_region, const double xcoords[2], const double ycoords[2])")
     #_deselect_below_line      = GeoPrototype("void geo_region_deselect_below_line(geo_region, const double xcoords[2], const double ycoords[2])")
-    _get_index_list           = GeoPrototype("int_vector_ref geo_region_get_index_list(geo_region)")
 
 
     def __init__(self, pointset, preselect=False):
@@ -41,9 +42,35 @@ class GeoRegion(BaseCClass):
             super(GeoRegion, self).__init__(c_ptr)
         else:
             raise ValueError('Could not construct GeoRegion from pointset %s.' % pointset)
+        self.select_polygon_fn = {
+            (True, True): self._select_inside_polygon,
+            (False, True): self._select_outside_polygon,
+            (True, False): self._deselect_inside_polygon,
+            (False, False): self._deselect_outside_polygon
+        }
+
 
     def getActiveList(self):
         return self._get_index_list()
+
+    def select_polygon(self, polygon, inside=True, select=True):
+        if not isinstance(polygon, CPolyline):
+            raise ValueError('Need to select with a CPolyline, not %s.'
+                             % type(polygon))
+        selector_fn = self.select_polygon_fn[(inside, select)]
+        selector_fn(polygon)
+
+    def select_inside(self, polygon):
+        self.select_polygon(polygon, inside=True, select=True)
+
+    def select_outside(self, polygon):
+        self.select_polygon(polygon, inside=False, select=True)
+
+    def deselect_inside(self, polygon):
+        self.select_polygon(polygon, inside=True, select=False)
+
+    def deselect_outside(self, polygon):
+        self.select_polygon(polygon, inside=False, select=False)
 
 
     def __len__(self):

--- a/python/tests/core/geometry/test_geo_region.py
+++ b/python/tests/core/geometry/test_geo_region.py
@@ -1,15 +1,54 @@
-from ert.geo import GeoRegion, GeoPointset
+from ert.geo import GeoRegion, GeoPointset, CPolyline, Surface
 from ert.test import ExtendedTestCase, TestAreaContext
 
 
 class GeoRegionTest(ExtendedTestCase):
 
     def test_init(self):
-        ps = GeoPointset()
-        gp = GeoRegion(ps)
-        self.assertEqual(0, len(gp))
+        pointset = GeoPointset()
+        georegion = GeoRegion(pointset)
+        self.assertEqual(0, len(georegion))
 
     def test_repr(self):
-        ps = GeoPointset()
-        gp = GeoRegion(ps)
-        self.assertTrue(repr(gp).startswith('GeoRegion'))
+        pointset = GeoPointset()
+        georegion = GeoRegion(pointset)
+        self.assertTrue(repr(georegion).startswith('GeoRegion'))
+
+    @staticmethod
+    def small_surface():
+        ny,nx = 12,12
+        xinc,yinc = 1, 1
+        xstart,ystart = -1, -1
+        angle = 0.0
+        s_args = (None, nx, ny, xinc, yinc, xstart, ystart, angle)
+        return Surface(*s_args)
+
+    def test_select_polygon(self):
+        surface = self.small_surface()
+        pointset = GeoPointset.fromSurface(surface)
+        georegion = GeoRegion(pointset)
+        self.assertEqual(0, len(georegion))
+        points = [(-0.1,2.0), (1.9,8.1), (6.1,8.1), (9.1,5), (7.1,0.9)]
+        polygon = CPolyline(name='test_polygon', init_points=points)
+        picked = 52  # https://www.futilitycloset.com/2013/04/24/picks-theorem/
+        georegion.select_inside(polygon)
+        self.assertEqual(picked, len(georegion))
+        georegion.deselect_inside(polygon)
+        self.assertEqual(0, len(georegion))
+        georegion.select_outside(polygon)
+        self.assertEqual(len(surface) - picked, len(georegion))
+        georegion.deselect_outside(polygon)
+        self.assertEqual(0, len(georegion))
+
+        georegion.select_inside(polygon)
+        georegion.select_outside(polygon)
+        self.assertEqual(len(surface), len(georegion))
+        georegion.deselect_inside(polygon)
+        georegion.deselect_outside(polygon)
+        self.assertEqual(0, len(georegion))
+
+        georegion.select_inside(polygon)
+        self.assertEqual(picked, len(georegion))
+        internal_square = [(2.5,2.5), (2.5,6.5), (6.5,6.5), (6.5,2.5)]
+        georegion.deselect_inside(CPolyline(init_points=internal_square))
+        self.assertEqual(picked - 4*4, len(georegion))  # internal square is 4x4

--- a/python/tests/core/geometry/test_geo_region.py
+++ b/python/tests/core/geometry/test_geo_region.py
@@ -52,3 +52,37 @@ class GeoRegionTest(ExtendedTestCase):
         internal_square = [(2.5,2.5), (2.5,6.5), (6.5,6.5), (6.5,2.5)]
         georegion.deselect_inside(CPolyline(init_points=internal_square))
         self.assertEqual(picked - 4*4, len(georegion))  # internal square is 4x4
+
+
+    def test_select_halfspace(self):
+        surface = self.small_surface()
+        pointset = GeoPointset.fromSurface(surface)
+        georegion = GeoRegion(pointset)
+        self.assertEqual(0, len(georegion))
+        line = [(-0.1,2.0), (1.9,8.1)]
+        picked = 118
+        georegion.select_above(line)
+        self.assertEqual(picked, len(georegion))
+        georegion.deselect_above(line)
+        self.assertEqual(0, len(georegion))
+        georegion.select_below(line)
+        self.assertEqual(len(surface) - picked, len(georegion))
+        georegion.deselect_below(line)
+        self.assertEqual(0, len(georegion))
+
+        georegion.select_above(line)
+        georegion.select_below(line)
+        self.assertEqual(len(surface), len(georegion))
+        georegion.deselect_above(line)
+        georegion.deselect_below(line)
+        self.assertEqual(0, len(georegion))
+
+
+    def test_raises(self):
+        surface = self.small_surface()
+        pointset = GeoPointset.fromSurface(surface)
+        georegion = GeoRegion(pointset)
+        with self.assertRaises(ValueError):
+            georegion.select_above(((2,), (1, 3)))
+        with self.assertRaises(ValueError):
+            georegion.select_above((('not-a-number', 2), (1, 3)))


### PR DESCRIPTION
Refactored:
* removed absurdly long lines
* removed trailing whitespace
* removed abused `|` character; it's purpose is to inhibit reflow of paragraph
* added
  ```
   ``double backticks``
  ```
  around code related text

This is based on #1477.