### PR TITLE
backport of redhat documentation packaging fix

### DIFF
--- a/redhat/ert.ecl.spec
+++ b/redhat/ert.ecl.spec
@@ -85,7 +85,8 @@ rm -rf %{buildroot}
 %postun -n libert.ecl1 -p /sbin/ldconfig
 
 %files
-%doc README
+%doc README.md
+%{_datadir}/*
 
 %files -n libert.ecl1
 %defattr(-,root,root,-)


### PR DESCRIPTION
This backports a fix done to rhel packaging for 2017.04 so we do not have to re-do it in half a year (not entirely sure how it ends up with the split going but let's follow procedures).