### PR TITLE
bump packaging versions to 2017.04 rc1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,17 +1,5 @@
-ert.ecl (1.0-4) precise; urgency=low
+ert.ecl (2017.04-rc1-1~xenial) xenial; urgency=medium
 
-  * Unmark -dev package as architecture independent due to library symlink
+  * New release
 
- -- Arne Morten Kvarving <arne.morten.kvarving@sintef.no>  Wed, 03 Apr 2013 17:49:24 +0200
-
-ert.ecl (1.0-2) precise; urgency=low
-
-  * Mark -dev package as architecture independent
-
- -- Arne Morten Kvarving <arne.morten.kvarving@sintef.no>  Tue, 19 Feb 2013 10:03:04 +0100
-
-ert.ecl (1.0-1) unstable; urgency=low
-
-  * Initial release
-
- -- Arne Morten Kvarving <arne.morten.kvarving@sintef.no>  Wed, 16 Jan 2013 11:21:17 +0100
+ -- Arne Morten Kvarving <akva@akvarium>  Tue, 18 Apr 2017 09:17:29 +0200

--- a/redhat/ert.ecl.spec
+++ b/redhat/ert.ecl.spec
@@ -2,10 +2,10 @@
 # spec file for package ert.ecl
 #
 
-%define tag final2
+%define tag rc1
 
 Name:           ert.ecl
-Version:        2015.10
+Version:        2017.04
 Release:        0
 Summary:        ERT - Ensemble based Reservoir Tool - ECL library
 License:        GPL-3+


### PR DESCRIPTION
Please pick https://github.com/Ensembles/ert/pull/1491 then apply this and tag as release/2017.04/rc1